### PR TITLE
add Claude Code PR review pilot

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,103 @@
+# Proposed: .github/workflows/claude-review.yml
+# Phase 2 v1 — baseline PR review, no log-repo write (ships before PAT lands).
+# v2 adds log-repo issue creation once AI_REVIEW_LOG_TOKEN secret is available.
+
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Only review PRs authored by HarperFast org members / collaborators.
+    # External PRs are not auto-reviewed — a maintainer can opt one in later
+    # via an @claude mention (handled by a separate workflow).
+    if: >-
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+      github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Claude review
+        uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: claude-sonnet-4-6
+          max_turns: 8
+          prompt: |
+            You are reviewing a pull request on HarperFast/oauth.
+
+            Read `CLAUDE.md` in the repo root first — it has the project
+            overview, conventions, and (importantly) a "Non-Obvious Gotchas"
+            section covering Resource API v2 patterns, GenericTrackedObject
+            spread behavior, `tsc || true` build semantics, and security
+            invariants.
+
+            ## OAuth-specific things to check
+
+            - CSRF state tokens present on every OAuth flow; 10-minute expiry
+              is enforced; state is single-use
+            - Tokens are never logged and never returned in HTTP responses
+            - Redirect URI validation on callback endpoints
+            - Provider-of-record enforcement (cross-provider CSRF protection
+              should redirect with error, not 403)
+            - Session field preservation across token refresh (`provider`,
+              `providerConfigId`, `providerType`)
+            - Resource API v2 conventions (`static loadAsInstance = false`,
+              instance methods)
+            - `GenericTrackedObject` spread gotcha — if code uses `{...obj}`
+              on a session field, flag it
+            - New endpoints include auth checks and context validation
+            - Path length validation (≤ 2048 chars) where user input can
+              reach a path
+
+            ## Review scope and style
+
+            Report **blocker-severity findings only**. Blockers are:
+            - Correctness bugs
+            - Security issues (token exposure, missing CSRF, auth bypass,
+              unvalidated redirect/path, injection)
+            - Broken contracts (public API behavior change without migration)
+            - Missing tests for new behavior or fixed bugs
+            - Documentation drift that would mislead integrators
+
+            Do NOT comment on style, naming, nits, or personal preference.
+            Do NOT restate what the diff does. Do NOT praise.
+
+            Cap the review at 10 findings. If you found more, note it at
+            the bottom and pick the top 10 by severity.
+
+            ## Output
+
+            If you find zero blockers: post one short comment —
+            "No blockers found." — and stop.
+
+            If you find blockers: post one PR review as a COMMENT.
+            Do NOT use REQUEST_CHANGES or APPROVE during this
+            calibration phase — review type stays COMMENT so the
+            workflow never blocks or auto-approves a merge. Include
+            all findings using this structure:
+
+              ### <N>. <concise title>
+
+              **File:** `path/to/file.ts:line`
+              **What:** one or two sentence description
+              **Why it matters:** concrete impact
+              **Suggested fix:** specific change, not generic advice
+
+            No preamble, no closing summary.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,3 @@
-# Proposed: .github/workflows/claude-review.yml
-# Phase 2 v1 — baseline PR review, no log-repo write (ships before PAT lands).
-# v2 adds log-repo issue creation once AI_REVIEW_LOG_TOKEN secret is available.
-
 name: Claude PR Review
 
 on:
@@ -25,7 +21,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
 
     steps:
       - name: Checkout
@@ -79,8 +74,10 @@ jobs:
             Do NOT comment on style, naming, nits, or personal preference.
             Do NOT restate what the diff does. Do NOT praise.
 
-            Cap the review at 10 findings. If you found more, note it at
-            the bottom and pick the top 10 by severity.
+            Cap the review at 10 findings. The findings list is the
+            entire output. If you found more than 10, pick the top 10
+            by severity and append "(+N more not shown)" to the last
+            finding's fix line.
 
             ## Output
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write # required by claude-code-action even with API-key auth
 
     steps:
       - name: Checkout
@@ -32,8 +33,9 @@ jobs:
         uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-sonnet-4-6
-          max_turns: 8
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 8
           prompt: |
             You are reviewing a pull request on HarperFast/oauth.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,117 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## Project Overview
+
+OAuth 2.0 plugin for Harper. Authentication with any OAuth provider (GitHub, Google, Azure, Auth0, Okta, custom). Automatic token refresh, session management, lifecycle hooks for user provisioning, CSRF protection. Supports multi-tenant SSO with dynamic per-tenant provider resolution.
+
+## Development Commands
+
+```bash
+npm install             # Install dependencies
+npm run build           # Compile TypeScript (tolerates TS errors via `tsc || true`)
+npm run dev             # tsc --watch
+npm test                # Build, then run Node.js tests
+bun test                # Run Bun tests (requires Bun)
+npm run test:coverage   # Node 22+ coverage run
+npm run lint            # ESLint (not a type check — see Gotchas)
+npm run format:check    # Prettier check
+npm run format:write    # Prettier fix
+```
+
+## Architecture
+
+1. **Plugin entry** (`src/index.ts`) — `handleApplication()` with HTTP middleware for auto token refresh
+2. **OAuth resource** (`src/lib/resource.ts`) — REST endpoints using Resource API v2
+3. **Session validator** (`src/lib/sessionValidator.ts`) — token refresh on every request
+4. **Hook system** (`src/lib/hookManager.ts`) — lifecycle hooks (`onLogin`, `onLogout`, `onTokenRefresh`)
+5. **Provider registry** (`src/lib/config.ts`) — initializes and manages OAuth providers
+6. **Multi-tenant SSO** (`src/lib/multiTenantResource.ts`, `src/lib/tenantManager.ts`) — dynamic per-tenant provider resolution
+
+### Token refresh
+
+Middleware runs on every HTTP request. Refreshes at 80% of token lifetime. Transparent to application code.
+
+### Providers
+
+Base class in `src/lib/providers/base.ts`. Built-in: GitHub, Google, Azure, Auth0, Okta. Custom providers implement `authorize()` and `getUserInfo()`.
+
+### Errors
+
+Custom classes in `src/errors.ts` (`ConfigurationError`, `OAuthProviderError`, `TokenExchangeError`, ...). All include `statusCode`. Provider-specific errors include `provider`.
+
+## Session Structure
+
+```typescript
+request.session = {
+  user: 'username',             // Harper username
+  oauthUser: {                  // OAuth profile
+    username, email, name, role,
+  },
+  oauth: {                      // Token metadata
+    provider: string,           // Config key — backwards-compatible name
+    providerConfigId: string,   // Config key — clearer naming, same value as provider
+    providerType: string,       // e.g., 'github', 'okta'
+    accessToken: string,
+    refreshToken?: string,
+    expiresAt: number,
+    refreshThreshold: number,
+    scope: string,
+    tokenType: string,
+    lastRefreshed: number,
+  },
+  // Additional custom data from onLogin hook
+  [key: string]: any,
+}
+```
+
+## Code Conventions
+
+- TypeScript strict mode
+- ES modules — `.js` extensions in imports
+- Named exports, no default exports
+- Custom error classes from `src/errors.ts`
+- Logging: `logger?.info?.()` pattern (optional logger)
+- **Never log tokens; never expose tokens in responses**
+- CSRF protection: all flows use state tokens (10-minute expiry)
+- Harper types: `import type { Scope, User, RequestTarget } from 'harperdb'`
+
+## Non-Obvious Gotchas
+
+**Resource API v2:**
+- Classes declare `static loadAsInstance = false`
+- Methods are instance methods; Harper instantiates the class
+- Test mocks must instantiate accordingly
+
+**`GenericTrackedObject` + spread:**
+- `{ ...obj }` does NOT work on Harper tracked objects — copies nothing
+- Use explicit property access: `{ provider: oauth.provider, ... }`
+- Affects `request.session.oauth` and any session fields
+
+**Build tolerates TS errors:**
+- `npm run build` runs `tsc || true` — passes even with type errors
+- "Build passes" ≠ "types are sound"; rely on editor diagnostics and CI separately
+
+**Lint is ESLint only:**
+- `npm run lint` runs ESLint against source. It does NOT type-check.
+- No explicit `typecheck` script exists; `npm run build` is the closest proxy but suppresses errors (see above)
+
+**Security invariants (enforce in any new endpoint):**
+- Context validation in `get()` / `post()` methods
+- Path length ≤ 2048 chars
+- Debug endpoints: IP-based access control (localhost by default; `DEBUG_ALLOWED_IPS` env var to allow others)
+- Cross-provider CSRF: redirect with error, not 403 page
+
+## Testing
+
+Node.js built-in test runner (`node:test`) and Bun. Tests import from compiled `dist/`. Use `node:assert/strict`. Bun uses a preload script (`test/bun-preload.js`) to mock the `harperdb` module.
+
+Test scripts use `$(find test -name '*.test.js' -type f)`-style globbing for Node 20 compatibility; once Node 20 support ends, switch to `node --test test` or `node --test "test/**/*.test.js"` on Node 22+.
+
+## Dependencies
+
+- **Runtime:** `jsonwebtoken`, `jwks-rsa` (required by Okta / JWT-based providers)
+- **Peer:** `harperdb` (`>=4.6.0`)
+- **Dev:** `typescript`, `eslint`, `prettier`, `@types/node`, `@types/jsonwebtoken`, `@harperdb/code-guidelines`, `harperdb` (for types + test)
+- **Invariant:** justify any new runtime dependency in the PR; prefer built-ins (`fetch`, `crypto`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,24 +80,29 @@ request.session = {
 ## Non-Obvious Gotchas
 
 **Resource API v2:**
+
 - Classes declare `static loadAsInstance = false`
 - Methods are instance methods; Harper instantiates the class
 - Test mocks must instantiate accordingly
 
 **`GenericTrackedObject` + spread:**
+
 - `{ ...obj }` does NOT work on Harper tracked objects — copies nothing
 - Use explicit property access: `{ provider: oauth.provider, ... }`
 - Affects `request.session.oauth` and any session fields
 
 **Build tolerates TS errors:**
+
 - `npm run build` runs `tsc || true` — passes even with type errors
 - "Build passes" ≠ "types are sound"; rely on editor diagnostics and CI separately
 
 **Lint is ESLint only:**
+
 - `npm run lint` runs ESLint against source. It does NOT type-check.
 - No explicit `typecheck` script exists; `npm run build` is the closest proxy but suppresses errors (see above)
 
 **Security invariants (enforce in any new endpoint):**
+
 - Context validation in `get()` / `post()` methods
 - Path length ≤ 2048 chars
 - Debug endpoints: IP-based access control (localhost by default; `DEBUG_ALLOWED_IPS` env var to allow others)


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` (first commit of this file) as project context for Claude Code sessions and CI-based review. Trimmed to stable content only — no branch-state, no user-home refs, corrects a few factual drifts (lint is ESLint not typecheck, runtime deps exist, `npm run build` is `tsc || true`).
- Adds `.github/workflows/claude-review.yml` — baseline PR review via `anthropics/claude-code-action`. Sonnet 4.6, `max_turns: 8`, concurrency 1/PR with cancel-in-progress, SHA-pinned actions, gated to HarperFast org members via `author_association`. Review type is COMMENT-only during calibration (no merge-blocking, no auto-approval).

Part of a broader AI review pilot starting here (solo-maintained, small blast radius). Lessons from the next ~2 weeks feed into expanding to `/harper`, `/harper-pro`, and `/nextjs`.

## Not in this PR

- Cross-repo feedback capture via GitHub Issues in `HarperFast/ai-review-log` — pending PAT approval; follow-up PR will add `claude_env: AI_REVIEW_LOG_TOKEN` + issue-creation instructions in the prompt.
- `@claude deep-review` triggered workflow (Opus) — deferred to Phase 4 after baseline calibration.

## Prerequisites

- [x] `ANTHROPIC_API_KEY` secret added to repo
- [ ] Merge — workflow activates on next PR

## Test plan

- [ ] Merge this PR
- [ ] Open a small follow-up PR; verify the workflow fires, gates correctly on author_association, and posts a COMMENT-type review
- [ ] Spot-check the review quality and log into calibration notes