### PR TITLE
fix: reset CSRF table cache between OAuthProvider tests

### DIFF
--- a/test/lib/OAuthProvider.test.js
+++ b/test/lib/OAuthProvider.test.js
@@ -5,6 +5,7 @@
 import { describe, it, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { OAuthProvider } from '../../dist/lib/OAuthProvider.js';
+import { resetCSRFTableCache } from '../../dist/lib/CSRFTokenManager.js';
 
 describe('OAuthProvider', () => {
 	let provider;
@@ -43,6 +44,14 @@ describe('OAuthProvider', () => {
 	});
 
 	beforeEach(() => {
+		// Reset CSRFTokenManager's module-level table cache so each test
+		// picks up this iteration's mockTableInstance. Without this, Bun
+		// (which shares module state across tests in a single process)
+		// keeps the first iteration's table reference and writes go to
+		// a stale storedTokens Map. Node hides this by running each file
+		// in a separate process.
+		resetCSRFTableCache();
+
 		// Initialize token storage
 		storedTokens = new Map();
 


### PR DESCRIPTION
## Summary

Fixes #35. Two `OAuthProvider > CSRF Token Management` tests were failing under `bun test` while passing on `node --test`.

## Root cause

`CSRFTokenManager.ts` module-caches the `csrf_tokens` table reference on first `getCSRFTable()` call. `OAuthProvider.test.js` recreates its `mockTableInstance` fresh in every `beforeEach`, but the module cache still pointed to the *first iteration's* mock — all subsequent CSRF writes went to a stale `storedTokens` Map that no longer belonged to the current test.

`CSRFTokenManager.test.js` already handles this correctly by calling `resetCSRFTableCache()` in its `beforeEach`. `OAuthProvider.test.js` missed it.

Node masks the bug because `node --test` runs each test file in an isolated process by default (Node ≥ 22), resetting module state per file. Bun shares module state across tests in a single process, so the cache poisoning surfaces there.

## Fix

Import `resetCSRFTableCache` and call it in the `OAuthProvider` `beforeEach`, matching the pattern already in `CSRFTokenManager.test.js`.

## Note on the two sessionValidator failures from #35

Issue #35 listed 4 failures: 2 CSRF (fixed here) + 2 sessionValidator. The 2 sessionValidator failures (`should use default validation interval when not specified` and `should not validate tokens with expiration (Google-style)`) appear to have resolved as a side effect of this fix — likely the cache poisoning was cascading into test ordering for other files too. 5 consecutive `bun test` runs are now clean. If they reappear, we'll open a follow-up; leaving #35 closable by this PR.

## Test plan

- [x] `bun test` — 422 pass, 0 fail, 2 skip (5 consecutive clean runs locally)
- [x] `node --test "test/**/*.test.js"` — 422 pass, 0 fail, 2 skip
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [ ] This PR exercises the new Claude Code review workflow — first live run

Closes #35