### PR TITLE
workflow: allow Read, Grep, Glob tools for Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,6 +36,7 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 8
+            --allowedTools Read,Grep,Glob
           prompt: |
             You are reviewing a pull request on HarperFast/oauth.
 


### PR DESCRIPTION
## Summary

First live review run on PR #36 hit `max_turns` at turn 9 with `permission_denials_count: 9`. Claude couldn't read `CLAUDE.md` or inspect code because the default `claude-code-action@v1` tool policy denies everything not explicitly allowed, and we hadn't set an allowlist.

Adding `--allowedTools Read,Grep,Glob` to `claude_args` gives read-only access sufficient for baseline review:
- **Read** — load `CLAUDE.md`, tested files, files referenced in the diff
- **Grep** — search for patterns (e.g. "where else is this API called?")
- **Glob** — find files by pattern

Deliberately omitting `Edit`/`Write`/`Bash` — a reviewer shouldn't need to modify files or run shell commands, and the implicit deny list keeps attack surface minimal. If a future review needs git history inspection, we can add `Bash(git:*)`.

## Test plan

- [x] Format check passes
- [ ] Merge
- [ ] Re-run the review job on #36 (push empty commit or "Update branch" after merge) and verify Claude completes the review without hitting max_turns

## Context

This is the first calibration learning from the pilot. PR #36 remains red on the `review` check until this merges; its test-fix contents are independently validated (Node + Bun green there).