### PR TITLE
workflow: allowlist the canonical PR-review tools from the action docs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,7 +36,7 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 8
-            --allowedTools Read,Grep,Glob
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
           prompt: |
             You are reviewing a pull request on HarperFast/oauth.
 


### PR DESCRIPTION
## Summary

Follow-up to #37. The first allowlist (`Read,Grep,Glob`) was the wrong set — `claude-code-action` v1's PR-review pattern uses MCP-provided GitHub tools and `gh pr *` bash commands, not filesystem Read. The rerun on #36 still hit `max_turns` with 3 denials because Claude couldn't actually post the review.

Per [the action's docs/solutions.md "Automatic PR Code Review" example](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md#basic-example-no-tracking), the canonical allowlist is:

```
mcp__github_inline_comment__create_inline_comment
Bash(gh pr comment:*)
Bash(gh pr diff:*)
Bash(gh pr view:*)
```

Keeping `Read,Grep,Glob` additionally so Claude can load `CLAUDE.md` and inspect repo files beyond the diff. Still omitting `Edit/Write` and unconstrained `Bash` — reviewer should not modify files or run arbitrary shell.

## Test plan

- [x] Prettier clean
- [ ] Merge
- [ ] Update-branch on #36 and verify the review runs to completion (posts a review or "No blockers found" comment)

## Calibration lesson

The claude-code-action v1 default-deny policy is strict enough that even `Read` isn't enough to complete a PR-review flow. Required tools for a minimal review are MCP+gh-bash, not filesystem. Saved to memory.