### PR TITLE
workflow: align prompt and config with claude-code-action docs example

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,12 +33,16 @@ jobs:
         uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          show_full_output: true # TEMP: keep on during calibration so tool denials are visible; revert once reviews run cleanly
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 8
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
           prompt: |
-            You are reviewing a pull request on HarperFast/oauth.
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            The PR branch is already checked out in the current working directory.
 
             Read `CLAUDE.md` in the repo root first — it has the project
             overview, conventions, and (importantly) a "Non-Obvious Gotchas"
@@ -77,21 +81,27 @@ jobs:
             Do NOT comment on style, naming, nits, or personal preference.
             Do NOT restate what the diff does. Do NOT praise.
 
-            Cap the review at 10 findings. The findings list is the
-            entire output. If you found more than 10, pick the top 10
-            by severity and append "(+N more not shown)" to the last
-            finding's fix line.
+            Cap the review at 10 findings.
 
-            ## Output
+            ## How to post the review
+
+            - Use `gh pr comment` for top-level feedback (single consolidated
+              summary comment with all findings).
+            - Use `mcp__github_inline_comment__create_inline_comment`
+              (with `confirmed: true`) for specific code-line annotations.
+            - Only post GitHub comments — do NOT submit review text as SDK
+              messages.
+            - Do NOT use REQUEST_CHANGES or APPROVE during this calibration
+              phase. Stick to comments so the workflow never blocks or
+              auto-approves a merge.
+
+            ## Output format for the top-level comment
 
             If you find zero blockers: post one short comment —
             "No blockers found." — and stop.
 
-            If you find blockers: post one PR review as a COMMENT.
-            Do NOT use REQUEST_CHANGES or APPROVE during this
-            calibration phase — review type stays COMMENT so the
-            workflow never blocks or auto-approves a merge. Include
-            all findings using this structure:
+            If you find blockers: post one summary comment with all findings
+            using this structure, one block per finding:
 
               ### <N>. <concise title>
 
@@ -100,4 +110,4 @@ jobs:
               **Why it matters:** concrete impact
               **Suggested fix:** specific change, not generic advice
 
-            No preamble, no closing summary.
+            No preamble. No closing summary.


### PR DESCRIPTION
## Summary

Third iteration on the review workflow. Previous attempts hit `max_turns` with 3 → 10 tool denials because the prompt was missing context and Claude didn't know which tool to use for which step.

Changes, all modeled on [the docs example](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md#basic-example-no-tracking):

1. **Prompt: add `REPO` and `PR NUMBER` headers.** Docs: "Always include REPO and PR NUMBER for context." Without this, Claude burns turns probing for PR identity via tool calls that get denied.
2. **Prompt: explicit tool-use instructions.** Tell Claude to use `gh pr comment` for top-level feedback, `mcp__github_inline_comment__create_inline_comment` for line annotations, and that GitHub comments are the only valid output channel. Previous prompt said *what* to do, not *which tool* to use.
3. **Enable `show_full_output: true` temporarily.** The SDK log truncation ("full output hidden for security") made debugging tool denials impossible. Keep on during calibration; revert once a review completes cleanly.

Also added a note that the PR branch is pre-checked out, matching the docs example.

## Expected outcome

- Allowlist is now correct (verified in previous run log); the remaining denials were driven by prompt gaps, not tool policy. This PR fixes the prompt side.
- If it still fails, `show_full_output` gives us the tool names.

## Test plan

- [x] Prettier clean
- [ ] Merge
- [ ] Update-branch on #36; verify the review either (a) posts "No blockers found" or (b) posts a review comment with findings