### PR TITLE
workflow: steer Claude to native Read/Grep/Glob tools

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -44,6 +44,20 @@ jobs:
 
             The PR branch is already checked out in the current working directory.
 
+            ## Tools
+
+            For file inspection use the `Read`, `Grep`, and `Glob` tools.
+            Do NOT use `cat`, `head`, `tail`, `grep`, `ls`, or `find`
+            via Bash — those commands are not allowed and waste turns.
+            Do NOT run `bun test`, `npm test`, or any other script
+            that executes PR code — the PR's tests are already checked
+            separately.
+
+            The only allowed Bash commands are:
+            - `gh pr view` / `gh pr diff` — inspect the PR (already run
+              at start, you can re-invoke if needed)
+            - `gh pr comment` — post the final review comment
+
             Read `CLAUDE.md` in the repo root first — it has the project
             overview, conventions, and (importantly) a "Non-Obvious Gotchas"
             section covering Resource API v2 patterns, GenericTrackedObject


### PR DESCRIPTION
## Summary

Fourth iteration on the review workflow. With `show_full_output: true` on (from #39), we can finally see what Claude is doing: it reads the PR via `gh pr view`/`gh pr diff` (allowed), then pivots to `cat -n`, `grep`, and even `bun test` for deeper inspection — all denied.

Root cause is prompt-level, not policy: Claude has `Read`, `Grep`, `Glob` in its allowlist but defaults to Bash equivalents once it sees Bash working for the `gh` commands. Not broadening Bash — a PR review shouldn't be executing PR code (`bun test` on an untrusted branch) or reaching for shell utilities when native tools are available.

This PR adds a **"Tools"** section to the prompt that:
- Explicitly names `Read`/`Grep`/`Glob` for file inspection
- Names the Bash commands NOT to use (`cat`, `head`, `tail`, `grep`, `ls`, `find`)
- Forbids running PR code (`bun test`, `npm test`)
- Lists the only allowed Bash commands (`gh pr view`/`diff`/`comment`)

## Test plan

- [x] Prettier clean
- [ ] Merge
- [ ] Update-branch on #36; verify the review posts a summary comment (either "No blockers found" or findings)