### PR TITLE
fix: default redirectUri matches Harper dev config (http://localhost:9926)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,4 +20,4 @@ defaultRole: 'user'
 postLoginRedirect: '/'
 
 # Default redirect URI pattern (will be adjusted per provider)
-redirectUri: 'https://localhost:9953/oauth/callback'
+redirectUri: 'http://localhost:9926/oauth/callback'

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -52,7 +52,7 @@ export function buildProviderConfig(
 	const providerPreset = providerType ? getProvider(providerType) : null;
 
 	// Build redirect URI with provider name in path
-	const baseRedirectUri = expandedOptions.redirectUri || pluginDefaults.redirectUri || 'https://localhost:9953/oauth';
+	const baseRedirectUri = expandedOptions.redirectUri || pluginDefaults.redirectUri || 'http://localhost:9926/oauth';
 	const redirectUri = baseRedirectUri
 		.replace('/oauth/callback', `/oauth/${providerName}/callback`)
 		.replace(/\/oauth$/, `/oauth/${providerName}/callback`);

--- a/test/lib/OAuthProvider.test.js
+++ b/test/lib/OAuthProvider.test.js
@@ -20,7 +20,7 @@ describe('OAuthProvider', () => {
 		authorizationUrl: 'https://auth.example.com/authorize',
 		tokenUrl: 'https://auth.example.com/token',
 		userInfoUrl: 'https://auth.example.com/userinfo',
-		redirectUri: 'https://localhost:9953/oauth/test/callback',
+		redirectUri: 'http://localhost:9926/oauth/test/callback',
 		scope: 'openid profile email',
 		usernameClaim: 'email',
 		defaultRole: 'user',

--- a/test/lib/config.test.js
+++ b/test/lib/config.test.js
@@ -96,7 +96,7 @@ describe('OAuth Configuration', () => {
 			assert.equal(config.clientId, 'test-client');
 			assert.equal(config.clientSecret, 'test-secret');
 			assert.equal(config.authorizationUrl, 'https://auth.test.com/authorize');
-			assert.equal(config.redirectUri, 'https://localhost:9953/oauth/test/callback');
+			assert.equal(config.redirectUri, 'http://localhost:9926/oauth/test/callback');
 		});
 
 		it('should expand environment variables', () => {
@@ -189,7 +189,7 @@ describe('OAuth Configuration', () => {
 
 			const config = buildProviderConfig(providerConfig, 'myprovider', {});
 
-			assert.equal(config.redirectUri, 'https://localhost:9953/oauth/myprovider/callback');
+			assert.equal(config.redirectUri, 'http://localhost:9926/oauth/myprovider/callback');
 		});
 
 		it('should handle custom redirect URI', () => {

--- a/test/lib/handlers.test.js
+++ b/test/lib/handlers.test.js
@@ -32,7 +32,7 @@ describe('OAuth Handlers', () => {
 			authorizationUrl: 'https://auth.test.com/authorize',
 			tokenUrl: 'https://auth.test.com/token',
 			userInfoUrl: 'https://auth.test.com/userinfo',
-			redirectUri: 'https://localhost:9953/oauth/test/callback',
+			redirectUri: 'http://localhost:9926/oauth/test/callback',
 			postLoginRedirect: '/dashboard',
 		};
 


### PR DESCRIPTION
## Summary

Plugin defaulted to `https://localhost:9953/oauth/callback`, but Harper v5 dev mode serves plain HTTP on port 9926 (see `utility/install/installer.js:50` — `HTTP_PORT: 9926`, `HTTP_SECUREPORT` null by default in dev). Users booted Harper, saw 9926 HTTP, and got a redirect mismatch the first time they wired up an OAuth provider.

Changing the default to `http://localhost:9926/oauth/callback` so the out-of-the-box flow works. Users running with TLS can still override via `redirectUri` in config.

## Changes

- `config.yaml` default
- `src/lib/config.ts` fallback in `buildProviderConfig`
- Matching test assertions in `test/lib/config.test.js`
- Test fixture `redirectUri` values in `test/lib/OAuthProvider.test.js` and `test/lib/handlers.test.js` for consistency

## Test plan

- [x] `npm test` — 422 pass, 0 fail, 2 skip
- [x] `bun test` — 422 pass, 0 fail, 2 skip
- [x] `npm run lint` passes
- [ ] Claude review passes

Closes #30