### PR TITLE
workflow: bump max-turns 16 → 24

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -37,7 +37,7 @@ jobs:
           show_full_output: true # TEMP: keep on during calibration so tool denials are visible; revert once reviews run cleanly
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 16
+            --max-turns 24
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

PR #43 hit the 16-turn cap with zero denials and $0.87 spent, posting one valid finding before cutoff. Bumping to 24 gives Sonnet room to complete substantive reviews.

## Trade-offs

- Sonnet at 24 turns worst-case is ~$1.30 (historical rate ~$0.05/turn); concurrency-1/PR and 10-min job timeout stay as safety rails.
- For PRs that still cap out at 24, the answer is splitting the PR — not raising turns further.

## Test plan

- [x] Prettier clean
- [ ] Merge
- [ ] Next substantive PR exercises the new budget