### PR TITLE
workflow: skip stale-comment re-logs and surface review status in the title

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -157,21 +157,51 @@ jobs:
             exit 0
           fi
 
-          # Fetch the latest comment posted by the Claude bot on this PR.
-          CLAUDE_BODY=$(gh pr view "$PR_NUMBER" --json comments \
-            --jq '[.comments[] | select(.author.login == "claude")] | last | .body // empty')
+          # When this workflow job started. Used to filter out stale Claude
+          # comments from previous runs so a cancelled in-flight run (e.g.
+          # from a force-push) doesn't re-log the prior run's comment as a
+          # fresh finding.
+          JOB_STARTED=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" --jq '.run_started_at // empty')
+
+          # Fetch Claude's latest comment and its createdAt timestamp.
+          CLAUDE_JSON=$(gh pr view "$PR_NUMBER" --json comments \
+            --jq '[.comments[] | select(.author.login == "claude")] | last // empty')
+
+          if [ -z "$CLAUDE_JSON" ] || [ "$CLAUDE_JSON" = "null" ]; then
+            echo "No Claude comment found on PR #$PR_NUMBER (review_status=$REVIEW_STATUS); skipping log."
+            exit 0
+          fi
+
+          CLAUDE_BODY=$(printf '%s' "$CLAUDE_JSON" | jq -r '.body // empty')
+          CLAUDE_AT=$(printf '%s' "$CLAUDE_JSON" | jq -r '.createdAt // empty')
 
           if [ -z "$CLAUDE_BODY" ]; then
-            echo "No Claude comment found on PR #$PR_NUMBER (review_status=$REVIEW_STATUS); skipping log."
+            echo "Claude comment had empty body; skipping log."
+            exit 0
+          fi
+
+          # ISO-8601 lexicographic compare — both are UTC timestamps in the
+          # same shape, so string comparison is sound.
+          if [ -n "$JOB_STARTED" ] && [ -n "$CLAUDE_AT" ] && [ "$CLAUDE_AT" \< "$JOB_STARTED" ]; then
+            echo "::notice::Latest Claude comment ($CLAUDE_AT) predates this job's start ($JOB_STARTED); skipping to avoid re-logging a stale comment."
             exit 0
           fi
 
           # Title: count findings (lines starting with `### <digit>`). "No blockers" case has none.
           if printf '%s' "$CLAUDE_BODY" | grep -qi '^no blockers found'; then
-            TITLE="[oauth] PR #$PR_NUMBER: no blockers"
+            COUNT_PART="no blockers"
           else
             FINDING_COUNT=$(printf '%s\n' "$CLAUDE_BODY" | grep -c '^### [0-9]' || true)
-            TITLE="[oauth] PR #$PR_NUMBER: ${FINDING_COUNT} finding(s) — triage pending"
+            COUNT_PART="${FINDING_COUNT} finding(s) — triage pending"
+          fi
+
+          # Decorate the title with the review job status when the review
+          # didn't complete cleanly (e.g., max_turns). Findings posted before
+          # the cutoff are still logged but flagged as potentially incomplete.
+          if [ "$REVIEW_STATUS" = "success" ]; then
+            TITLE="[oauth] PR #$PR_NUMBER: $COUNT_PART"
+          else
+            TITLE="[oauth] PR #$PR_NUMBER: $COUNT_PART (review $REVIEW_STATUS — may be incomplete)"
           fi
 
           BODY=$(printf '**Source:** %s\n**Repo:** oauth\n**PR:** #%s\n**Model:** claude-sonnet-4-6\n**Phase:** baseline\n**Review job status:** %s\n**Date:** %s\n\n---\n\n%s\n' \


### PR DESCRIPTION
## Summary

Two improvements to the ai-review-log posting step, driven by calibration feedback after PR #46 produced a duplicate log entry from a cancelled force-push run.

### 1. Skip stale-comment re-logs

`if: always()` caused the log step to run on cancellation too. When a force-push cancelled an in-flight review, the log step still ran, found the PRIOR run's Claude comment, and POST'd it again as a fresh log issue. That's what `ai-review-log#3` is — a duplicate of `#2`.

Fix: fetch the job's `run_started_at` and the comment's `createdAt`, and skip if the comment predates the job start.

### 2. Status in title

`ai-review-log#1` title reads "1 finding(s) — triage pending" but the review actually hit `max_turns` and may have missed more findings. Triage shouldn't need to open the body to see this.

Non-success reviews now get a title suffix: `(review failure — may be incomplete)`.

## Test plan

- [x] Prettier clean
- [ ] Merge
- [ ] Next PR run: verify normal success path still produces clean titles
- [ ] Exercise force-push scenario: open a PR, push twice quickly; confirm only one log issue lands for the completed run, not the cancelled one

## Cleanup reminder

After this lands, `ai-review-log#3` should be closed as `verdict:noise` (duplicate of `#2`).