### PR TITLE
workflow: give the bot access to HarperFast/skills (SHA-pinned)

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -43,6 +43,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Clone shared Harper skills
+        # Pinned to a SHA (not `main`) so agent behavior is reproducible
+        # across runs — updates to the skills repo require an explicit
+        # pin bump in this workflow.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          repository: HarperFast/skills
+          ref: d2db99bb37a6dde868cbc5ac81ca4146be8956fb # 1.3.0 (2026-04-16)
+          path: .harper-skills
+
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
@@ -105,6 +115,20 @@ jobs:
             Read `CLAUDE.md` in the repo root. Its "Code Conventions"
             and "Non-Obvious Gotchas" sections apply. Match the repo's
             style.
+
+            For docs and deployment-related changes — especially doc
+            issues like env-var / config / production-setup guidance —
+            also consult the shared Harper skills at
+            `.harper-skills/harper-best-practices/rules/`. In particular,
+            `.harper-skills/harper-best-practices/rules/deploying-to-harper-fabric.md`
+            is authoritative for Harper's deployment model (Fabric).
+            Do NOT invent generic production patterns (systemd units,
+            raw Kubernetes, cloud secrets managers, arbitrary .env
+            recommendations) without first checking whether a
+            Harper-specific path exists in those rules. If the skills
+            don't cover the ask and the issue body doesn't specify,
+            comment on the issue asking for clarification rather than
+            guessing.
 
             ## Process
 

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -49,6 +49,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Clone shared Harper skills
+        # Pinned to a SHA (not `main`) so agent behavior is reproducible
+        # across runs — updates to the skills repo require an explicit
+        # pin bump in this workflow.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          repository: HarperFast/skills
+          ref: d2db99bb37a6dde868cbc5ac81ca4146be8956fb # 1.3.0 (2026-04-16)
+          path: .harper-skills
+
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
@@ -84,6 +94,16 @@ jobs:
             and "Non-Obvious Gotchas" sections apply to any code you
             write. Match the repo's existing style rather than
             introducing a new one.
+
+            For any change touching deployment patterns, docs about
+            production, or Harper best practices, also consult the
+            shared skills at `.harper-skills/harper-best-practices/rules/`.
+            In particular,
+            `.harper-skills/harper-best-practices/rules/deploying-to-harper-fabric.md`
+            is authoritative for Harper's deployment model (Fabric). Do
+            NOT recommend generic patterns (systemd units, raw
+            Kubernetes, cloud secrets managers) without first checking
+            whether a Harper-specific path applies.
 
             ## Before committing
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,6 +29,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Clone shared Harper skills
+        # Pinned to a specific SHA (not `main`) so review behavior is
+        # reproducible across runs — updates to the skills repo require
+        # an explicit pin bump in this workflow.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          repository: HarperFast/skills
+          ref: d2db99bb37a6dde868cbc5ac81ca4146be8956fb # 1.3.0 (2026-04-16)
+          path: .harper-skills
+
       - name: Claude review
         id: claude-review
         uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
@@ -84,6 +94,19 @@ jobs:
             section covering Resource API v2 patterns, GenericTrackedObject
             spread behavior, `tsc || true` build semantics, and security
             invariants.
+
+            Shared Harper conventions (applicable to any PR touching
+            deployment, docs, or best practices) are available at
+            `.harper-skills/harper-best-practices/rules/*.md`. Notably:
+
+            - `.harper-skills/harper-best-practices/rules/deploying-to-harper-fabric.md`
+              is the authoritative source for Harper's deployment model
+              (Fabric). Any doc recommendation that contradicts it — e.g.
+              suggesting systemd, raw Kubernetes, or generic cloud-secrets
+              patterns — is wrong for Harper and should be flagged.
+            - Other rule files in that directory cover schema, auth
+              patterns, and custom resources. Consult them when a PR's
+              recommendations touch those areas.
 
             ## OAuth-specific things to check
 


### PR DESCRIPTION
## Summary

Adds a `Clone shared Harper skills` step to all three bot workflows (review, mention, issue-to-pr). Each clone pulls `HarperFast/skills` at SHA `d2db99bb37a6dde868cbc5ac81ca4146be8956fb` (1.3.0, 2026-04-16) into `.harper-skills/` on the runner, and the prompts now point Claude there for Harper deployment + best-practices context.

## Why

PR #50 was Claude's attempt at issue #32 via `claude-fix:docs`. The output:
- Recommended `systemd` / Kubernetes / cloud secrets managers (none of which are Harper's actual deployment story)
- Missed Fabric entirely (the authoritative path)
- Inverted the issue's intent (said "don't use .env" when the reporter was asking for a .env story)

None of those facts live in `/oauth/CLAUDE.md`. They live in `HarperFast/skills/harper-best-practices/rules/deploying-to-harper-fabric.md` (and neighbors). The bot had no access. This PR fixes that.

## Design choices

- **`.harper-skills/` not `.claude/skills/`**: claude-code-action restores `.claude/` from `origin/main` at startup for its "PR head is untrusted" security model. Anything we write into `.claude/` at workflow time is at risk of being wiped. A separate path avoids the question entirely — Claude just `Read`s the markdown.
- **Pinned SHA, not `main`**: per calibration learning, bot behavior should be reproducible across runs. Skills updates require an explicit pin bump here.
- **Review workflow also flags the failure mode**: new prompt text tells Claude to reject PRs that recommend non-Harper patterns. Defense-in-depth for future PR #50–style drift.

## Test plan

- [x] Prettier clean
- [ ] Merge
- [ ] (Optional) re-label issue #32 or file a test issue to verify the new skills guidance actually steers output correctly

## Follow-up ideas

- Port skills access to the backport branch (`v1.x`) when we backport the workflow
- Consider pinning skills to a tag rather than SHA for easier human parsing (skills repo uses semver tags per the 1.3.0 release I pinned to)
- Add `harper-engineering-guidelines` / `deep-review` (private `skills-internal`) once we can set up authed cross-repo checkout