### PR TITLE
workflow: scale agent turn budgets + skip validation for doc-only tasks

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -137,14 +137,18 @@ jobs:
             2. Make the change scoped to the label.
             3. Validate, scaling to the kind of change you made:
                - `claude-fix:typo` / `claude-fix:docs` (doc-only
-                 changes to `*.md`, `docs/**`, `config.yaml`):
-                 run `npm run format:check` and `npm run lint`.
-                 Skip `npm run build` / `npm test` / `bun test` —
-                 they are not affected and waste turns.
+                 changes to `*.md`, `docs/**`, or `package.json`
+                 keyword/description fields): run
+                 `npm run format:check` and `npm run lint`. Skip
+                 `npm run build` / `npm test` / `bun test` — they
+                 are not affected and waste turns.
                - `claude-fix:deps` / `claude-fix:bug` or any change
-                 that touches code: run
+                 that touches code OR `config.yaml` (plugin entry
+                 point + runtime OAuth defaults — not doc-only): run
                  `npm run build && npm run lint && npm run format:check && npm test`
                  and `bun test`. Fix anything that fails.
+
+               When in doubt, err toward the fuller validation.
             4. Commit with a descriptive message.
             5. Push the branch and open a PR via `gh pr create` with a
                body that says `Closes #${{ github.event.issue.number }}`.

--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -135,7 +135,13 @@ jobs:
             1. Create a branch named `claude/fix-${{ github.event.issue.number }}`
                (or append `-<short-desc>` if useful).
             2. Make the change scoped to the label.
-            3. Validate, scaling to the kind of change you made:
+            3. Validate, scaling to the kind of change you made.
+
+               **`config.yaml` is NOT doc-only** — it holds the plugin
+               entry point (`pluginModule`) and runtime OAuth defaults.
+               Any change that touches `config.yaml` requires the full
+               validation path regardless of the `claude-fix:*` label.
+
                - `claude-fix:typo` / `claude-fix:docs` (doc-only
                  changes to `*.md`, `docs/**`, or `package.json`
                  keyword/description fields): run
@@ -143,8 +149,7 @@ jobs:
                  `npm run build` / `npm test` / `bun test` — they
                  are not affected and waste turns.
                - `claude-fix:deps` / `claude-fix:bug` or any change
-                 that touches code OR `config.yaml` (plugin entry
-                 point + runtime OAuth defaults — not doc-only): run
+                 that touches code or `config.yaml`: run
                  `npm run build && npm run lint && npm run format:check && npm test`
                  and `bun test`. Fix anything that fails.
 

--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -75,7 +75,7 @@ jobs:
           show_full_output: true
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 40
+            --max-turns 72
             --allowedTools "Read,Write,Edit,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr create:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(git:*),Bash(npm install:*),Bash(npm ci:*),Bash(npm run:*),Bash(npm test:*),Bash(bun install:*),Bash(bun run:*),Bash(bun test:*),Bash(npx:*)"
           prompt: |
             You were invoked because issue #${{ github.event.issue.number }}
@@ -135,8 +135,16 @@ jobs:
             1. Create a branch named `claude/fix-${{ github.event.issue.number }}`
                (or append `-<short-desc>` if useful).
             2. Make the change scoped to the label.
-            3. Run `npm run build && npm run lint && npm run format:check && npm test`
-               and `bun test`. Fix anything that fails.
+            3. Validate, scaling to the kind of change you made:
+               - `claude-fix:typo` / `claude-fix:docs` (doc-only
+                 changes to `*.md`, `docs/**`, `config.yaml`):
+                 run `npm run format:check` and `npm run lint`.
+                 Skip `npm run build` / `npm test` / `bun test` —
+                 they are not affected and waste turns.
+               - `claude-fix:deps` / `claude-fix:bug` or any change
+                 that touches code: run
+                 `npm run build && npm run lint && npm run format:check && npm test`
+                 and `bun test`. Fix anything that fails.
             4. Commit with a descriptive message.
             5. Push the branch and open a PR via `gh pr create` with a
                body that says `Closes #${{ github.event.issue.number }}`.

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -109,11 +109,15 @@ jobs:
 
             Scale validation to the kind of change you made:
 
-            - Doc-only change (only `*.md`, `docs/**`, `config.yaml`,
-              or `package.json` keyword/description edits): run
+            - Doc-only change (only `*.md`, `docs/**`, or
+              `package.json` keyword/description edits): run
               `npm run format:check` and `npm run lint`. Do NOT run
               `npm run build` / `npm test` / `bun test` — they are
               not affected and waste turns.
+
+              `config.yaml` is NOT doc-only — it holds the plugin
+              entry point (`pluginModule`) and runtime OAuth defaults.
+              Treat any change there as a code/config change.
             - Code or config change that affects behavior: run
               `npm run build && npm run lint && npm run format:check && npm test`
               and `bun test`. Fix anything that fails.

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -81,7 +81,7 @@ jobs:
           show_full_output: true
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 30
+            --max-turns 48
             --allowedTools "Read,Write,Edit,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr checkout:*),Bash(gh pr create:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(git:*),Bash(npm install:*),Bash(npm ci:*),Bash(npm run:*),Bash(npm test:*),Bash(bun install:*),Bash(bun run:*),Bash(bun test:*),Bash(npx:*)"
           # In agent mode the action uses the triggering comment as the
           # prompt. The text below layers supplemental context on top.
@@ -107,9 +107,18 @@ jobs:
 
             ## Before committing
 
-            Run `npm run build && npm run lint && npm run format:check && npm test`
-            in the workspace. Also run `bun test` — Bun is installed in
-            the runner. Fix anything that fails before committing.
+            Scale validation to the kind of change you made:
+
+            - Doc-only change (only `*.md`, `docs/**`, `config.yaml`,
+              or `package.json` keyword/description edits): run
+              `npm run format:check` and `npm run lint`. Do NOT run
+              `npm run build` / `npm test` / `bun test` — they are
+              not affected and waste turns.
+            - Code or config change that affects behavior: run
+              `npm run build && npm run lint && npm run format:check && npm test`
+              and `bun test`. Fix anything that fails.
+
+            When in doubt, err toward the fuller validation.
 
             ## Output
 


### PR DESCRIPTION
## Summary

Bumps max-turns on the two agent workflows to match the actual shape of the work, and teaches the prompts to skip unnecessary validation on doc-only changes.

## The problem

PR #50's @claude retry showed the eyes emoji (action acknowledged the mention), ran Claude through reading + some tool calls, and then died at turn 30 without committing anything or posting a comment.

Root cause: the mention workflow had `max-turns: 30` — barely more than the review workflow's 24, despite agent work being strictly more involved (read + **change + validate + push + report**). Four of those turns were burned on `build/lint/test/bun test` validation that wouldn't be affected by a docs-only change.

## Changes

### Turn budgets scale with workflow effort

| Workflow | Old | New | Ratio to review |
|---|---|---|---|
| Review | 24 | 24 | 1x (baseline) |
| Mention | 30 | 48 | 2x |
| Issue-to-PR | 40 | 72 | 3x |

At ~$0.05/turn worst-case Sonnet: ~$1.20 / $2.40 / $3.60. Concurrency per PR/issue and timeout-minutes remain the hard safety rails.

### Validation scales with change type

Both agent prompts now tell Claude to:

- Doc-only changes (`*.md`, `docs/**`, `config.yaml`, package.json keyword edits): `npm run format:check` + `npm run lint`. Skip build/test.
- Code/config changes: full `build && lint && format:check && test` + `bun test`.
- When in doubt, err toward the fuller validation.

Saves ~3-4 turns per doc task — the exact pattern that caused the #50 retry to hit the cap.

## Not changed

- `claude-review.yml` (max-turns 24) — review work has fit within 24 turns consistently on recent PR #48 runs.

## Test plan

- [x] Prettier clean
- [ ] Merge
- [ ] Re-exercise the #50 mention (or push a doc-only commit that triggers a fresh attempt)
- [ ] Watch next issue-to-pr trigger for a bug-label issue to see the 72-turn ceiling in action