### PR TITLE
ci(review): adopt layered review-scopes; bump step timeout 10→15

### DIFF
--- a/.github/review-scopes/README.md
+++ b/.github/review-scopes/README.md
@@ -1,0 +1,40 @@
+# review-scopes (layered prompts for the AI review workflow)
+
+Layered prompt content consumed by `.github/workflows/claude-review.yml`. Composed into a single prompt block at workflow runtime, most-general first, most-specific last.
+
+## Provenance
+
+Copied from `HarperFast/ai-review-log/review-scopes/` at merge SHA `ef8d99458c27094a6fac97f373ebddee2abc5376` (PR #19). The expectation is that these layer files will eventually live in a single shared location (either the original `ai-review-log` repo once it goes public, or a dedicated `HarperFast/ai-review-prompts` repo) — but for now each consumer repo keeps its own copy so we can evaluate the layered-scope approach across 2–3 repos without committing to a shared-repo architecture prematurely. When syncing from an upstream copy is needed, diff against the source and bring over any reviewer-discipline improvements.
+
+## Layout
+
+```
+review-scopes/
+  universal.md           # architecture, security, dispatch, public-API
+                         # discipline — applies to EVERY PR
+  harper/
+    common.md            # gotchas that cross Harper versions
+    v5.md                # v5-specific (harper package, Resource API v2,
+                         # static vs instance dispatch, Fabric deployment)
+  repo-type/
+    plugin.md            # oauth, future npm-published plugins
+```
+
+## How the workflow consumes these
+
+`.github/workflows/claude-review.yml` declares which layers apply via the `REVIEW_LAYERS` env var, then composes the prompt at runtime:
+
+```yaml
+env:
+  REVIEW_LAYERS: |
+    universal
+    harper/common
+    harper/v5
+    repo-type/plugin
+```
+
+Each named layer resolves to `.github/review-scopes/<name>.md`. The "Compose review scope from layers" step concatenates them (with blank-line separators) and exposes the result as a step output that's interpolated into the `prompt:` input of `anthropics/claude-code-action`.
+
+## Writing / editing layers
+
+Each layer file is a markdown document that reads as review guidance. Each bullet should be something a reviewer can check on a PR — specific, not generic. Keep layers tight (aim for ~1–2 KB each). Claude reads all included layers before working through the diff; bigger = slower + more token-expensive.

--- a/.github/review-scopes/harper/common.md
+++ b/.github/review-scopes/harper/common.md
@@ -1,0 +1,23 @@
+# Harper common conventions
+
+Version-agnostic review guidance for repos in the Harper ecosystem. The repo's own `CLAUDE.md` may duplicate or extend this — when in conflict, the repo's CLAUDE.md wins (it's closer to the source).
+
+## Non-obvious behavior
+
+- **`GenericTrackedObject` + spread.** `{ ...obj }` on a Harper *generic* tracked object (the shape for `session.oauth`, `session.oauthUser`, and any tracked object without a declared schema) copies nothing — properties are served through a Proxy `get` trap, not as own enumerable properties. `Object.keys(obj)` returns `[]`. Use explicit property access: `{ provider: obj.provider, ... }`. Typed TrackedObjects (table rows with declared attributes) may behave differently; verify against the specific tracked type rather than assuming either way. Any test using spread on session fields is testing a plain object, not the production shape.
+- **`session.oauth` vs `session.delete()`.** Some session objects expose `.delete(id)` (Harper production shape — destroys the DB record). Some don't (in-memory test mocks). Code calling `clearOAuthSession` or similar may mutate `.oauth`/`.oauthUser` in-memory on test shapes but destroy the entire session record in production. Tests that exercise only one shape hide the divergence.
+- **`npm run build` tolerance.** Many Harper repos use `tsc || true` so the build passes even with type errors. "Build passes" ≠ "types are sound." Type correctness must be verified separately (editor diagnostics, a dedicated typecheck script, or CI step).
+- **`npm run lint` is ESLint-only**, not a typecheck.
+
+## Code conventions
+
+- TypeScript strict mode; ES modules with `.js` extensions in imports; named exports only (no default exports).
+- Logging uses the optional-chain pattern `logger?.info?.()` — the `logger` argument is frequently undefined in library code, so code must not assume it's present.
+- Error classes come from each repo's `src/errors.ts` OR the framework package (`harper` v5 / `harperdb` v4). All custom errors include a `statusCode` property.
+- Tokens, passwords, session IDs — **never** log, never return in responses, never include in error messages.
+
+## Review checks specific to Harper
+
+- **`scope.resources` / `scope.server` usage.** Declared optional in the Harper type but always assigned in the Scope constructor. Code should either guard once at entry or use narrowed locals, not sprinkle `?.` / `!` throughout.
+- **`static loadAsInstance = false` (Resource API v2).** Harper instantiates the class per request; do NOT rely on shared mutable instance state across requests. If per-request state is stored, it belongs on the context (`this.getContext()`).
+- **Unused runtime dependencies.** Harper repos target minimal runtime deps. New ones require explicit justification in the PR description (some repos maintain a `dependencies.md` for this).

--- a/.github/review-scopes/harper/v5.md
+++ b/.github/review-scopes/harper/v5.md
@@ -1,0 +1,68 @@
+# Harper v5 conventions
+
+Review guidance for repos that target Harper v5. Apply this layer when the repo's `peerDependencies` declares `harper`.
+
+> **Authoritative source.** `HarperFast/skills/harper-best-practices/` is the customer-facing guidance for building on Harper. This document is a **review lens** — what to CHECK when reviewing changes. If anything here contradicts the skills, the skills win for user-facing guidance; this file's job is reviewer discipline.
+
+## Package and CLI
+
+- **Package**: `harper`. Imports: `from 'harper'`. Peer dep range: `harper >=5.0.0`.
+- **CLI binary**: `harper` (e.g., `harper deploy_component`). PR diffs introducing v4-era `harperdb` imports or `harperdb` CLI calls are stale — flag them.
+
+## Resource API v2
+
+v5 has two co-existing dispatch patterns. A review of any Resource — or anything that wraps a Resource — must account for BOTH.
+
+- **Instance-method pattern**:
+  ```ts
+  class MyResource extends Resource {
+    static loadAsInstance = false;
+    async get(target) {
+      const request = this.getContext();
+      ...
+    }
+  }
+  ```
+  Harper's Resource base static `get` is `transactional(fn)` — it creates a per-request instance and calls the instance method.
+
+- **Static-method pattern** (v5 migration guide explicitly recommends this):
+  ```ts
+  class MyResource extends Resource {
+    static async get(target, request) { ... }
+  }
+  ```
+  Harper's REST dispatcher calls `Class.get(target, request)` at the STATIC level. The user's static shadows the Resource base's transactional static — no instance is created.
+
+- **Wrappers must cover both surfaces.** A wrapper that intercepts only instance methods is silently bypassed when the user adopts the static-method pattern. Full coverage wraps both and de-duplicates work (e.g. via a WeakSet keyed by the request context) so a single dispatch doesn't run validation twice.
+
+- **405 vs 204.** Harper's REST dispatcher returns `405 Method Not Allowed` when the method is undefined on the resource. A wrapper that defines all five verbs unconditionally — even when the parent doesn't implement them — replaces `undefined` with a function that returns `undefined`, and Harper serializes that as `204 No Content`. Only wrap verbs the parent actually implements.
+
+## Context + `getContext()`
+
+- Request-scoped state lives on the context returned by `this.getContext()` (inside an instance method). For static methods, Harper passes the request as the second arg: `static async get(target, request)`.
+- `this.getCurrentUser()` returns the authenticated user off the current context. Checks against `user.role.permission.super_user` are the standard "require superuser" guard.
+- `scope.resources` and `scope.server` are typed as optional in v5 but always assigned in the Scope constructor (`components/Scope.ts:70-71`). Plugins should guard once at `handleApplication` entry and use narrowed locals.
+
+## `config.yaml` and resource loading
+
+- `jsResource.files` controls which files Harper loads as resources. A change to this glob / pattern / directory / extension IS a meaningful review concern — it changes what actually gets served.
+- `config.yaml` also carries plugin entry point (`pluginModule`), `graphqlSchema.files`, and runtime defaults (e.g. `redirectUri`, `scope`, `defaultRole`). Treat `config.yaml` changes as code, not docs — a typo breaks the plugin/app at runtime.
+
+## Environment variables and `.env`
+
+- **Harper runtime** reads `process.env.*`. It does not itself parse a `.env` file on startup.
+- **Harper app template** (`npm create harper`) scaffolds `dotenv-cli` in `package.json` scripts. `npm run dev` / `npm run deploy` invokes `dotenv -- npm run <script>`, loading `.env` before Harper or the deploy CLI starts. `.env` IS the standard local-dev and deploy-credentials pattern for Harper v5 apps.
+- **Fabric deployment** takes cluster credentials via `CLI_TARGET*` env vars during deploy. Runtime configuration is injected by the platform.
+- When reviewing docs about env-var handling, recommendations should match Harper's actual toolchain — `.env` via `dotenv-cli` for local/CI/deploy credentials, Fabric for production runtime — NOT generic systemd, Kubernetes secrets, or cloud-provider secrets manager patterns unless the PR author has specifically asked about non-Fabric deployment.
+
+## Deployment: Fabric
+
+Harper v5's managed production platform is Fabric.
+
+- **Authoritative references** in `HarperFast/skills`: `harper-best-practices/rules/deploying-to-harper-fabric.md`, `harper-best-practices/rules/creating-a-fabric-account-and-cluster.md`.
+- Default deployment recommendations go to Fabric. Alternatives are for users who explicitly opt out.
+
+## Typing
+
+- Imports from `harper` — v5 exports `Resource`, `Scope`, `User`, `RequestTarget`, `Context`, `SourceContext`, and others. Verify imports against the v5 `index.d.ts`.
+- Harper v5 has pre-existing TS errors in its own source that surface during consumer `tsc` runs; repos use `tsc || true` to tolerate these. Do NOT flag type errors originating from `node_modules/harper/` as blockers — they're upstream.

--- a/.github/review-scopes/repo-type/plugin.md
+++ b/.github/review-scopes/repo-type/plugin.md
@@ -1,0 +1,36 @@
+# Harper plugin repo
+
+Applies to repos that ship as npm packages consumed by Harper applications — OAuth, and future plugins. These repos have a distinct review surface because they extend Harper rather than being Harper itself.
+
+## Registration and lifecycle
+
+- **Plugin entry** is `handleApplication(scope)` exported from `src/index.ts`. Verify the PR preserves this signature and doesn't rename or re-shape it.
+- **Resource registration** uses `scope.resources.set('<name>', Class)`. Harper's dispatch logic requires the registered value to be a class (with `static getResource` inherited from `Resource`), not an instance, not a plain object.
+- **HTTP middleware** registration uses `scope.server.http?.(handler)`. Verify new middleware handles the "no OAuth / no auth data" passthrough case correctly — middleware runs on every HTTP request, including requests that don't need the plugin's semantics.
+- **Close handlers**: Plugins that hold resources (cache instances, timers, sockets) should register a cleanup listener on `scope.on('close', ...)`. Verify new long-lived state has a corresponding cleanup path.
+
+## Public API surface
+
+- **Everything exported from `src/index.ts` is public.** Re-exports need JSDoc and semver care.
+- **New public symbols require tests.** Silent no-test public API was a recurring gap in the OAuth plugin's review history.
+- **Breaking changes require a major version bump.** For plugins with a maintenance branch (e.g. `v1.x` for harperdb-v4 support), check whether the fix needs a backport. Surface the backport question in the PR description if non-trivial.
+
+## Dependencies
+
+- **Zero or justified runtime dependencies.** Every new runtime dep needs explicit justification in the PR description. Plugins that previously claimed zero runtime deps and then added one (e.g. `jsonwebtoken` for JWT-based providers) must update their README / docs accordingly.
+- **Peer dep version range** should match the plugin's compatibility promise. v5-only plugin → `harper >=5.0.0`. Multi-version plugin → union range or separate release lines.
+
+## Wrapping and decorating patterns
+
+Plugins frequently offer a wrapper function that user resources opt into (e.g. `withOAuthValidation`). Review such wrappers against the full dispatch surface audit in `universal.md` and the v5 static-vs-instance guidance in `harper/v5.md`. Common bypass shapes we've seen:
+
+- Proxy-based wrappers that don't intercept class-level dispatch.
+- Subclass wrappers that only override instance methods and miss user-defined statics.
+- Subclass wrappers that define all five verbs unconditionally and break Harper's 405 Method Not Allowed semantics for verbs the parent doesn't implement.
+- Wrappers whose `onValidationError` (or equivalent) callback accepts `undefined` as a "no problem" sentinel — giving an integrator's no-op logger silent auth-bypass powers.
+
+## Docs expectations
+
+- README's "Quick Start" is local-dev guidance — `.env` or shell `export`. Production guidance should point to Fabric (see `harper/v5.md`), not generic deployment patterns.
+- `docs/` covers integration patterns. Doc-only PRs still need to be consistent with the `harper/v5.md` deployment model.
+- `CLAUDE.md` captures non-obvious local gotchas. Any new wrinkle discovered during review (especially one that bit an earlier PR) should be proposed for `CLAUDE.md` in the same or follow-up PR.

--- a/.github/review-scopes/universal.md
+++ b/.github/review-scopes/universal.md
@@ -1,0 +1,55 @@
+# Universal review scope
+
+Applies to every PR regardless of the repo. Read this first and apply everything below to the diff you're reviewing.
+
+## Architecture
+
+- **API contracts.** Does this change alter a public API (signature, return shape, error type, side effects)? Is the alteration intentional? Is it documented?
+- **Dispatch surfaces.** If the PR introduces or modifies a wrapper, decorator, middleware, or Proxy over a third-party API, verify it intercepts **all** call surfaces the wrapped API exposes. For class-based APIs this typically means:
+  - Instance methods
+  - Static methods (frameworks may dispatch directly to statics, bypassing instances)
+  - Lifecycle hooks or registration-time callbacks
+  - Protocol-specific handlers (HTTP verbs, subscription, etc.)
+
+  A wrapper that covers only one dispatch surface is a silent bypass waiting to happen. Trace through `node_modules/<framework>/` if the dispatch shape isn't obvious from the wrapper's code alone — don't assume the documented behavior is the *only* behavior.
+- **Public/private boundaries.** Are new exports from `src/index.ts` (or equivalent) intentional? Do they need JSDoc? Do internals stay scoped?
+- **Breaking changes.** Is this one? Is the version bumped? Is a migration path documented? For repos with maintenance branches (e.g. `v1.x`), does the fix need a backport?
+- **Observable behavior changes.** If behavior changes on a code path integrators depend on, the change needs to be documented in JSDoc, a CHANGELOG, or a PR body readable by release-notes tooling.
+
+## Security
+
+- **Authentication bypass.** Can the change cause auth to be silently skipped? Look especially for:
+  - "No context / no session → pass through" paths — are they fail-closed when auth is required?
+  - Wrappers that sit between a framework's dispatcher and a user's method — do they cover every path the framework uses to reach the method?
+  - Callbacks that return `undefined` where the code expects a response object — is `undefined` a "no problem" sentinel anywhere? If so, does the surrounding code fall back to a deny?
+- **Input validation.** All untrusted input (URL params, headers, bodies, query strings) validated?
+- **Secret handling.** Tokens, credentials, session IDs, or PII — never logged, never returned in responses, never stored in error messages.
+- **Error handling.** Do error paths avoid leaking internals (stack traces to clients, SQL/query fragments, file paths)?
+- **Dependency trust.** New runtime dependencies: justified in the PR description? Trusted publisher? Any post-install scripts?
+- **Cross-site hygiene.** CSRF state where relevant? Redirect URI validation? Open-redirect paths closed?
+
+## Testing
+
+- **New public APIs have tests.** For each new exported symbol: at least one test exercising the happy path and one for the primary failure path.
+- **Tests exercise real code paths, not only mocks.** If the code has a "production path" and a "test/fallback path" (e.g. `if (typeof session.delete === 'function') { ... } else { ... }`), both need coverage. A test that only lands in the fallback gives false confidence.
+- **Failure-path coverage matches the severity.** Security-relevant branches (deny paths, 401 returns, auth-required enforcement) need explicit tests, not implicit "it probably works."
+- **String identifiers and verb lists.** If the code iterates over a list of method names (`'get'`, `'post'`, etc.) and a typo in one name would silently disable a feature, each name needs direct coverage.
+
+## Documentation
+
+- **JSDoc examples match the current API.** If the signature changed, the example changed too.
+- **Code that references a doc path** (`CLAUDE.md`, migration guides, skills) — verify the referenced section still exists.
+- **Gotchas section updates.** If this PR introduces a new foot-gun, it belongs in the repo's `CLAUDE.md` or equivalent.
+
+## What to ignore
+
+- `package-lock.json`, `bun.lock`, `yarn.lock` — lockfile regens are deterministic from `package.json`.
+- `package.json` edits that ONLY bump patch/minor versions of existing deps. `engines`, `peerDependencies`, and new `dependencies` entries DO need review.
+- `dist/` compiled output.
+
+## Output discipline
+
+- Blocker-severity findings only. No nits, no style, no "consider adding a comment."
+- Structured format: `### <N>. <title>` + `**File:** path:line` + `**What:** …` + `**Why it matters:** …` + `**Suggested fix:** …`.
+- If zero blockers: one short comment, "No blockers found.", then stop.
+- Never `REQUEST_CHANGES` or `APPROVE` during calibration — comments only.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,11 +17,25 @@ jobs:
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
       github.event.pull_request.author_association)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Bumped from 10 to 15. We've observed the Claude review step stall on a
+    # single long-running API call inside the 10-min window on substantial
+    # diffs, producing a "cancelled" status with partial output. 15 gives
+    # headroom without letting a runaway loop burn forever (max-turns=24 is
+    # the real cost ceiling).
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write
       id-token: write # required by claude-code-action even with API-key auth
+    env:
+      # Layered review scope — see HarperFast/ai-review-log/review-scopes/README.md.
+      # Order matters: most-general first, most-specific last. Composed into a
+      # single prompt block by the "Compose review scope from layers" step.
+      REVIEW_LAYERS: |
+        universal
+        harper/common
+        harper/v5
+        repo-type/plugin
 
     steps:
       - name: Checkout
@@ -39,6 +53,52 @@ jobs:
           ref: d2db99bb37a6dde868cbc5ac81ca4146be8956fb # 1.3.0 (2026-04-16)
           path: .harper-skills
 
+      - name: Clone review scopes
+        # Pinned to the merge SHA of HarperFast/ai-review-log#19 so updates to
+        # the layered review prompts are intentional, not silent.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          repository: HarperFast/ai-review-log
+          ref: ef8d99458c27094a6fac97f373ebddee2abc5376
+          path: .ai-review
+          token: ${{ secrets.AI_REVIEW_LOG_TOKEN }}
+
+      - name: Compose review scope from layers
+        id: scope
+        env:
+          LAYERS: ${{ env.REVIEW_LAYERS }}
+        run: |
+          set -euo pipefail
+          OUT=/tmp/composed-scope.md
+          : > "$OUT"
+          while IFS= read -r raw_layer; do
+            # Trim whitespace around each layer name
+            layer="$(printf '%s' "$raw_layer" | awk '{$1=$1;print}')"
+            [ -z "$layer" ] && continue
+            file=".ai-review/review-scopes/${layer}.md"
+            if [ ! -f "$file" ]; then
+              echo "::warning::Review layer '$layer' not found at $file; skipping."
+              continue
+            fi
+            {
+              cat "$file"
+              printf '\n\n'
+            } >> "$OUT"
+          done <<< "$LAYERS"
+
+          BYTES=$(wc -c < "$OUT")
+          echo "Composed ${BYTES} bytes from review layers"
+          if [ "$BYTES" -eq 0 ]; then
+            echo "::error::Composed review scope is empty — all layers missing or unreadable."
+            exit 1
+          fi
+
+          {
+            echo 'composed<<CLAUDE_SCOPE_EOF'
+            cat "$OUT"
+            echo 'CLAUDE_SCOPE_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Claude review
         id: claude-review
         uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
@@ -55,18 +115,9 @@ jobs:
 
             The PR branch is already checked out in the current working directory.
 
-            ## What to ignore in the diff
-
-            Skip mechanical, non-reviewable diffs — they waste turns
-            and add no signal:
-
-            - `package-lock.json`, `bun.lock`, `yarn.lock` — lockfile
-              regens are deterministic from `package.json`
-            - `package.json` changes that are ONLY version bumps of
-              existing deps (patch/minor). If `engines`, `peerDependencies`,
-              or new `dependencies` entries change, DO review those.
-            - `dist/` compiled output (shouldn't be in PRs, but if it
-              is, ignore it — source is the source of truth)
+            Read `CLAUDE.md` in the repo root first — it has the project
+            overview, conventions, and repo-specific gotchas. Then apply
+            the layered review scope below.
 
             ## Tools
 
@@ -89,86 +140,46 @@ jobs:
             intermediate drafts to disk wastes turns on permission
             denials.
 
-            Read `CLAUDE.md` in the repo root first — it has the project
-            overview, conventions, and (importantly) a "Non-Obvious Gotchas"
-            section covering Resource API v2 patterns, GenericTrackedObject
-            spread behavior, `tsc || true` build semantics, and security
-            invariants.
+            Shared Harper best-practices are mirrored on disk at
+            `.harper-skills/harper-best-practices/rules/*.md` if a layer
+            references them and you want to drill into the customer-facing
+            source.
 
-            Shared Harper conventions (applicable to any PR touching
-            deployment, docs, or best practices) are available at
-            `.harper-skills/harper-best-practices/rules/*.md`. Notably:
+            ## Layered review scope
 
-            - `.harper-skills/harper-best-practices/rules/deploying-to-harper-fabric.md`
-              is the authoritative source for Harper's deployment model
-              (Fabric). Any doc recommendation that contradicts it — e.g.
-              suggesting systemd, raw Kubernetes, or generic cloud-secrets
-              patterns — is wrong for Harper and should be flagged.
-            - Other rule files in that directory cover schema, auth
-              patterns, and custom resources. Consult them when a PR's
-              recommendations touch those areas.
+            The sections below are composed from
+            HarperFast/ai-review-log/review-scopes (universal + Harper +
+            repo-type). They are the authoritative review checklist —
+            the OAuth-specific bullets further down stack ON TOP of them,
+            they do not replace them.
 
-            ## OAuth-specific things to check
+            ${{ steps.scope.outputs.composed }}
 
-            - CSRF state tokens present on every OAuth flow; 10-minute expiry
-              is enforced; state is single-use
-            - Tokens are never logged and never returned in HTTP responses
+            ## Repo-specific checks (OAuth plugin)
+
+            On top of the layered scope above, these are OAuth-only
+            semantics not covered by the shared layers:
+
+            - CSRF state tokens present on every OAuth flow; 10-minute
+              expiry is enforced; state is single-use
             - Redirect URI validation on callback endpoints
-            - Provider-of-record enforcement (cross-provider CSRF protection
-              should redirect with error, not 403)
-            - Session field preservation across token refresh (`provider`,
-              `providerConfigId`, `providerType`)
-            - Resource API v2 conventions (`static loadAsInstance = false`,
-              instance methods)
-            - `GenericTrackedObject` spread gotcha — if code uses `{...obj}`
-              on a session field, flag it
-            - New endpoints include auth checks and context validation
-            - Path length validation (≤ 2048 chars) where user input can
-              reach a path
-
-            ## Review scope and style
-
-            Report **blocker-severity findings only**. Blockers are:
-            - Correctness bugs
-            - Security issues (token exposure, missing CSRF, auth bypass,
-              unvalidated redirect/path, injection)
-            - Broken contracts (public API behavior change without migration)
-            - Missing tests for new behavior or fixed bugs
-            - Documentation drift that would mislead integrators
-
-            Do NOT comment on style, naming, nits, or personal preference.
-            Do NOT restate what the diff does. Do NOT praise.
-
-            Cap the review at 10 findings.
+            - Provider-of-record enforcement (cross-provider CSRF
+              protection should redirect with error, not 403)
+            - Session field preservation across token refresh
+              (`provider`, `providerConfigId`, `providerType`)
+            - Path length validation (≤ 2048 chars) where user input
+              can reach a path
 
             ## How to post the review
 
-            - Use `gh pr comment` for top-level feedback (single consolidated
-              summary comment with all findings).
+            - Use `gh pr comment` for the single consolidated top-level
+              summary comment.
             - Use `mcp__github_inline_comment__create_inline_comment`
               (with `confirmed: true`) for specific code-line annotations.
             - Only post GitHub comments — do NOT submit review text as SDK
               messages.
-            - Do NOT use REQUEST_CHANGES or APPROVE during this calibration
-              phase. Stick to comments so the workflow never blocks or
-              auto-approves a merge.
 
-            ## Output format for the top-level comment
-
-            If you find zero blockers: post one short comment —
-            "No blockers found." — and stop.
-
-            If you find blockers: post one summary comment with all findings
-            using this structure, one block per finding:
-
-              ### <N>. <concise title>
-
-              **File:** `path/to/file.ts:line`
-              **What:** one or two sentence description
-              **Why it matters:** concrete impact
-              **Suggested fix:** specific change, not generic advice
-
-            No preamble. No closing summary.
+            Cap the review at 10 findings.
 
       - name: Log review to ai-review-log
         # Best-effort — never fail the job if logging fails

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -28,8 +28,9 @@ jobs:
       pull-requests: write
       id-token: write # required by claude-code-action even with API-key auth
     env:
-      # Layered review scope — see HarperFast/ai-review-log/review-scopes/README.md.
-      # Order matters: most-general first, most-specific last. Composed into a
+      # Layered review scope — see .github/review-scopes/README.md for what
+      # each layer covers and the provenance of the vendored files. Order
+      # matters: most-general first, most-specific last. Composed into a
       # single prompt block by the "Compose review scope from layers" step.
       REVIEW_LAYERS: |
         universal

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -53,17 +53,10 @@ jobs:
           ref: d2db99bb37a6dde868cbc5ac81ca4146be8956fb # 1.3.0 (2026-04-16)
           path: .harper-skills
 
-      - name: Clone review scopes
-        # Pinned to the merge SHA of HarperFast/ai-review-log#19 so updates to
-        # the layered review prompts are intentional, not silent.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          repository: HarperFast/ai-review-log
-          ref: ef8d99458c27094a6fac97f373ebddee2abc5376
-          path: .ai-review
-          token: ${{ secrets.AI_REVIEW_LOG_TOKEN }}
-
       - name: Compose review scope from layers
+        # Layer files live in .github/review-scopes/ in this repo — see its
+        # README for provenance and the plan around eventually sharing them
+        # across HarperFast repos.
         id: scope
         env:
           LAYERS: ${{ env.REVIEW_LAYERS }}
@@ -75,7 +68,7 @@ jobs:
             # Trim whitespace around each layer name
             layer="$(printf '%s' "$raw_layer" | awk '{$1=$1;print}')"
             [ -z "$layer" ] && continue
-            file=".ai-review/review-scopes/${layer}.md"
+            file=".github/review-scopes/${layer}.md"
             if [ ! -f "$file" ]; then
               echo "::warning::Review layer '$layer' not found at $file; skipping."
               continue

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+dist/
+node_modules/
+
+# Vendored from HarperFast/ai-review-log — keep byte-identical to upstream
+# so future syncs are trivial. See .github/review-scopes/README.md.
+.github/review-scopes/


### PR DESCRIPTION
## Summary

- Compose `universal + harper/common + harper/v5 + repo-type/plugin` layers into the review prompt, replacing the inline monolithic "what to ignore / review scope / output format" sections
- OAuth-specific bullets (CSRF state, provider-of-record, redirect/path validation, session-field preservation across refresh) stack on top of the shared layers rather than replacing them
- Vendor the layer files into `.github/review-scopes/` (copied from `HarperFast/ai-review-log/review-scopes/` at merge SHA `ef8d994`). Kept per-repo for now while we evaluate the layered-scope approach across 2–3 repos; see `.github/review-scopes/README.md` for provenance and the sharing plan
- Bump `timeout-minutes` 10 → 15 on the review job. A recent run on #48 cancelled at 10m18s after Claude stalled for 9+ minutes inside a single API call (confirmed from job logs — last tool_result at 30s, then silence). `max-turns: 24` is the real cost ceiling; the timeout is a safety backstop.

## Test plan

- [x] YAML parses (`js-yaml` load of the file)
- [x] Compose step produces 15,978 bytes concatenating all 4 local layer files
- [x] Heredoc step-output format is valid (composed content bracketed by `CLAUDE_SCOPE_EOF` delimiters)
- [x] Prettier ignores vendored `.github/review-scopes/` so upstream syncs stay byte-identical
- [ ] Dogfood: this PR's own review run exercises compose + prompt injection on a trivial diff
- [ ] Merge, then push a new commit to #48 so its review uses the new workflow against a substantial diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)