### PR TITLE
ci(review): allow verification summary on zero-blocker path

### DIFF
--- a/.github/review-scopes/universal.md
+++ b/.github/review-scopes/universal.md
@@ -75,5 +75,5 @@ If a finding doesn't have concrete impact on correctness, security, contract, or
 **How to post:**
 
 - Structured format: `### <N>. <title>` + `**File:** path:line` + `**What:** …` + `**Why it matters:** …` + `**Suggested fix:** …`.
-- If zero blockers: one short comment — "No blockers found." — then stop.
+- If zero blockers: lead with "No blockers found." A short "here's what I traced" summary is welcome during calibration — it lets maintainers spot-check whether the bot reasoned through the right surfaces vs. hand-waved a pass. Keep it tight: one line per surface verified, not a full re-derivation.
 - Never `REQUEST_CHANGES` or `APPROVE` during calibration — comments only.


### PR DESCRIPTION
## Summary

Loosens the "If zero blockers: one short comment, then stop" rule to permit a short per-surface summary on the zero-blocker path.

## Why

The bot's review on #48 (post-merge of the 3-arg test) correctly returned "No blockers found." and then wrote a short "here's what I traced" summary — dispatch surface coverage, fail-closed paths, WeakSet dedup, 405 semantics. That's exactly the spot-check information the maintainer wants during calibration to verify the bot actually traced the surfaces vs. hand-waving a pass.

The old rule (strict: short comment then stop) would have flagged that output as off-spec. This PR updates the rule to match what we actually want.

## Constraints preserved

- One line per surface verified, not a full re-derivation (keeps the output scannable)
- Still leads with "No blockers found." so the verdict is unambiguous
- No APPROVE / REQUEST_CHANGES — calibration discipline unchanged

Once we trust the bot's coverage enough that the "did it actually check X" question stops coming up, we can drop the summaries and go strict. For now, the signal is worth the extra lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)