### PR TITLE
ci: unblock AI-authored PRs (review gate + mention context)

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -83,10 +83,36 @@ jobs:
             --model claude-sonnet-4-6
             --max-turns 48
             --allowedTools "Read,Write,Edit,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr checkout:*),Bash(gh pr create:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(git:*),Bash(npm install:*),Bash(npm ci:*),Bash(npm run:*),Bash(npm test:*),Bash(bun install:*),Bash(bun run:*),Bash(bun test:*),Bash(npx:*)"
-          # In agent mode the action uses the triggering comment as the
-          # prompt. The text below layers supplemental context on top.
+          # In agent mode the action can use the triggering comment as the
+          # prompt, but we inline it explicitly below to guarantee the agent
+          # always has PR/issue number, URL, and the commenter's exact
+          # request — without these, the agent has been observed to respond
+          # "I don't see a specific task in this mention, could you share
+          # the PR number?" which defeats the whole point of the workflow.
           prompt: |
             You were invoked via an `@claude` mention on ${{ github.repository }}.
+
+            ## Mention context
+
+            - Repo: ${{ github.repository }}
+            - Target number: #${{ github.event.issue.number || github.event.pull_request.number }}
+            - Target URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
+            - Target kind: ${{ github.event.issue.pull_request && 'pull request' || (github.event.pull_request && 'pull request' || 'issue') }}
+            - Commenter: @${{ github.event.comment.user.login }}
+
+            The commenter wrote:
+
+            > ${{ github.event.comment.body }}
+
+            Start by reading the target so you have real context:
+            - For a PR: `gh pr view <N>` then `gh pr diff <N>` if you need
+              the changes.
+            - For an issue: `gh issue view <N>`.
+
+            Then act on the request. If the request is "review this PR",
+            post the review as a single `gh pr comment` following the
+            review discipline in `.github/review-scopes/universal.md` (in
+            this repo) — do NOT treat review as a code-edit task.
 
             ## Conventions
 

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -89,6 +89,10 @@ jobs:
           # request — without these, the agent has been observed to respond
           # "I don't see a specific task in this mention, could you share
           # the PR number?" which defeats the whole point of the workflow.
+          #
+          # TODO: revisit if a future claude-code-action release reliably
+          # forwards the triggering comment as the prompt. This inline
+          # injection can then collapse back to supplemental context.
           prompt: |
             You were invoked via an `@claude` mention on ${{ github.repository }}.
 
@@ -100,9 +104,11 @@ jobs:
             - Target kind: ${{ github.event.issue.pull_request && 'pull request' || (github.event.pull_request && 'pull request' || 'issue') }}
             - Commenter: @${{ github.event.comment.user.login }}
 
-            The commenter wrote:
+            The commenter wrote (verbatim, including any multi-line content):
 
-            > ${{ github.event.comment.body }}
+            ```
+            ${{ github.event.comment.body }}
+            ```
 
             Start by reading the target so you have real context:
             - For a PR: `gh pr view <N>` then `gh pr diff <N>` if you need

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,12 +10,15 @@ concurrency:
 
 jobs:
   review:
-    # Only review PRs authored by HarperFast org members / collaborators.
-    # External PRs are not auto-reviewed — a maintainer can opt one in later
-    # via an @claude mention (handled by a separate workflow).
+    # Review PRs authored by HarperFast org members / collaborators AND
+    # PRs opened by our own issue-to-PR bot (claude[bot]) — AI-authored PRs
+    # need review MOST, not least. External human PRs are not auto-reviewed;
+    # a maintainer can opt one in via an `@claude` mention (handled by a
+    # separate workflow).
     if: >-
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
       github.event.pull_request.author_association)
+      || github.event.pull_request.user.login == 'claude[bot]'
     runs-on: ubuntu-latest
     # Bumped from 10 to 15. We've observed the Claude review step stall on a
     # single long-running API call inside the 10-min window on substantial


### PR DESCRIPTION
## Summary

Fixes two gaps that let AI-authored PRs go unreviewed.

### 1. `claude-review.yml` — extend author gate to include `claude[bot]`

The gate used to be `author_association in {OWNER, MEMBER, COLLABORATOR}`. PRs authored by `claude[bot]` (our `claude-issue-to-pr` pipeline) hit `author_association: NONE` and the review job was SKIPPED. That's how PR #55 landed with no review — the case where review matters most.

Gate is now:

```yaml
if: >-
  contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
  github.event.pull_request.author_association)
  || github.event.pull_request.user.login == 'claude[bot]'
```

### 2. `claude-mention.yml` — inject PR/issue context into the prompt

When Nathan tried `@claude review this PR` on #55, the mention workflow fired but the agent replied:

> I don't see a specific task in this mention. Could you share the PR number or issue that triggered this `@claude` mention, or describe what you'd like me to do?

The pinned action version isn't reliably surfacing the triggering comment as the prompt. Fix: inline `github.event.issue.number || github.event.pull_request.number`, URL, target kind, commenter login, and the full comment body directly into the prompt string. Also adds an explicit branch for "if the request is 'review this PR'" that points the agent at `.github/review-scopes/universal.md` for discipline.

## Gate safety (for the review-side change)

- `github.event.pull_request.user.login` is set by GitHub from the actual PR author — not user-controlled
- `[bot]` suffix is reserved for GitHub Apps; human accounts can't have it
- App slugs are globally unique on GitHub — `claude[bot]` is specifically Anthropic's Claude app, which has to be installed in HarperFast to open PRs here
- Fork-triggered runs have no access to `secrets.*`, so any hypothetical bypass has read-only blast radius (worst case: a spam comment on a PR, not code execution or secret exfiltration)

## Test plan

- [ ] Merge, then push a no-op to #55's branch (or close/reopen) — the review job should run against it now
- [ ] `@claude review this PR` on any open PR — agent should read the PR and post a review, not ask "what PR?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)