### PR TITLE
ci(review): allowlist claude bot actor at the action level

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -101,6 +101,14 @@ jobs:
         uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Allow our issue-to-PR bot's PRs to be reviewed. The job-level
+          # `if:` gate above lets the workflow start, but claude-code-action
+          # has its own bot-actor check that refuses with "Workflow initiated
+          # by non-human actor" unless the bot is on this allowlist. We
+          # specifically allow `claude` (slug match — no `[bot]` suffix here)
+          # rather than `*`, so any OTHER bot that somehow triggers this
+          # workflow is still refused.
+          allowed_bots: claude
           show_full_output: true # TEMP: keep on during calibration so tool denials are visible; revert once reviews run cleanly
           claude_args: |
             --model claude-sonnet-4-6


### PR DESCRIPTION
## Summary

Follow-up to #57. Adds `allowed_bots: claude` to the `Claude review` action inputs.

## Why

My job-level `if:` gate in #57 correctly admits `claude[bot]`-authored PRs to the workflow. But `claude-code-action` has its **own** bot-actor gate, separate from the workflow's, and rejects any run triggered by a Bot unless the bot is on this allowlist:

```
Action failed with error: Workflow initiated by non-human actor:
claude (type: Bot). Add bot to allowed_bots list or use '*' to allow
all bots.
```

That's what made the review run on #55 fail with exit 1 after all the setup work (checkout, skills clone, layer compose, prompt assembly). The action reached the gate and bailed before even calling the API.

## Scope of the allowlist

`allowed_bots: claude` — slug match, no `[bot]` suffix at this input layer. Specifically Anthropic's Claude GitHub App. Not `*`: if any *other* bot ever triggers this workflow (imagine a future "issue-to-PR v2" from a different app), we'd want to gate it deliberately rather than auto-admit.

## Test plan

- [ ] Merge
- [ ] Nudge #55's branch again — review run should complete successfully this time and post a review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)