### PR TITLE
ci: documentation-boundary rule; capture .env-deploys-to-fabric

### DIFF
--- a/.github/review-scopes/harper/common.md
+++ b/.github/review-scopes/harper/common.md
@@ -21,3 +21,17 @@ Version-agnostic review guidance for repos in the Harper ecosystem. The repo's o
 - **`scope.resources` / `scope.server` usage.** Declared optional in the Harper type but always assigned in the Scope constructor. Code should either guard once at entry or use narrowed locals, not sprinkle `?.` / `!` throughout.
 - **`static loadAsInstance = false` (Resource API v2).** Harper instantiates the class per request; do NOT rely on shared mutable instance state across requests. If per-request state is stored, it belongs on the context (`this.getContext()`).
 - **Unused runtime dependencies.** Harper repos target minimal runtime deps. New ones require explicit justification in the PR description (some repos maintain a `dependencies.md` for this).
+
+## Documentation boundary (defer to Harper docs)
+
+Harper maintains its own documentation at [docs.harperdb.io](https://docs.harperdb.io) covering core, pro, and fabric. App, sample, and plugin repos should:
+
+- Document what is specific to the app/plugin itself — env var names, config shape, setup flow, integration API.
+- **Link** to the Harper documentation for anything not app/component-specific: deployment mechanics, runtime env var handling, Fabric configuration, core database behavior, SQL translator, replication, etc.
+
+Flag PRs that re-explain Harper behavior in-repo when a link to the authoritative Harper docs would be more maintainable. Re-explanation creates drift — Harper updates its docs, the copy doesn't.
+
+Borderline calls (judgment, not a blocker):
+
+- Short factual reminders where a link alone is too thin (e.g. "Harper reads env vars directly from the process environment — see [...]") are fine.
+- Duplicating whole Harper docs sections inline is not — link.

--- a/.github/review-scopes/harper/v5.md
+++ b/.github/review-scopes/harper/v5.md
@@ -52,8 +52,9 @@ v5 has two co-existing dispatch patterns. A review of any Resource — or anythi
 
 - **Harper runtime** reads `process.env.*`. It does not itself parse a `.env` file on startup.
 - **Harper app template** (`npm create harper`) scaffolds `dotenv-cli` in `package.json` scripts. `npm run dev` / `npm run deploy` invokes `dotenv -- npm run <script>`, loading `.env` before Harper or the deploy CLI starts. `.env` IS the standard local-dev and deploy-credentials pattern for Harper v5 apps.
-- **Fabric deployment** takes cluster credentials via `CLI_TARGET*` env vars during deploy. Runtime configuration is injected by the platform.
-- When reviewing docs about env-var handling, recommendations should match Harper's actual toolchain — `.env` via `dotenv-cli` for local/CI/deploy credentials, Fabric for production runtime — NOT generic systemd, Kubernetes secrets, or cloud-provider secrets manager patterns unless the PR author has specifically asked about non-Fabric deployment.
+- **`.env` at app root deploys with the component.** Harper Fabric ships the repo's `.env` alongside the deployed application, so the same file that provides secrets locally is available in the Fabric runtime too. This is why app-specific docs don't need to explain a separate Fabric-runtime mechanism — the local-dev `.env` IS the production `.env`. (Repo docs should still link to the Harper docs for the deployment mechanics, per the "defer to Harper docs" rule in `common.md`.)
+- **Deploy credentials vs runtime secrets.** `CLI_TARGET*` vars authenticate `harperdb deploy_component` against the cluster — they're loaded in the SHELL that runs the deploy CLI, NOT deployed with the app. Runtime app secrets (`OAUTH_GITHUB_CLIENT_ID`, etc.) come from the deployed `.env`. Don't conflate the two in docs — a GitHub Actions `env:` block used for deploy credentials does NOT propagate to runtime.
+- When reviewing docs about env-var handling, recommendations should match Harper's actual toolchain — `.env` via `dotenv-cli` for local/CI/deploy credentials, deployed `.env` for Fabric runtime — NOT generic systemd, Kubernetes secrets, or cloud-provider secrets manager patterns unless the PR author has specifically asked about non-Fabric deployment.
 
 ## Deployment: Fabric
 

--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -130,6 +130,25 @@ jobs:
             comment on the issue asking for clarification rather than
             guessing.
 
+            ## Documentation scope boundary
+
+            Harper maintains authoritative documentation at
+            https://docs.harperdb.io covering core, pro, and fabric. This
+            repo's docs should NOT re-explain Harper mechanics that the
+            Harper docs already cover — they drift out of sync when the
+            Harper docs update.
+
+            When writing or revising docs here:
+
+            - Document what's specific to THIS component — env var names,
+              config shape, setup flow, integration API.
+            - For anything not component-specific (deployment mechanics,
+              runtime env var handling, Fabric configuration, core Harper
+              behavior, SQL, replication), LINK to the Harper docs rather
+              than re-explaining.
+
+            This is a general rule, not specific to any one area.
+
             ## Process
 
             1. Create a branch named `claude/fix-${{ github.event.issue.number }}`

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -137,6 +137,25 @@ jobs:
             Kubernetes, cloud secrets managers) without first checking
             whether a Harper-specific path applies.
 
+            ## Documentation scope boundary
+
+            Harper maintains authoritative documentation at
+            https://docs.harperdb.io covering core, pro, and fabric. This
+            repo's docs should NOT re-explain Harper mechanics that the
+            Harper docs already cover — they drift out of sync when the
+            Harper docs update.
+
+            When writing or revising docs here:
+
+            - Document what's specific to THIS component — env var names,
+              config shape, setup flow, integration API.
+            - For anything not component-specific (deployment mechanics,
+              runtime env var handling, Fabric configuration, core Harper
+              behavior, SQL, replication), LINK to the Harper docs rather
+              than re-explaining.
+
+            This is a general rule, not specific to any one area.
+
             ## Before committing
 
             Scale validation to the kind of change you made:


### PR DESCRIPTION
## Summary

Two related tunings driven by the #55 review rounds (the env-vars docs PR that went through multiple iterations of "re-explain Harper mechanics vs point at Harper docs").

### 1. Documentation-boundary rule

Harper maintains authoritative docs at docs.harperdb.io covering core, pro, and fabric. App/plugin/sample repos should:

- Document what's specific to the component (env var names, config shape, setup flow, integration API)
- **Link** to Harper docs for anything not component-specific (deployment mechanics, runtime env vars, Fabric config, core behavior, SQL, replication)

Re-explaining Harper mechanics in repo docs creates drift — Harper updates its docs, the repo's copy doesn't.

Applied in parallel:
- `.github/review-scopes/harper/common.md` — reviewer-facing: flag PRs that re-explain instead of link
- `.github/workflows/claude-mention.yml` + `.github/workflows/claude-issue-to-pr.yml` — author-facing: same principle for agents writing or revising docs

### 2. Capture `.env`-deploys-to-fabric fact

The last review round on #55 correctly flagged that a GitHub Actions `env:` block doesn't propagate to Fabric runtime, but left the path forward ambiguous because the actual mechanism (`.env` at app root is deployed alongside the component) wasn't in any layer. Adding it to `harper/v5.md` under Environment variables, plus a clarifying bullet on deploy credentials vs runtime secrets so future reviews don't re-derive the distinction.

## Test plan

- [x] YAML parses for both workflow files
- [ ] Dogfood: this PR's own review run applies the new `common.md` rule and picks up the `.env`-deploys-to-fabric context
- [ ] Follow-up: the documentation-boundary *principle* is worth proposing as a `HarperFast/skills` rule for customer-facing authoring guidance — I'll draft a separate PR for that after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)