### PR TITLE
ci(mention): switch to Opus 4.7

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -80,7 +80,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true
           claude_args: |
-            --model claude-sonnet-4-6
+            --model claude-opus-4-7
             --max-turns 48
             --allowedTools "Read,Write,Edit,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr checkout:*),Bash(gh pr create:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(git:*),Bash(npm install:*),Bash(npm ci:*),Bash(npm run:*),Bash(npm test:*),Bash(bun install:*),Bash(bun run:*),Bash(bun test:*),Bash(npx:*)"
           # In agent mode the action can use the triggering comment as the


### PR DESCRIPTION
## Summary

Flip `claude-mention.yml` to Opus 4.7 for reasoning-heavy mention work (review-this-PR, address-this-feedback, implement-this-feature).

Leaves the other two workflows on Sonnet 4.6:

- `claude-review.yml` — pattern-matching against the layered checklist; Sonnet is well-calibrated there.
- `claude-issue-to-pr.yml` — bounded `claude-fix:*` maintenance (typo/docs/deps/bug); Opus would be overkill.

## Test plan

- [ ] Merge
- [ ] Try `@claude please implement ...` on the feature issue with Opus in play

🤖 Generated with [Claude Code](https://claude.com/claude-code)