### PR TITLE
ci(claude): fetch-depth cleanup + review-side git ops

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -39,9 +39,11 @@ jobs:
 
     steps:
       - name: Checkout
+        # Default shallow fetch (depth 1). The agent can commit and push on
+        # a shallow clone; `git log` / `git blame` aren't reached for by
+        # the current prompt. Bump to a deeper fetch only if we see the
+        # agent blocked on history lookups.
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 0
 
       - name: Clone shared Harper skills
         # Pinned to a SHA (not `main`) so agent behavior is reproducible

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -45,9 +45,11 @@ jobs:
 
     steps:
       - name: Checkout
+        # Default shallow fetch (depth 1). The agent can commit and push on
+        # a shallow clone; `git log` / `git blame` aren't reached for by
+        # the current prompt. Bump to a deeper fetch only if we see the
+        # agent blocked on history lookups.
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 0
 
       - name: Clone shared Harper skills
         # Pinned to a SHA (not `main`) so agent behavior is reproducible

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -43,6 +43,13 @@ jobs:
 
     steps:
       - name: Checkout
+        # Full history so the review agent can use `git blame` / `git log`
+        # / `git diff <base>...HEAD` for context — who wrote a line, how
+        # old it is, whether this PR's author has touched it before. Those
+        # signals materially improve review quality on non-trivial diffs.
+        # Paired with a tightly-scoped `Bash(git <subcommand>:*)` allowlist
+        # below (no `Bash(git:*)` — that would allow `git push --force`,
+        # `git reset --hard`, etc.).
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
@@ -119,7 +126,11 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 24
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+            # Read-only allowlist. Git subcommands are scoped individually —
+            # deliberately NOT `Bash(git:*)`, which would permit `git push
+            # --force`, `git reset --hard`, etc. The subcommands listed here
+            # are all strictly read-only.
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*),Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git blame:*),Bash(git show:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -149,10 +160,26 @@ jobs:
             that executes PR code — the PR's tests are already checked
             separately.
 
-            The only allowed Bash commands are:
-            - `gh pr view` / `gh pr diff` — inspect the PR (already run
-              at start, you can re-invoke if needed)
-            - `gh pr comment` — post the final review comment
+            The allowed Bash commands are:
+            - `git diff <base>...HEAD` — the PR diff, local (no API
+              round-trip). `<base>` is typically `origin/main`.
+            - `git log`, `git show` — history context. Use these to
+              understand WHY a line is the way it is before flagging
+              it. "This load-bearing check was added 3 years ago in
+              commit abc123 with a fix for bug X" is often the
+              difference between a blocker finding and a non-finding.
+            - `git blame <file>` (or with `-L start,end`) — who wrote
+              which lines, when. Especially useful for judging whether
+              a changed line is new code from this PR (fair review
+              target) or pre-existing code the PR merely touched
+              (per the layered scope, pre-existing gaps are NOT
+              blockers).
+            - `gh pr view` — PR metadata (title, body, author,
+              labels). Already run at start; re-invoke if needed.
+            - `gh pr comment` — post the top-level summary comment.
+
+            Git subcommands are scoped individually on purpose — no
+            write operations are permitted.
 
             Do NOT write files during the review — not to `.claude-pr/`,
             not to `/tmp/`, not anywhere. The `Write` and `Edit` tools


### PR DESCRIPTION
## Summary

Mirrors [HarperFast/harper#402's](https://github.com/HarperFast/harper/pull/402) fetch-depth + git-ops changes. Chris's `fetch-depth: 0` feedback there was the starting point; taking the opportunity to upgrade the review-side tool scope at the same time.

### Mention / issue-to-PR

Drop `fetch-depth: 0`. Default shallow is fine. Agents commit and push — neither needs deep history. Current prompts don't direct the agent toward `git log` / `git blame`.

### Review

Keep `fetch-depth: 0`. Make the depth actually useful.

- `--allowedTools` gains: `Bash(git diff:*)`, `Bash(git log:*)`, `Bash(git blame:*)`, `Bash(git show:*)`
- Individually scoped — deliberately NOT `Bash(git:*)` (which would permit destructive write ops)
- Drops `Bash(gh pr diff:*)` since `git diff <base>...HEAD` replaces it with no API round-trip
- Keeps `gh pr view`, `gh pr comment`, and the MCP inline-comment tool — they all do different things (metadata, top-level summary, per-line anchored findings; and yes, the inline tool is in active use — 16+ inline comments from the bot on #48 alone)

Review prompt now directs the agent to use `git blame` for the "is this code the PR introduced vs pre-existing" judgment (which the layered scope's Testing section already cares about), and `git log` / `git show` for "why is this load-bearing" context before flagging something as a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)