### PR TITLE
meta: fix CODEOWNERS team handle (development → developers)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # Importantly, **the last matching pattern takes precedence**
 
 # By default, everything must be reviewed by someone in the core engineering team
-*          @HarperFast/development
+*          @HarperFast/developers
 
 # Otherwise, certain paths may require other reviewers as well
-/.github/  @HarperFast/development @HarperFast/devops
+/.github/  @HarperFast/developers @HarperFast/devops


### PR DESCRIPTION
## Summary

Fix a team-handle mismatch in `.github/CODEOWNERS`. `@HarperFast/development` doesn't resolve to a real team on GitHub — the actual team (used by `HarperFast/harper`'s CODEOWNERS) is `@HarperFast/developers`.

## Why it matters

When a CODEOWNERS line references a non-existent team, GitHub silently can't resolve an owner for that pattern. If "Require review from Code Owners" is ever enabled on branch protection, PRs will sit unassignable. Even without that requirement, the CODEOWNERS file isn't doing its job of auto-requesting review from the right team.

## Coordination

New `HarperFast/ai-review-prompts` (#3 there) uses `@HarperFast/developers` too, matching the harper/oauth-fixed-here shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)