### PR TITLE
ci(claude): mirror harper's review-workflow consolidation + learnings channel

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: HarperFast/ai-review-prompts
-          ref: 752c5da8f1a7746e8202dba8aba4c28bd17d14c4 # main at seed merge
+          ref: 14c79a1c36565c764b68d3641c32bdadfc4d0512 # main 2026-04-30 (incl. concise-PR + within-PR-memory)
           path: .ai-review-prompts
 
       - name: Compose review scope from layers
@@ -139,7 +139,15 @@ jobs:
             # workflows. Their guarantee against destructive git ops
             # comes from branch protection on main / release_* / v*.x,
             # not from this allowlist.)
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*),Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(git blame:*),Bash(git show:*)"
+            # `Write` is granted but the prompt restricts it to a
+            # single path (`$RUNNER_TEMP/claude-review-notes.md`) — the
+            # channel for structured run notes that flow into the
+            # per-PR ai-review-log issue. claude-code-action's
+            # allowedTools doesn't support per-path filters, so the
+            # path-bound is enforced via prompt; deviations are
+            # contained because the runner is ephemeral and has no
+            # write credentials beyond `gh pr comment`.
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*),Read,Grep,Glob,Write,Bash(git diff:*),Bash(git log:*),Bash(git blame:*),Bash(git show:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -199,12 +207,13 @@ jobs:
             Git subcommands are scoped individually on purpose — no
             write operations are permitted.
 
-            Do NOT write files during the review — not to `.claude-pr/`,
-            not to `/tmp/`, not anywhere. The `Write` and `Edit` tools
-            are not allowed. If you want to organize notes, keep them
-            in-memory and assemble the final PR comment; saving
-            intermediate drafts to disk wastes turns on permission
-            denials.
+            You MAY use the `Write` tool, but ONLY to write to
+            `${{ runner.temp }}/claude-review-notes.md`. No other
+            paths or filenames. This file is the single channel for
+            structured run notes that flow into the per-PR
+            ai-review-log issue — see "## After reviewing" below for
+            its purpose and format. The `Edit` tool is not allowed,
+            and writes to any other path will be denied.
 
             Shared Harper best-practices are mirrored on disk at
             `.harper-skills/harper-best-practices/rules/*.md` if a layer
@@ -237,14 +246,108 @@ jobs:
 
             ## How to post the review
 
-            - Use `gh pr comment` for the single consolidated top-level
-              summary comment.
-            - Use `mcp__github_inline_comment__create_inline_comment`
-              (with `confirmed: true`) for specific code-line annotations.
-            - Only post GitHub comments — do NOT submit review text as SDK
-              messages.
+            Aim for **concise and actionable**. The cost is cognitive
+            overhead on humans; the constant is that you're missing
+            context the PR author has (motivation, prior conversation,
+            related work). Don't restate the PR's intent, don't recap
+            the diff, don't grade the author's reasoning — focus on
+            what to change.
+
+            Two surfaces:
+
+            - **Inline findings** via
+              `mcp__github_inline_comment__create_inline_comment` (with
+              `confirmed: true`). Per-line concerns belong here — it's
+              the most actionable place to put them. New findings post
+              fresh on each run; GitHub auto-marks superseded ones
+              "outdated".
+            - **Top-level PR comment** — a concise summary that
+              anchors the inline findings. Cap at ~5 lines. Edit
+              in place across runs so the PR never accumulates stacked
+              review comments:
+              `gh pr comment <N> --edit-last --create-if-none --body "<BODY>"`.
+              Use `--body-file` if the body is large enough to hit
+              shell argument limits. Don't wrap prior reviews in
+              `<details>` here — the related ai-review-log issue
+              keeps history across runs.
+
+            **For "no blockers" runs, the PR comment is one sentence.**
+            This overrides the universal scope's
+            `summary is welcome during calibration` allowance — this
+            workflow has a log surface (the next step threads each
+            run's PR comment into a per-PR `HarperFast/ai-review-log`
+            issue), so the verbose tracing belongs there, not on the
+            PR. Concrete shape:
+
+            ✅ Right shape on the PR:
+
+            ```
+            Reviewed; no blockers found.
+            ```
+
+            ❌ Wrong shape (the recap belongs in the log surface):
+
+            ```
+            No blockers found.
+
+            Two independent fixes:
+            - **<file>:** <one-line rationale for change A>
+            - **<other file>:** <one-line rationale for change B>
+            ```
+
+            The "what I traced" recap — one line per surface verified —
+            still has value for calibration; it just lives in the
+            ai-review-log issue, where reviewers can spot-check the
+            bot's reasoning without paying that cost on every PR.
+
+            Only post GitHub comments — do NOT submit review text as SDK
+            messages.
 
             Cap the review at 10 findings.
+
+            ## After reviewing: capture learnings for the log surface
+
+            The PR comment is for the PR author and human reviewers —
+            it stays concise (see "## How to post the review" above).
+            Verbose context, structured run notes, and learnings from
+            this run go into the per-PR ai-review-log issue, NOT the
+            PR. **Do not duplicate any of this content in the PR
+            comment.**
+
+            The channel: write a structured markdown file to
+            `${{ runner.temp }}/claude-review-notes.md`. The next
+            workflow step appends this file's contents to the
+            log-issue comment for this run, so reviewers can spot-
+            check your reasoning and a future KB can ingest it.
+
+            Format:
+
+            ```
+            ## Run notes
+
+            ### Surfaces verified
+            - One line per surface (auth, API contract, error path,
+              etc.). No full re-derivation.
+
+            ### Dismissals honored from prior conversation
+            - Finding "<title>" — thread #<N> said "<reason>" (link
+              the thread URL when useful).
+
+            ### Findings resolved by this push
+            - Finding "<title>" — line <X> in commit <abbrev SHA>
+              addresses the concern.
+
+            ### New observations
+            - Patterns, conventions, or context worth tracking for
+              cross-PR learning. Keep concrete; reference files and
+              lines.
+            ```
+
+            Sections may be empty; omit empty sections rather than
+            writing "(none)". If you have nothing to capture (e.g.,
+            first review on a fresh PR with no prior conversation
+            and nothing notable to flag), skip the file entirely —
+            the log step is a no-op when the file is absent.
 
       - name: Log review to ai-review-log
         # Best-effort — never fail the job if logging fails
@@ -298,7 +401,11 @@ jobs:
           fi
 
           # Title: count findings (lines starting with `### <digit>`). "No blockers" case has none.
-          if printf '%s' "$CLAUDE_BODY" | grep -qi '^no blockers found'; then
+          # Match the phrase anywhere in the body — the new concise prompt asks for
+          # `Reviewed; no blockers found.`, which doesn't start with "no blockers"
+          # and so wouldn't match an anchored regex. Anywhere-match is safe because
+          # `no blockers found` is a deliberate sentinel phrase from the prompt.
+          if printf '%s' "$CLAUDE_BODY" | grep -qi 'no blockers found'; then
             COUNT_PART="no blockers"
           else
             FINDING_COUNT=$(printf '%s\n' "$CLAUDE_BODY" | grep -c '^### [0-9]' || true)
@@ -317,23 +424,90 @@ jobs:
           BODY=$(printf '**Source:** %s\n**Repo:** %s\n**PR:** #%s\n**Model:** claude-sonnet-4-6\n**Phase:** baseline\n**Review job status:** %s\n**Date:** %s\n\n---\n\n%s\n' \
             "$PR_URL" "$REPO_SHORT" "$PR_NUMBER" "$REVIEW_STATUS" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$CLAUDE_BODY")
 
-          PAYLOAD=$(jq -nc \
-            --arg title "$TITLE" \
-            --arg repo_label "repo:$REPO_SHORT" \
-            --arg body "$BODY" \
-            '{title: $title, body: $body, labels: [$repo_label, "verdict:pending", "phase:baseline"]}')
+          # Structured run notes from the agent (optional). This is
+          # the channel that keeps verbose context off the PR — the
+          # agent writes to a fixed path under $RUNNER_TEMP, and we
+          # append here so the log issue gets the full picture while
+          # the PR comment stays concise. Absent file is fine; means
+          # the run had nothing structured to capture.
+          NOTES_FILE="${RUNNER_TEMP:-/tmp}/claude-review-notes.md"
+          if [ -f "$NOTES_FILE" ]; then
+            NOTES_CONTENT=$(cat "$NOTES_FILE")
+            BODY=$(printf '%s\n\n---\n\n%s\n' "$BODY" "$NOTES_CONTENT")
+            echo "Appended $(wc -c < "$NOTES_FILE") bytes of run notes from $NOTES_FILE"
+          else
+            echo "No run notes file at $NOTES_FILE — skipping notes append"
+          fi
 
-          HTTP=$(curl -sS -o /tmp/ai-log-resp.json -w '%{http_code}' -X POST \
+          # One ai-review-log issue per PR. Stable prefix
+          # `[<repo>] PR #<N>:` lets us look up an existing issue for
+          # this PR across runs even though the count/status portion
+          # past the colon changes per run. List API (not search) is
+          # used because search is eventually-consistent — a same-day
+          # second review run might fire before the first issue is
+          # indexed.
+          TITLE_PREFIX="[$REPO_SHORT] PR #$PR_NUMBER:"
+
+          EXISTING_NUMBER=$(curl -sS \
             -H "Authorization: Bearer $AI_REVIEW_LOG_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/HarperFast/ai-review-log/issues \
-            -d "$PAYLOAD")
+            "https://api.github.com/repos/HarperFast/ai-review-log/issues?labels=repo:$REPO_SHORT&state=all&per_page=100&sort=created&direction=desc" \
+            | jq -r --arg prefix "$TITLE_PREFIX" \
+              '[.[] | select(.title | startswith($prefix))] | first | .number // empty')
 
-          if [ "$HTTP" -ge 200 ] && [ "$HTTP" -lt 300 ]; then
-            ISSUE_URL=$(jq -r '.html_url' /tmp/ai-log-resp.json)
-            echo "Logged review to $ISSUE_URL"
+          if [ -n "$EXISTING_NUMBER" ] && [ "$EXISTING_NUMBER" != "null" ]; then
+            # Existing issue: append a comment, refresh the title to
+            # reflect this run's status. Title refresh is best-effort —
+            # we still report success on the comment alone.
+            COMMENT_PAYLOAD=$(jq -nc --arg body "$BODY" '{body: $body}')
+            HTTP_C=$(curl -sS -o /tmp/ai-log-comment-resp.json -w '%{http_code}' -X POST \
+              -H "Authorization: Bearer $AI_REVIEW_LOG_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/HarperFast/ai-review-log/issues/$EXISTING_NUMBER/comments" \
+              -d "$COMMENT_PAYLOAD")
+
+            PATCH_PAYLOAD=$(jq -nc --arg title "$TITLE" '{title: $title}')
+            HTTP_T=$(curl -sS -o /tmp/ai-log-patch-resp.json -w '%{http_code}' -X PATCH \
+              -H "Authorization: Bearer $AI_REVIEW_LOG_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/HarperFast/ai-review-log/issues/$EXISTING_NUMBER" \
+              -d "$PATCH_PAYLOAD")
+
+            if [ "$HTTP_C" -ge 200 ] && [ "$HTTP_C" -lt 300 ]; then
+              COMMENT_URL=$(jq -r '.html_url' /tmp/ai-log-comment-resp.json)
+              echo "Logged review as comment on existing issue: $COMMENT_URL"
+            else
+              echo "::warning::ai-review-log comment POST failed (HTTP $HTTP_C):"
+              cat /tmp/ai-log-comment-resp.json
+            fi
+
+            if [ "$HTTP_T" -lt 200 ] || [ "$HTTP_T" -ge 300 ]; then
+              echo "::warning::ai-review-log title PATCH failed (HTTP $HTTP_T):"
+              cat /tmp/ai-log-patch-resp.json
+            fi
           else
-            echo "::warning::ai-review-log POST failed (HTTP $HTTP):"
-            cat /tmp/ai-log-resp.json
+            # No existing issue for this PR — create one.
+            CREATE_PAYLOAD=$(jq -nc \
+              --arg title "$TITLE" \
+              --arg repo_label "repo:$REPO_SHORT" \
+              --arg body "$BODY" \
+              '{title: $title, body: $body, labels: [$repo_label, "verdict:pending", "phase:baseline"]}')
+
+            HTTP=$(curl -sS -o /tmp/ai-log-resp.json -w '%{http_code}' -X POST \
+              -H "Authorization: Bearer $AI_REVIEW_LOG_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/HarperFast/ai-review-log/issues \
+              -d "$CREATE_PAYLOAD")
+
+            if [ "$HTTP" -ge 200 ] && [ "$HTTP" -lt 300 ]; then
+              ISSUE_URL=$(jq -r '.html_url' /tmp/ai-log-resp.json)
+              echo "Logged review to new issue: $ISSUE_URL"
+            else
+              echo "::warning::ai-review-log POST failed (HTTP $HTTP):"
+              cat /tmp/ai-log-resp.json
+            fi
           fi


### PR DESCRIPTION
## Summary

Brings oauth's `claude-review.yml` in line with the harper pilot after the 2026-04-30 calibration sweep. Five harper PRs collapse into one mirror PR here.

| Mirrored from | What lands |
|---|---|
| [`harper#432`](https://github.com/HarperFast/harper/pull/432) | Top-level PR comment edit-in-place; log step find-or-create + comment-on-existing per-PR issue |
| [`harper#437`](https://github.com/HarperFast/harper/pull/437) | "How to post" rewrite — concise PR comment as canon, ✅/❌ examples |
| [`harper#438`](https://github.com/HarperFast/harper/pull/438) | `Write` tool restricted to `$RUNNER_TEMP/claude-review-notes.md`; new "After reviewing" prompt section; log step appends notes file to log-issue body |
| [`harper#439`](https://github.com/HarperFast/harper/pull/439) | `ai-review-prompts` ref bump `752c5da` → `14c79a1` (picks up universal-layer concise-PR + within-PR memory) |
| [`harper#442`](https://github.com/HarperFast/harper/pull/442) | Drop `^` anchor from no-blockers detection regex |

## Adapted for oauth

- `## How to post the review` override now reads "this workflow has a log surface" (was "Harper has a log surface" in harper #437).
- `REVIEW_LAYERS` keeps `repo-type/plugin` (oauth-specific).
- `## Repo-specific checks (OAuth plugin)` preserved as-is — CSRF, redirect URI, provider-of-record, session field preservation, path length bounds.
- The "Do NOT run `bun test` / `npm test`" guidance preserved (oauth uses bun).

## Why

Without this, oauth review runs continue to:
- Stack a fresh `ai-review-log` issue per run (PR #48 already has 10 issues; we're at 25 oauth issues total).
- Pile fresh top-level PR comments on every push.
- Lack the structured run-notes channel that the future KB MCP server will ingest.

After this lands, oauth review experience matches harper's: one edited top-level PR comment, one log issue per PR, verbose tracing flows to the log issue via `$RUNNER_TEMP`, never the PR.

## Test plan

- [ ] Open / push to an oauth PR after this lands → confirm a single top-level claude comment posts (concise body) and a `[oauth] PR #<N>: …` issue lands or is appended in `HarperFast/ai-review-log`.
- [ ] Push a follow-up commit → confirm the PR's existing claude comment is **edited in place** (not duplicated), and a **new comment** lands on the existing log issue (not a new issue).
- [ ] Confirm a "no blockers" run titles correctly (`no blockers`, not `0 finding(s)`).
- [ ] Confirm \`$RUNNER_TEMP/claude-review-notes.md\` content (when written) appears in the log-issue comment body but not on the PR.
- [ ] Verify the agent honors the override and posts a single sentence on no-blockers runs (no bullet recap).

## Followup

After this merges, triage the existing 25 oauth log issues — close pre-consolidation duplicates and apply verdict labels per the same approach used for the 56 harper issues. The mirror has to land first so the cleanup doesn't fight new runs re-stacking duplicates behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)