### PR TITLE
ci: bump third-party action versions across workflows + SHA-pin pr-checks.yml

### DIFF
--- a/.github/workflows/auth-gate-invariants.yml
+++ b/.github/workflows/auth-gate-invariants.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate auth gate structure
         run: bash .github/scripts/validate-auth-gate-invariants.sh

--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -60,7 +60,7 @@ jobs:
           owner: HarperFast
 
       - name: Checkout (for CODEOWNERS read)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             .github/CODEOWNERS
@@ -93,20 +93,20 @@ jobs:
         # a shallow clone; `git log` / `git blame` aren't reached for by
         # the current prompt. Bump to a deeper fetch only if we see the
         # agent blocked on history lookups.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Clone shared Harper skills
         # Pinned to a SHA (not `main`) so agent behavior is reproducible
         # across runs — updates to the skills repo require an explicit
         # pin bump in this workflow.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: HarperFast/skills
           ref: d2db99bb37a6dde868cbc5ac81ca4146be8956fb # 1.3.0 (2026-04-16)
           path: .harper-skills
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -121,7 +121,7 @@ jobs:
 
       - name: Claude (agent mode)
         id: claude-agent
-        uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
+        uses: anthropics/claude-code-action@ef50f123a3a9be95b60040d042717517407c7256 # v1.0.110
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -57,7 +57,7 @@ jobs:
           owner: HarperFast
 
       - name: Checkout (for CODEOWNERS read)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             .github/CODEOWNERS
@@ -94,7 +94,7 @@ jobs:
         # a shallow clone; `git log` / `git blame` aren't reached for by
         # the current prompt. Bump to a deeper fetch only if we see the
         # agent blocked on history lookups.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Parse mention
         # Real precision gate (the job-level `if:` is a cheap pre-filter).
@@ -115,7 +115,7 @@ jobs:
         # across runs — updates to the skills repo require an explicit
         # pin bump in this workflow.
         if: steps.mention.outputs.proceed == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: HarperFast/skills
           ref: d2db99bb37a6dde868cbc5ac81ca4146be8956fb # 1.3.0 (2026-04-16)
@@ -129,7 +129,7 @@ jobs:
         # prompt tells the agent to run `npm ci` itself before any script
         # that needs dependencies.
         if: steps.mention.outputs.proceed == 'true'
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -143,7 +143,7 @@ jobs:
       - name: Claude (agent mode)
         if: steps.mention.outputs.proceed == 'true'
         id: claude-agent
-        uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
+        uses: anthropics/claude-code-action@ef50f123a3a9be95b60040d042717517407c7256 # v1.0.110
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -61,7 +61,7 @@ jobs:
           owner: HarperFast
 
       - name: Checkout (for CODEOWNERS read)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             .github/CODEOWNERS
@@ -110,7 +110,7 @@ jobs:
         # Paired with a tightly-scoped `Bash(git <subcommand>:*)` allowlist
         # below (no `Bash(git:*)` — that would allow `git push --force`,
         # `git reset --hard`, etc.).
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -118,7 +118,7 @@ jobs:
         # Pinned to a specific SHA (not `main`) so review behavior is
         # reproducible across runs — updates to the skills repo require
         # an explicit pin bump here.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: HarperFast/skills
           ref: d2db99bb37a6dde868cbc5ac81ca4146be8956fb # 1.3.0 (2026-04-16)
@@ -127,7 +127,7 @@ jobs:
       - name: Clone review prompts
         # Layer files live in HarperFast/ai-review-prompts (public).
         # Pinned to a merge SHA — bump this deliberately to adopt updates.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: HarperFast/ai-review-prompts
           ref: 14c79a1c36565c764b68d3641c32bdadfc4d0512 # main 2026-04-30 (incl. concise-PR + within-PR-memory)
@@ -148,7 +148,7 @@ jobs:
 
       - name: Claude review
         id: claude-review
-        uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
+        uses: anthropics/claude-code-action@ef50f123a3a9be95b60040d042717517407c7256 # v1.0.110
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Admit the issue-to-PR bot's PRs. Job-level `if:` gate above lets

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -49,10 +49,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary

Two things in one PR — they're both "all third-party actions on this repo to current SHA-pinned versions past the 3-day buffer":

| Concern | Files | Detail |
|---|---|---|
| **Bump** to current versions | claude-*.yml, auth-gate-invariants.yml, release.yml | Same three bumps as [harper#464](https://github.com/HarperFast/harper/pull/464) — \`actions/checkout\`, \`actions/setup-node\`, \`anthropics/claude-code-action\`. Plus mirror of [harper#461](https://github.com/HarperFast/harper/pull/461)'s checkout v4.3.1 → v6.0.2 (which never came across to oauth). |
| **SHA-pin** tag-pinned refs | pr-checks.yml | Three references were carrying supply-chain risk via mutable tags: \`actions/checkout@v4\`, \`actions/setup-node@v4\`, \`oven-sh/setup-bun@v2\`. All now pinned to the same SHAs the rest of the repo uses. |

## Bumps

| Action | Was | Now | Released | Age |
|---|---|---|---|---|
| \`actions/checkout\` | v4.3.1 | v6.0.2 | 2026-01-09 | 4 months |
| \`actions/setup-node\` | v6.2.0 | v6.4.0 | 2026-04-20 | 14 days |
| \`anthropics/claude-code-action\` | v1.0.99 | v1.0.110 | 2026-04-29 | 5 days |

## SHA pins (pr-checks.yml)

| Was (tag-pinned) | Now (SHA-pinned) |
|---|---|
| \`actions/checkout@v4\` | \`@de0fac2e... # v6.0.2\` |
| \`actions/setup-node@v4\` | \`@48b55a01... # v6.4.0\` |
| \`oven-sh/setup-bun@v2\` | \`@0c5077e5... # v2.2.0\` |

\`actions/setup-node\` went \`v4 → v6\` in pr-checks.yml. v5 was the Node 20 → Node 24 jump; v6 minor releases since. Backwards-compatible for typical setup-node usage.

## Held back

- \`anthropics/claude-code-action\` v1.0.111 (2026-05-01) — at the 3-day buffer edge today; deliberately one patch behind. Will pick up on the next sweep.

## Verified locally

- All affected workflows parse as valid YAML.
- \`bash .github/scripts/validate-auth-gate-invariants.sh\` passes against all three \`claude-*.yml\` workflows.

## Test plan

- [ ] Push to a PR after this lands → confirm \`Auth gate invariants / validate\` still passes.
- [ ] Confirm \`pr-checks\` workflow still runs cleanly with v6 setup-node.
- [ ] Confirm a Claude review run completes end-to-end on v1.0.110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)