### PR TITLE
docs(README): add missing references to multi-tenant-sso and token-refresh-and-sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Complete documentation is available in the [docs](./docs) directory:
 - **[Configuration](./docs/configuration.md)** - Complete configuration reference
 - **[OAuth Providers](./docs/providers.md)** - Provider setup guides
 - **[Lifecycle Hooks](./docs/lifecycle-hooks.md)** - User provisioning and custom logic
+- **[Multi-Tenant SSO](./docs/multi-tenant-sso.md)** - Per-organization OAuth providers for B2B SaaS
+- **[Token Refresh and Sessions](./docs/token-refresh-and-sessions.md)** - How OAuth tokens and Harper sessions interact
 - **[API Reference](./docs/api-reference.md)** - Endpoints and programmatic API
 
 ## Development


### PR DESCRIPTION
## Summary

The README's Documentation section listed 5 docs but \`docs/\` has 7. The two missing entries are real, current docs:

- [\`docs/multi-tenant-sso.md\`](./docs/multi-tenant-sso.md) — per-organization OAuth providers for B2B SaaS (Okta / Azure AD / Auth0 with per-tenant config).
- [\`docs/token-refresh-and-sessions.md\`](./docs/token-refresh-and-sessions.md) — operational reference for how OAuth tokens and Harper sessions interact (proactive refresh, provider-specific behavior).

Both were authored after the README's docs list was last updated and never got linked. Surfacing them so they're discoverable from the entry point.

Two-line README change. Doubles as the first PR exercising oauth's caller-pattern \`claude-review.yml\` (post #71) — confirms the reusable runs end-to-end on a real PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)