### PR TITLE
ci(claude): pass ai-review-prompts-ref explicitly from caller

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -26,6 +26,18 @@ jobs:
   review:
     uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@0a5ccbc6daf746472be16ac6cea0a96277bf38e4 # main 2026-05-05 (incl. resolution-status sharpening + honest allowlist comment + reusable workflow)
     with:
+      # Pass the same SHA the `uses:` ref above is pinned to. The reusable
+      # uses this to check out HarperFast/ai-review-prompts (for layer
+      # files + bash scripts) at the SAME ref as the workflow logic
+      # itself — keeps the upgrade motion atomic (bump the pin in both
+      # places at once).
+      #
+      # We can't auto-derive this in the reusable: in a `workflow_call`
+      # context, `github.workflow_ref` resolves to the CALLER's ref
+      # (e.g. `refs/pull/72/merge`), not the called workflow's ref.
+      # Until GitHub exposes the called-workflow ref to reusables, the
+      # caller has to pass it explicitly.
+      ai-review-prompts-ref: 0a5ccbc6daf746472be16ac6cea0a96277bf38e4
       review-layers: |
         universal
         harper/common


### PR DESCRIPTION
## Summary

- Caller now passes `ai-review-prompts-ref` explicitly to the reusable, matching the SHA in the `uses:` ref pin.
- Unblocks Claude review runs on this repo (oauth main has been broken since #71 merged).

## Why

The reusable workflow auto-derives the ref by parsing `github.workflow_ref`, but in a `workflow_call` context that variable resolves to the **caller's** ref (e.g. `refs/pull/72/merge`), not the called workflow's ref. The reusable then tries to check out `HarperFast/ai-review-prompts` at `refs/pull/72/merge` and fails:

> fatal: couldn't find remote ref refs/pull/72/merge

See https://github.com/HarperFast/oauth/actions/runs/25410329060 for the failed run on #72.

The reusable already supports `ai-review-prompts-ref` as an explicit input override. This PR uses it.

## Followup

- harper #478 needs the same fix on its caller.
- After both callers are passing the input explicitly, drop the broken auto-derive in `HarperFast/ai-review-prompts` and make the input required.

## Test plan

- [x] YAML validates (`yq` parses cleanly)
- [ ] Merge → push to oauth #72 (the README test PR) → confirm Claude review run completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)