### PR TITLE
ci(claude): bump ai-review-prompts pin to 3278ce4e

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@f6daed301f8a7ece74593506de38c6e80820b00b # main 2026-05-06 (post #11/#12/#14 — Day 2 reusables)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@3278ce4e63c5af33cd1db68602aad9580e60dce7 # main 2026-05-09 (post #20 — title format + areas-not-traced + dev/prod dep rule)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -35,7 +35,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: f6daed301f8a7ece74593506de38c6e80820b00b
+      ai-review-prompts-ref: 3278ce4e63c5af33cd1db68602aad9580e60dce7
       review-layers: |
         universal
         harper/common


### PR DESCRIPTION
## Summary

Bumps `HarperFast/ai-review-prompts` pin to `3278ce4e` (post #20).

Picks up:
- Title-format consistency for ai-review-log issues — zero-finding runs always title as "no blockers"
- New `### Areas not traced` run-notes section — inverse of "Surfaces verified"
- New "dev/prod dependency mismatch" rule in `harper/common.md`

## Test plan

- [x] Workflow validation passes
- [ ] Next PR review run threads the new shape into `HarperFast/ai-review-log`; "no blockers" runs title cleanly; "Areas not traced" appears when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)