### PR TITLE
ci(gemini): add Gemini PR reviewer alongside Claude

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -1,0 +1,68 @@
+name: Gemini PR Review
+
+# Thin caller of the Gemini reusable in HarperFast/ai-review-prompts.
+# Runs in parallel with claude-review.yml so the two reviewers can be
+# compared on the same PRs.
+#
+# Layer inputs and `repo-specific-checks:` MIRROR claude-review.yml
+# in this repo. Output comparability between the two providers
+# depends on them seeing the same review scope — keep them in sync
+# when bumping the pin or editing the checks block.
+#
+# Pre-requisites:
+#   - HARPERFAST_AI_CLIENT_ID       (org-level App Client ID)
+#   - HARPERFAST_AI_APP_PRIVATE_KEY (org-level App private key)
+#   - GEMINI_API_KEY                (per-repo; optional — missing
+#                                   key cleanly skips the review
+#                                   with a workflow notice)
+#   - AI_REVIEW_LOG_TOKEN           (optional — threads each run
+#                                   into a per-(PR, provider) issue
+#                                   in HarperFast/ai-review-log
+#                                   with `provider:gemini` label)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  # Different group key from claude-review so the two providers can
+  # run in parallel on the same PR. cancel-in-progress is per-group,
+  # so a synchronize push cancels the in-flight Gemini run without
+  # touching the Claude run (and vice versa).
+  group: gemini-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@9471cd8026bbbf6b0eb2a75143071c533811c52e # main 2026-05-12 (post #22 — Gemini reusable + shared provider scripts + auth-gate validator generalization)
+    with:
+      # Same SHA as the `uses:` ref above. See claude-review.yml
+      # in this repo for why the duplication is unavoidable
+      # (reusable workflows can't introspect their own ref in
+      # workflow_call context).
+      ai-review-prompts-ref: 9471cd8026bbbf6b0eb2a75143071c533811c52e
+      review-layers: |
+        universal
+        harper/common
+        harper/v5
+        repo-type/plugin
+      repo-specific-checks: |
+        ## Repo-specific checks (OAuth plugin)
+
+        On top of the layered scope above, these are OAuth-only
+        semantics not covered by the shared layers:
+
+        - CSRF state tokens present on every OAuth flow; 10-minute
+          expiry is enforced; state is single-use
+        - Redirect URI validation on callback endpoints
+        - Provider-of-record enforcement (cross-provider CSRF
+          protection should redirect with error, not 403)
+        - Session field preservation across token refresh
+          (`provider`, `providerConfigId`, `providerType`)
+        - Path length validation (≤ 2048 chars) where user input
+          can reach a path
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      AI_REVIEW_LOG_TOKEN: ${{ secrets.AI_REVIEW_LOG_TOKEN }}
+      HARPERFAST_AI_CLIENT_ID: ${{ secrets.HARPERFAST_AI_CLIENT_ID }}
+      HARPERFAST_AI_APP_PRIVATE_KEY: ${{ secrets.HARPERFAST_AI_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Adds a Gemini reviewer that runs in parallel with the existing Claude reviewer on every PR. Both reviewers see the same layered review scope and the same `repo-specific-checks` block, so output from the two is directly comparable.

## How it works

- `claude-review.yml` and `gemini-review.yml` run concurrently. Different concurrency groups (`claude-review-N` vs `gemini-review-N`), so a synchronize cancels each provider's in-flight run independently.
- Both reviewers load the same layers: `universal` + `harper/common` + `harper/v5` + `repo-type/plugin`, and the same `repo-specific-checks` (CSRF state, redirect URI, etc.). Keep both callers in sync when bumping pins or editing the checks block.
- Distinguishing on the PR:
  - Sentinel markers: `<!-- claude-review:v1 -->` vs `<!-- gemini-review:v1 -->`
  - Bot identity: `claude[bot]` vs `github-actions[bot]`
- Each reviewer's findings thread to its own issue in the central review-log repo with a `provider:<name>` label, with a cross-link search URL in each issue body.

## Prerequisite

`GEMINI_API_KEY` needs to be set as a repo-level secret before merge. The Gemini reusable tolerates a missing key (skips cleanly with a workflow notice), so this caller is safe to land even before the secret if needed — it just won't post reviews until the secret is configured.

## Pin

Reusable workflow pinned to `ai-review-prompts@9471cd80`.

## Test plan

- [ ] Set `GEMINI_API_KEY` repo secret
- [ ] Open a small test PR; confirm:
  - Claude reviewer posts under `claude[bot]` with `<!-- claude-review:v1 -->` marker (unchanged)
  - Gemini reviewer posts under `github-actions[bot]` with `<!-- gemini-review:v1 -->` marker (new)
  - Both runs' findings appear in the review-log repo as separate per-provider issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)