### PR TITLE
ci(gemini): pin model to gemini-2.5-flash for routine review duty

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -41,6 +41,12 @@ jobs:
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
       ai-review-prompts-ref: 9471cd8026bbbf6b0eb2a75143071c533811c52e
+      # Match Claude's tier (Sonnet) — Flash is Gemini's mid-tier
+      # peer. The reusable's current default is `gemini-2.5-pro`
+      # (flagship), which is the tier mismatch we want to avoid for
+      # routine review duty. Once the reusable's default flips to
+      # Flash this override becomes redundant.
+      model: gemini-2.5-flash
       review-layers: |
         universal
         harper/common


### PR DESCRIPTION
## Summary

The Gemini reusable defaults to `gemini-2.5-pro` (flagship tier) which is a tier mismatch for routine PR review. Claude's reviewer uses Sonnet 4.6 (mid-tier); the apples-to-apples Gemini peer is **Flash**, not Pro.

This also resolves the quota failure observed on PR #80's first run — `gemini-2.5-pro` has no free-tier allocation on the project behind this repo's `GEMINI_API_KEY` (HTTP 429 with `limit: 0, model: gemini-2.5-pro`). `gemini-2.5-flash` typically has free-tier capacity.

Once the reusable's default flips to Flash this override becomes redundant; we can drop it then.

## Why Flash, not Pro

| Claude tier | Gemini tier | Used for |
|---|---|---|
| Haiku | Flash-Lite | Small/cheap |
| **Sonnet** | **Flash** | Routine review |
| Opus | Pro | Deep / thorough |

Pro should be reserved for thorough review modes (mirroring how Opus is reserved on the Claude side via the deep-review flow), not routine per-PR work.

## Test plan

- [ ] Merge
- [ ] Push something on the open release PR (#80) to retrigger the reviewers
- [ ] Confirm Gemini run succeeds and posts a marker'd comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)