### PR TITLE
ci: bump both AI-review caller pins to ai-review-prompts@128656e4

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@3278ce4e63c5af33cd1db68602aad9580e60dce7 # main 2026-05-09 (post #20 — title format + areas-not-traced + dev/prod dep rule)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@128656e40c87c0e1293c542a5500df4f68dbff85 # main 2026-05-12 (post #25 — symmetric pin with gemini-review.yml; picks up shared-script refactor and authorize-ai-workflow.sh rename)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -35,7 +35,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 3278ce4e63c5af33cd1db68602aad9580e60dce7
+      ai-review-prompts-ref: 128656e40c87c0e1293c542a5500df4f68dbff85
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -34,13 +34,13 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@9471cd8026bbbf6b0eb2a75143071c533811c52e # main 2026-05-12 (post #22 — Gemini reusable + shared provider scripts + auth-gate validator generalization)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@128656e40c87c0e1293c542a5500df4f68dbff85 # main 2026-05-12 (post #25 — workflow posts Gemini response, output-name fix, default model gemini-3-flash-preview)
     with:
       # Same SHA as the `uses:` ref above. See claude-review.yml
       # in this repo for why the duplication is unavoidable
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
-      ai-review-prompts-ref: 9471cd8026bbbf6b0eb2a75143071c533811c52e
+      ai-review-prompts-ref: 128656e40c87c0e1293c542a5500df4f68dbff85
       review-layers: |
         universal
         harper/common


### PR DESCRIPTION
## Summary

Symmetric pin across `claude-review.yml` and `gemini-review.yml` — both now reference `ai-review-prompts@128656e4`. Easier to audit "are we current?" without per-file checks, and matches the "single pin per repo upgrade motion" the caller comment already promises.

## What each caller picks up

### `claude-review.yml` (was @3278ce4e → @128656e4)

- Shared-script refactor: provider-agnostic `find-prior-review-comment.sh` + `log-review-to-ai-review-log.sh` with explicit `MARKER` / `MODEL` env vars. Behavior for Claude is unchanged — `PROVIDER_LABEL` stays empty so the legacy title format is preserved.
- New `**Run:**` link in the ai-review-log issue body (one click to the workflow run, where token usage / estimated cost is visible).
- `authorize-claude-workflow.sh` → `authorize-ai-workflow.sh` rename, handled inside the reusable (consumer caller doesn't reference the script directly).
- Auth-gate validator now pattern-based (covers both providers' reusables automatically).

### `gemini-review.yml` (was @9471cd80 → @128656e4)

- **Architectural fix**: Gemini's review is now posted by the workflow on the agent's behalf, since `run-gemini-cli`'s single-shot mode doesn't give the agent shell tools to call `gh pr comment` directly.
- **Output-name fix**: post step now references the action's caller-facing output (`summary`) instead of the action's internal step output (`gemini_response`). Without this fix the post step was silently skipped — discovered on this PR's first run, after the artifact upload addition surfaced the agent's actual response (which was correct all along).
- Artifact upload enabled on the Gemini step for post-mortem visibility.
- Default model: `gemini-3-flash-preview` — Google's current-gen mid-tier Flash. No `model:` override needed.

## Expected first-run quirk

The Claude step on this PR's branch will fail with a GitHub-side App-token 401 from claude-code-action's workflow validation ("workflow file must exist and have identical content to the version on the default branch"). This is a known gotcha for workflow-modifying PRs and the message itself says to ignore it. After this PR merges, subsequent PRs review normally.

## Test plan

- [ ] Merge
- [ ] Push something on PR #80 to retrigger reviewers — first real dual-provider datapoint with all fixes in place
- [ ] Confirm:
  - Claude posts as `claude[bot]` with `<!-- claude-review:v1 -->` (resumes normal operation)
  - Gemini posts as `github-actions[bot]` with `<!-- gemini-review:v1 -->` (was always silently skipped before)
  - Two log issues land in the review-log repo, one per provider, with correct titles + labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)