### PR TITLE
ci(claude-review): bump pin to f22bf7d + label-gated review + scoped caller permissions

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@832d8e6bb1ab2068585ded4288797ac191b21360 # main 2026-05-14 (post #30..#34 — symmetric pin with gemini-review.yml; Claude has no functional change from any of these; pin just stays in lockstep)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@e1f8d434aafbd71943649ba7a8c6727638a1f5a3 # main 2026-05-14 (post #30..#35 — symmetric pin with gemini-review.yml; Claude has no functional change from any of these; pin just stays in lockstep)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -35,7 +35,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 832d8e6bb1ab2068585ded4288797ac191b21360
+      ai-review-prompts-ref: e1f8d434aafbd71943649ba7a8c6727638a1f5a3
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@d446b4c68bb02068ede471ad5ac34c9af380bdfb # main 2026-05-13 (post #30/#31/#32 — symmetric pin with gemini-review.yml; Claude has no functional change from any of these; pin just stays in lockstep)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@fa9ba10643037ef9d42b2a6b954617cd411317b3 # main 2026-05-13 (post #30/#31/#32/#33 — symmetric pin with gemini-review.yml; Claude has no functional change from any of these; pin just stays in lockstep)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -35,7 +35,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: d446b4c68bb02068ede471ad5ac34c9af380bdfb
+      ai-review-prompts-ref: fa9ba10643037ef9d42b2a6b954617cd411317b3
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@e1f8d434aafbd71943649ba7a8c6727638a1f5a3 # main 2026-05-14 (post #30..#35 — symmetric pin with gemini-review.yml; Claude has no functional change from any of these; pin just stays in lockstep)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@045c81bf2c2b5b5b4a520fa6b2de137f86fcbc2a # main 2026-05-14 (post #30..#36 — symmetric pin with gemini-review.yml; Claude has no functional change from any of these; pin just stays in lockstep)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -35,7 +35,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: e1f8d434aafbd71943649ba7a8c6727638a1f5a3
+      ai-review-prompts-ref: 045c81bf2c2b5b5b4a520fa6b2de137f86fcbc2a
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@128656e40c87c0e1293c542a5500df4f68dbff85 # main 2026-05-12 (post #25 — symmetric pin with gemini-review.yml; picks up shared-script refactor and authorize-ai-workflow.sh rename)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@d446b4c68bb02068ede471ad5ac34c9af380bdfb # main 2026-05-13 (post #30/#31/#32 — symmetric pin with gemini-review.yml; Claude has no functional change from any of these; pin just stays in lockstep)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -35,7 +35,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 128656e40c87c0e1293c542a5500df4f68dbff85
+      ai-review-prompts-ref: d446b4c68bb02068ede471ad5ac34c9af380bdfb
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,7 +16,9 @@ name: Claude PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # `labeled` admits the `claude-review` label gesture for
+    # bot-authored PRs (renovate, dependabot). See ai-review-prompts#38.
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
@@ -24,7 +26,21 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@045c81bf2c2b5b5b4a520fa6b2de137f86fcbc2a # main 2026-05-14 (post #30..#36 — symmetric pin with gemini-review.yml; Claude has no functional change from any of these; pin just stays in lockstep)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@f22bf7dcb7d22d5de94c938daa9d790f2b5c776b # main 2026-05-18 (post #37 + #38 + #40 — calibration layer update + label-gated bot-PR review; gemini-review.yml pin intentionally NOT in lockstep here — Gemini reviewer has known issues being worked separately, no need to drag it along)
+    # Caller-side permissions, scoped at the calling-job level (NOT
+    # workflow-level — that placement caps the reusable's per-job
+    # grants below what they need and breaks the workflow at startup;
+    # see ai-review-prompts#39/#40 for the incident). Union of what
+    # the reusable's `authorize` (`contents: read`) and `review`
+    # (`contents: read + pull-requests: write + id-token: write`)
+    # jobs declare. GitHub's rule: caller's GITHUB_TOKEN permissions
+    # can only be DOWNGRADED (not elevated) by the called workflow,
+    # so the caller must grant at least the union the reusable needs.
+    # Reference: https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -35,7 +51,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 045c81bf2c2b5b5b4a520fa6b2de137f86fcbc2a
+      ai-review-prompts-ref: f22bf7dcb7d22d5de94c938daa9d790f2b5c776b
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@fa9ba10643037ef9d42b2a6b954617cd411317b3 # main 2026-05-13 (post #30/#31/#32/#33 — symmetric pin with gemini-review.yml; Claude has no functional change from any of these; pin just stays in lockstep)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@832d8e6bb1ab2068585ded4288797ac191b21360 # main 2026-05-14 (post #30..#34 — symmetric pin with gemini-review.yml; Claude has no functional change from any of these; pin just stays in lockstep)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -35,7 +35,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: fa9ba10643037ef9d42b2a6b954617cd411317b3
+      ai-review-prompts-ref: 832d8e6bb1ab2068585ded4288797ac191b21360
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review-debug.yml
+++ b/.github/workflows/gemini-review-debug.yml
@@ -1,51 +1,30 @@
 name: Gemini PR Review (debug)
 
-# Single-repo debug spike to isolate why MCP tools never propagate to
-# the model's function-call surface in our production `gemini-review.yml`
-# (despite the github-mcp-server starting fine and registering session-
-# side). This workflow runs in PARALLEL with the production caller —
-# different concurrency group, no shared steps.
+# Pragmatic shell-based Gemini reviewer. After 3 debug iterations
+# proving MCP tool propagation is unreliable (v1.0.x server bug,
+# umbrella-tool-shape mismatch with model's training, INVALID_STREAM
+# on /pr-code-review, hallucinated review on /pr-review), pivoting
+# to what the model wants to do anyway: use the `gh` CLI.
 #
-# Hypothesis under test:
-#   Our production caller pins `ghcr.io/github/github-mcp-server@sha256:
-#   e3816a4...` which is the v1.0.4 image (released 2026-05-11). v1.0.0
-#   (2026-04-16) bumped the modelcontextprotocol/go-sdk to v1.5.0 and
-#   reorganized toolsets, introducing feature-flagged tool groups gated
-#   by `dynamicToolsets` (visible in our server logs as
-#   `dynamicToolsets=false`). Upstream's example pins to `:v0.27.0`
-#   (2026-02-03 era) which predates that reorganization. The bump to
-#   v1.0.x was Harper-side and well-intended but likely the regression.
+# Goal: produce A working Gemini review on PR #83 to compare against
+# Claude. Architectural elegance is a non-goal for this iteration.
 #
-# This workflow mirrors upstream's tip-of-main example as closely as
-# practical:
-#   https://github.com/google-github-actions/run-gemini-cli/tree/main/examples/workflows/pr-review
-#
-# Deviations from upstream main, kept minimal:
-#   - Auth: skip the App-token-mint step entirely. Use the workflow's
-#     default GITHUB_TOKEN. This loses the auth gate but we're on a
-#     single-repo debug branch — only Nathan / org members push here.
-#     Backport will reintroduce the gate via the existing reusable.
-#   - Model: hardcoded `gemini-3-flash-preview` (no `vars.GEMINI_MODEL`).
-#   - Layered Harper scope: NOT applied. Goal is to prove MCP propagates
-#     before reintroducing scope complexity. ADDITIONAL_CONTEXT is empty.
-#   - Visibility: same failure-path artifact upload + summary-tail steps
-#     we added to the reusable in #36 (with the pipefail / SIGPIPE bug
-#     fixed). Upstream's inner upload step still doesn't gate on
-#     `if: always()` so we need our own failure-path upload.
-#
-# Iteration model:
-#   Edit this file → push → wait ~90s for run. No PR ceremony on
-#   ai-review-prompts. When we identify the working config, backport
-#   to `_gemini-review.yml` in one focused PR.
+# Architecture:
+#   - No MCP. No upstream `code-review` extension. No custom slash
+#     command file. Just an inline prompt.
+#   - tools.core allows `gh`, `git`, `cat`, `echo`, `grep`, `head`,
+#     `tail`. The agent uses these natively.
+#   - Agent reads the diff via `gh pr diff`, generates a review,
+#     posts it via `gh pr review --comment --body`.
+#   - Body-anchored findings (no per-line inline comments — would
+#     require MCP, which we just spent 3 iterations failing to wire).
+#     Findings reference file:line as `**File:** path:N` plain text.
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  # Distinct from `gemini-review-${pr}` so the production caller and
-  # this debug workflow run in parallel on the same PR without
-  # cancelling each other.
   group: gemini-review-debug-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
@@ -63,28 +42,6 @@ jobs:
         with:
           persist-credentials: 'false'
 
-      - name: Prepare prompt context
-        # Mirrors upstream main's pattern. Writes a JSON file the
-        # agent can `@{...}`-include or read directly. The currently-
-        # released `/pr-code-review` slash command (extension @ main)
-        # doesn't actually read this file — it references $REPOSITORY
-        # / $PULL_REQUEST_NUMBER / $ADDITIONAL_CONTEXT in its prompt
-        # body — but upstream main's workflow still writes the file,
-        # so we follow.
-        shell: bash
-        run: |-
-          mkdir -p .gemini
-          jq -n \
-            --arg repo "${REPOSITORY}" \
-            --arg pr "${PULL_REQUEST_NUMBER}" \
-            --arg context "${ADDITIONAL_CONTEXT}" \
-            '{repository: $repo, pull_request_number: $pr, additional_context: $context}' \
-            > .gemini/context.json
-        env:
-          REPOSITORY: ${{ github.repository }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-          ADDITIONAL_CONTEXT: ''
-
       - name: Run Gemini pull request review
         id: gemini-review
         uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
@@ -92,83 +49,101 @@ jobs:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GITHUB_TOKEN: ${{ github.token }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          # Upstream main keeps these as env vars too, alongside the
-          # context.json file. The currently-released `/pr-code-review`
-          # slash command reads them via shell echo at runtime.
+          GH_TOKEN: ${{ github.token }}
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
-          ISSUE_TITLE: ${{ github.event.pull_request.title }}
-          ISSUE_BODY: ${{ github.event.pull_request.body }}
-          ADDITIONAL_CONTEXT: ''
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           gemini_model: 'gemini-3-flash-preview'
           gemini_cli_version: 'latest'
           gemini_debug: 'true'
           upload_artifacts: 'true'
-          github_pr_number: ${{ github.event.pull_request.number }}
-          extensions: |
-            [
-              "https://github.com/gemini-cli-extensions/code-review"
-            ]
-          # MCP server pinned to TAG `:v0.27.0` — the version upstream
-          # tests with. Debug-spike-only deviation from our SHA-pinning
-          # discipline; when we backport to the reusable we'll resolve
-          # to a digest. No `modelConfigs`, no `tools.core` shell access
-          # (forces all I/O through MCP — proves whether MCP works).
           settings: |-
             {
               "model": {
-                "maxSessionTurns": 25
+                "maxSessionTurns": 15
               },
               "telemetry": {
                 "enabled": true,
                 "target": "local",
                 "outfile": ".gemini/telemetry.log"
               },
-              "mcpServers": {
-                "github": {
-                  "command": "docker",
-                  "args": [
-                    "run",
-                    "-i",
-                    "--rm",
-                    "-e",
-                    "GITHUB_PERSONAL_ACCESS_TOKEN",
-                    "ghcr.io/github/github-mcp-server:v0.27.0"
-                  ],
-                  "includeTools": [
-                    "add_comment_to_pending_review",
-                    "pull_request_read",
-                    "pull_request_review_write"
-                  ],
-                  "env": {
-                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
-                  }
-                }
-              },
               "tools": {
-                "core": []
+                "core": [
+                  "run_shell_command(gh)",
+                  "run_shell_command(git)",
+                  "run_shell_command(cat)",
+                  "run_shell_command(echo)",
+                  "run_shell_command(grep)",
+                  "run_shell_command(head)",
+                  "run_shell_command(tail)"
+                ]
               }
             }
-          # Experiment: switch from `/pr-code-review` (which got the
-          # model into INVALID_STREAM with 0 output tokens across 4
-          # API requests, despite MCP tools registering successfully
-          # under v0.27.0) to `/pr-review`. The extension's
-          # GEMINI.md (loaded into the agent's context at startup)
-          # documents `/pr-review` as the top-level command for
-          # "user requests that pr to be reviewed", though it's not
-          # in the extension's `commands/` directory — suggesting
-          # it might be a routing alias or skill-registered command.
-          # If it doesn't exist, gemini-cli will fail clearly.
-          prompt: '/pr-review'
+          prompt: |
+            You are a senior software engineer reviewing pull request
+            #${{ github.event.pull_request.number }} on
+            ${{ github.repository }}.
+
+            Step 1 — Read the diff. Run:
+
+                gh pr diff ${{ github.event.pull_request.number }} \
+                  --repo ${{ github.repository }}
+
+            Step 2 — Decide if the diff is trivial. Trivial means
+            dependency version bumps, CI workflow pin updates,
+            lockfile-only churn, prose-only doc edits, version-string
+            changes. If trivial, skip to Step 4 with the no-blockers
+            template.
+
+            Step 3 — For substantive diffs, review for BLOCKERS only.
+            A blocker is a 🔴 Critical (security vulnerability,
+            data-loss bug, broken public API contract) or 🟠 High
+            (clear correctness/security issue likely to bite in
+            production) finding. Do NOT post 🟡 Medium or 🟢 Low
+            findings. Cap at 10 findings. Reference each finding's
+            file:line as plain-text `**File:** path:LINE`.
+
+            Step 4 — Post the review via:
+
+                gh pr review ${{ github.event.pull_request.number }} \
+                  --repo ${{ github.repository }} \
+                  --comment \
+                  --body "$REVIEW_BODY"
+
+            Where REVIEW_BODY is your review markdown formatted as:
+
+                <!-- gemini-review:v1 -->
+
+                ## 📋 Review Summary
+
+                <one paragraph; for trivial diffs: "Reviewed; no blockers found.">
+
+                ## 🔍 Findings
+
+                ### 1. 🔴 <title>
+
+                **File:** `path/to/file.ext:LINE`
+
+                **What:** <one or two sentences>
+
+                **Why it matters:** <impact>
+
+                **Suggested fix:** <concrete change or fenced code block>
+
+                ### 2. ...
+
+            Omit the `## 🔍 Findings` section entirely if you have
+            zero blockers.
+
+            The `<!-- gemini-review:v1 -->` marker on the first line
+            is REQUIRED — it's how the team's tooling threads runs
+            together across pushes.
+
+            After posting, your job is done. Do not post a duplicate.
+            Do not edit the review.
 
       - name: Upload gemini-artifacts (failure path)
-        # Same workaround as in _gemini-review.yml (post-#36): the
-        # run-gemini-cli action's inner upload step is `if: upload_
-        # artifacts == 'true'` but not `if: always()`, so on the failure
-        # path the upload is skipped. The wrapper writes the artifact
-        # files BEFORE its exit 1, so we just upload them ourselves.
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -178,8 +153,6 @@ jobs:
           retention-days: 14
 
       - name: Append gemini logs tail to job summary
-        # Pipefail-safe: `tail | head -c N` exits SIGPIPE under pipefail;
-        # we drop pipefail for this step and use `|| true` to swallow.
         if: failure()
         shell: bash
         run: |
@@ -187,8 +160,6 @@ jobs:
           if [ ! -d gemini-artifacts ]; then
             {
               echo "## ⚠️ Gemini debug run failed (no gemini-artifacts/ directory)"
-              echo
-              echo "The gemini-cli wrapper exited before writing logs to disk."
             } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi

--- a/.github/workflows/gemini-review-debug.yml
+++ b/.github/workflows/gemini-review-debug.yml
@@ -151,7 +151,17 @@ jobs:
                 "core": []
               }
             }
-          prompt: '/pr-code-review'
+          # Experiment: switch from `/pr-code-review` (which got the
+          # model into INVALID_STREAM with 0 output tokens across 4
+          # API requests, despite MCP tools registering successfully
+          # under v0.27.0) to `/pr-review`. The extension's
+          # GEMINI.md (loaded into the agent's context at startup)
+          # documents `/pr-review` as the top-level command for
+          # "user requests that pr to be reviewed", though it's not
+          # in the extension's `commands/` directory — suggesting
+          # it might be a routing alias or skill-registered command.
+          # If it doesn't exist, gemini-cli will fail clearly.
+          prompt: '/pr-review'
 
       - name: Upload gemini-artifacts (failure path)
         # Same workaround as in _gemini-review.yml (post-#36): the

--- a/.github/workflows/gemini-review-debug.yml
+++ b/.github/workflows/gemini-review-debug.yml
@@ -1,0 +1,201 @@
+name: Gemini PR Review (debug)
+
+# Single-repo debug spike to isolate why MCP tools never propagate to
+# the model's function-call surface in our production `gemini-review.yml`
+# (despite the github-mcp-server starting fine and registering session-
+# side). This workflow runs in PARALLEL with the production caller —
+# different concurrency group, no shared steps.
+#
+# Hypothesis under test:
+#   Our production caller pins `ghcr.io/github/github-mcp-server@sha256:
+#   e3816a4...` which is the v1.0.4 image (released 2026-05-11). v1.0.0
+#   (2026-04-16) bumped the modelcontextprotocol/go-sdk to v1.5.0 and
+#   reorganized toolsets, introducing feature-flagged tool groups gated
+#   by `dynamicToolsets` (visible in our server logs as
+#   `dynamicToolsets=false`). Upstream's example pins to `:v0.27.0`
+#   (2026-02-03 era) which predates that reorganization. The bump to
+#   v1.0.x was Harper-side and well-intended but likely the regression.
+#
+# This workflow mirrors upstream's tip-of-main example as closely as
+# practical:
+#   https://github.com/google-github-actions/run-gemini-cli/tree/main/examples/workflows/pr-review
+#
+# Deviations from upstream main, kept minimal:
+#   - Auth: skip the App-token-mint step entirely. Use the workflow's
+#     default GITHUB_TOKEN. This loses the auth gate but we're on a
+#     single-repo debug branch — only Nathan / org members push here.
+#     Backport will reintroduce the gate via the existing reusable.
+#   - Model: hardcoded `gemini-3-flash-preview` (no `vars.GEMINI_MODEL`).
+#   - Layered Harper scope: NOT applied. Goal is to prove MCP propagates
+#     before reintroducing scope complexity. ADDITIONAL_CONTEXT is empty.
+#   - Visibility: same failure-path artifact upload + summary-tail steps
+#     we added to the reusable in #36 (with the pipefail / SIGPIPE bug
+#     fixed). Upstream's inner upload step still doesn't gate on
+#     `if: always()` so we need our own failure-path upload.
+#
+# Iteration model:
+#   Edit this file → push → wait ~90s for run. No PR ceremony on
+#   ai-review-prompts. When we identify the working config, backport
+#   to `_gemini-review.yml` in one focused PR.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  # Distinct from `gemini-review-${pr}` so the production caller and
+  # this debug workflow run in parallel on the same PR without
+  # cancelling each other.
+  group: gemini-review-debug-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.2
+        with:
+          persist-credentials: 'false'
+
+      - name: Prepare prompt context
+        # Mirrors upstream main's pattern. Writes a JSON file the
+        # agent can `@{...}`-include or read directly. The currently-
+        # released `/pr-code-review` slash command (extension @ main)
+        # doesn't actually read this file — it references $REPOSITORY
+        # / $PULL_REQUEST_NUMBER / $ADDITIONAL_CONTEXT in its prompt
+        # body — but upstream main's workflow still writes the file,
+        # so we follow.
+        shell: bash
+        run: |-
+          mkdir -p .gemini
+          jq -n \
+            --arg repo "${REPOSITORY}" \
+            --arg pr "${PULL_REQUEST_NUMBER}" \
+            --arg context "${ADDITIONAL_CONTEXT}" \
+            '{repository: $repo, pull_request_number: $pr, additional_context: $context}' \
+            > .gemini/context.json
+        env:
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          ADDITIONAL_CONTEXT: ''
+
+      - name: Run Gemini pull request review
+        id: gemini-review
+        uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0.1.22
+        env:
+          GEMINI_CLI_TRUST_WORKSPACE: 'true'
+          GITHUB_TOKEN: ${{ github.token }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # Upstream main keeps these as env vars too, alongside the
+          # context.json file. The currently-released `/pr-code-review`
+          # slash command reads them via shell echo at runtime.
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+          ISSUE_TITLE: ${{ github.event.pull_request.title }}
+          ISSUE_BODY: ${{ github.event.pull_request.body }}
+          ADDITIONAL_CONTEXT: ''
+        with:
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          gemini_model: 'gemini-3-flash-preview'
+          gemini_cli_version: 'latest'
+          gemini_debug: 'true'
+          upload_artifacts: 'true'
+          github_pr_number: ${{ github.event.pull_request.number }}
+          extensions: |
+            [
+              "https://github.com/gemini-cli-extensions/code-review"
+            ]
+          # MCP server pinned to TAG `:v0.27.0` — the version upstream
+          # tests with. Debug-spike-only deviation from our SHA-pinning
+          # discipline; when we backport to the reusable we'll resolve
+          # to a digest. No `modelConfigs`, no `tools.core` shell access
+          # (forces all I/O through MCP — proves whether MCP works).
+          settings: |-
+            {
+              "model": {
+                "maxSessionTurns": 25
+              },
+              "telemetry": {
+                "enabled": true,
+                "target": "local",
+                "outfile": ".gemini/telemetry.log"
+              },
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                  ],
+                  "includeTools": [
+                    "add_comment_to_pending_review",
+                    "pull_request_read",
+                    "pull_request_review_write"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              },
+              "tools": {
+                "core": []
+              }
+            }
+          prompt: '/pr-code-review'
+
+      - name: Upload gemini-artifacts (failure path)
+        # Same workaround as in _gemini-review.yml (post-#36): the
+        # run-gemini-cli action's inner upload step is `if: upload_
+        # artifacts == 'true'` but not `if: always()`, so on the failure
+        # path the upload is skipped. The wrapper writes the artifact
+        # files BEFORE its exit 1, so we just upload them ourselves.
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: gemini-debug-output-failure
+          path: gemini-artifacts/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Append gemini logs tail to job summary
+        # Pipefail-safe: `tail | head -c N` exits SIGPIPE under pipefail;
+        # we drop pipefail for this step and use `|| true` to swallow.
+        if: failure()
+        shell: bash
+        run: |
+          set -eu
+          if [ ! -d gemini-artifacts ]; then
+            {
+              echo "## ⚠️ Gemini debug run failed (no gemini-artifacts/ directory)"
+              echo
+              echo "The gemini-cli wrapper exited before writing logs to disk."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "## ⚠️ Gemini debug run failed — log tails"
+            echo
+            echo "Full logs uploaded as the \`gemini-debug-output-failure\` artifact."
+            echo
+            for f in stdout.log stderr.log telemetry.log; do
+              if [ -f "gemini-artifacts/$f" ] && [ -s "gemini-artifacts/$f" ]; then
+                echo "### \`gemini-artifacts/$f\` (last 200 lines)"
+                echo
+                echo '```'
+                (tail -n 200 "gemini-artifacts/$f" | head -c 50000) || true
+                echo
+                echo '```'
+                echo
+              fi
+            done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -34,13 +34,13 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@fa9ba10643037ef9d42b2a6b954617cd411317b3 # main 2026-05-13 (post #30/#31/#32/#33 — atomic submission via pull_request_review_write create+COMMENT; strict scope-to-diff prompt; minimal tools.core allowlist back; maxSessionTurns=20; gemini_debug=true kept for one more verification cycle)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@832d8e6bb1ab2068585ded4288797ac191b21360 # main 2026-05-14 (post #30..#34 — atomic submission + scope-to-diff + PR-context env vars (PULL_REQUEST_NUMBER/REPOSITORY/ISSUE_TITLE/ISSUE_BODY) so the agent stops thrashing on context discovery; tools.core widened to match upstream (cat/echo/git/grep/head/tail); gemini_debug=true for one more verification cycle)
     with:
       # Same SHA as the `uses:` ref above. See claude-review.yml
       # in this repo for why the duplication is unavoidable
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
-      ai-review-prompts-ref: fa9ba10643037ef9d42b2a6b954617cd411317b3
+      ai-review-prompts-ref: 832d8e6bb1ab2068585ded4288797ac191b21360
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -34,13 +34,13 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@832d8e6bb1ab2068585ded4288797ac191b21360 # main 2026-05-14 (post #30..#34 — atomic submission + scope-to-diff + PR-context env vars (PULL_REQUEST_NUMBER/REPOSITORY/ISSUE_TITLE/ISSUE_BODY) so the agent stops thrashing on context discovery; tools.core widened to match upstream (cat/echo/git/grep/head/tail); gemini_debug=true for one more verification cycle)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@e1f8d434aafbd71943649ba7a8c6727638a1f5a3 # main 2026-05-14 (post #30..#35 — pivot to upstream /pr-code-review slash command; Harper scope layered via ADDITIONAL_CONTEXT env var; tools.core matches upstream exactly (cat/echo/grep/head/tail, no git); gemini_debug=true for one more verification cycle)
     with:
       # Same SHA as the `uses:` ref above. See claude-review.yml
       # in this repo for why the duplication is unavoidable
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
-      ai-review-prompts-ref: 832d8e6bb1ab2068585ded4288797ac191b21360
+      ai-review-prompts-ref: e1f8d434aafbd71943649ba7a8c6727638a1f5a3
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -34,13 +34,13 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@e1f8d434aafbd71943649ba7a8c6727638a1f5a3 # main 2026-05-14 (post #30..#35 — pivot to upstream /pr-code-review slash command; Harper scope layered via ADDITIONAL_CONTEXT env var; tools.core matches upstream exactly (cat/echo/grep/head/tail, no git); gemini_debug=true for one more verification cycle)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@045c81bf2c2b5b5b4a520fa6b2de137f86fcbc2a # main 2026-05-14 (post #30..#36 — visibility fix: caller-side if-failure upload of gemini-artifacts (works around upstream's missing if:always() on its own upload step) + job-summary tail; this run-attempt's purpose is to capture the full post-#35 agent trace)
     with:
       # Same SHA as the `uses:` ref above. See claude-review.yml
       # in this repo for why the duplication is unavoidable
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
-      ai-review-prompts-ref: e1f8d434aafbd71943649ba7a8c6727638a1f5a3
+      ai-review-prompts-ref: 045c81bf2c2b5b5b4a520fa6b2de137f86fcbc2a
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -34,13 +34,13 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@045c81bf2c2b5b5b4a520fa6b2de137f86fcbc2a # main 2026-05-14 (post #30..#36 — visibility fix: caller-side if-failure upload of gemini-artifacts (works around upstream's missing if:always() on its own upload step) + job-summary tail; this run-attempt's purpose is to capture the full post-#35 agent trace)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@128656e40c87c0e1293c542a5500df4f68dbff85 # main 2026-05-12 (post #25 — workflow posts Gemini response, output-name fix, default model gemini-3-flash-preview)
     with:
       # Same SHA as the `uses:` ref above. See claude-review.yml
       # in this repo for why the duplication is unavoidable
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
-      ai-review-prompts-ref: 045c81bf2c2b5b5b4a520fa6b2de137f86fcbc2a
+      ai-review-prompts-ref: 128656e40c87c0e1293c542a5500df4f68dbff85
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -34,13 +34,13 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@d446b4c68bb02068ede471ad5ac34c9af380bdfb # main 2026-05-13 (post #30/#31/#32 — MCP pivot + debug-iteration: gemini_debug=true, no tools.core allowlist, maxSessionTurns=30 to surface what's happening with MCP registration and shell denials)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@fa9ba10643037ef9d42b2a6b954617cd411317b3 # main 2026-05-13 (post #30/#31/#32/#33 — atomic submission via pull_request_review_write create+COMMENT; strict scope-to-diff prompt; minimal tools.core allowlist back; maxSessionTurns=20; gemini_debug=true kept for one more verification cycle)
     with:
       # Same SHA as the `uses:` ref above. See claude-review.yml
       # in this repo for why the duplication is unavoidable
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
-      ai-review-prompts-ref: d446b4c68bb02068ede471ad5ac34c9af380bdfb
+      ai-review-prompts-ref: fa9ba10643037ef9d42b2a6b954617cd411317b3
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -34,13 +34,13 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@128656e40c87c0e1293c542a5500df4f68dbff85 # main 2026-05-12 (post #25 — workflow posts Gemini response, output-name fix, default model gemini-3-flash-preview)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@d446b4c68bb02068ede471ad5ac34c9af380bdfb # main 2026-05-13 (post #30/#31/#32 — MCP pivot + debug-iteration: gemini_debug=true, no tools.core allowlist, maxSessionTurns=30 to surface what's happening with MCP registration and shell denials)
     with:
       # Same SHA as the `uses:` ref above. See claude-review.yml
       # in this repo for why the duplication is unavoidable
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
-      ai-review-prompts-ref: 128656e40c87c0e1293c542a5500df4f68dbff85
+      ai-review-prompts-ref: d446b4c68bb02068ede471ad5ac34c9af380bdfb
       review-layers: |
         universal
         harper/common


### PR DESCRIPTION
Claude-only after split — original PR scope also bumped `gemini-review.yml` in lockstep; split out for separate handling since the Gemini reviewer has ongoing reliability issues being worked separately.

## Pickups from ai-review-prompts main

- **#37**: `harper/common.md` calibration update — "Meta-checks (run these before tracing internals)" section + reuse / CI hygiene / lockfile drift bullets.
- **#38**: label-gated review for bot-authored PRs (`claude-review` label as opt-in gesture). Claude-only.
- **#39 / #40**: #39's workflow-level `permissions: {}` on reusables broke reusable callers; #40 reverted it. Net: reusable side unchanged from pre-#39 state.

## Changes (claude-review.yml only)

- Pin: `20c2157` → `f22bf7d`.
- `pull_request: types:` adds `labeled` so the `claude-review` label fires the bot-PR gesture.
- **Caller-side `permissions:` block at the calling-job level**:

```yaml
jobs:
  review:
    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@<sha>
    permissions:
      contents: read
      pull-requests: write
      id-token: write
```

Union of what the reusable's two jobs (`authorize`: `contents: read`; `review`: `contents: read + pull-requests: write + id-token: write`) need. Placement at the calling-job level — NOT workflow-level — is the [documented canonical pattern](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations).

## Empirical verification (prior to split)

Before the split, this PR's CI ran with the same caller-side permissions pattern:

- ✅ `review / authorize` — **passed** (~10s)
- ✅ `review / review` — **started successfully**, ran for 34s
- ❌ `review / review` — bailed at the end with the upstream OIDC ref-validation gotcha ("workflow file must exist and have identical content to the version on the repository's default branch... this is normal and you should ignore this error")

That's the proof we wanted: workflow gets past startup, both jobs spin up, only the upstream's documented PR-modifies-own-workflow check bails. Once merged, the next non-workflow-modifying PR exercises the full review path normally.

## Prerequisite (already applied via `gh label create`)

- `claude-review` label exists on this repo.

## Not in this PR (queued)

- Bumping `gemini-review.yml` to the new pin — deferred until the Gemini reviewer's reliability issues clear up.
- Same hardening pattern on harper-pro and harper — will roll after this merges and a non-workflow-modifying PR confirms end-to-end behavior on oauth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)