### PR TITLE
ci(claude-review): bump pin to f22bf7d + label-gated review + scoped caller permissions

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,7 +16,9 @@ name: Claude PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # `labeled` admits the `claude-review` label gesture for
+    # bot-authored PRs (renovate, dependabot). See ai-review-prompts#38.
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
@@ -24,7 +26,21 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@128656e40c87c0e1293c542a5500df4f68dbff85 # main 2026-05-12 (post #25 — symmetric pin with gemini-review.yml; picks up shared-script refactor and authorize-ai-workflow.sh rename)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@f22bf7dcb7d22d5de94c938daa9d790f2b5c776b # main 2026-05-18 (post #37 + #38 + #40 — calibration layer update + label-gated bot-PR review; gemini-review.yml pin intentionally NOT in lockstep here — Gemini reviewer has known issues being worked separately, no need to drag it along)
+    # Caller-side permissions, scoped at the calling-job level (NOT
+    # workflow-level — that placement caps the reusable's per-job
+    # grants below what they need and breaks the workflow at startup;
+    # see ai-review-prompts#39/#40 for the incident). Union of what
+    # the reusable's `authorize` (`contents: read`) and `review`
+    # (`contents: read + pull-requests: write + id-token: write`)
+    # jobs declare. GitHub's rule: caller's GITHUB_TOKEN permissions
+    # can only be DOWNGRADED (not elevated) by the called workflow,
+    # so the caller must grant at least the union the reusable needs.
+    # Reference: https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (layer files + bash
@@ -35,7 +51,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 128656e40c87c0e1293c542a5500df4f68dbff85
+      ai-review-prompts-ref: f22bf7dcb7d22d5de94c938daa9d790f2b5c776b
       review-layers: |
         universal
         harper/common


### PR DESCRIPTION
**Supersedes #84.** Clean branch from main with ONLY the Claude work — no gemini-review.yml bump, no gemini-review-debug.yml artifact, no leftover commits from the Gemini iteration sessions.

## Pickups from ai-review-prompts main

Catches up oauth's claude-review.yml from `128656e4` to `f22bf7d`:

- **#37**: `harper/common.md` calibration update — "Meta-checks (run these before tracing internals)" section + reuse / CI hygiene / lockfile drift bullets.
- **#38**: label-gated review for bot-authored PRs (`claude-review` label as opt-in gesture). Claude-only.
- **#40**: the revert of #39's broken workflow-level `permissions: {}`. Net: reusable side unchanged from pre-#39 verified-working state.

## Changes

Single-file change to `claude-review.yml`:

- Pin: `128656e4` → `f22bf7d`.
- `pull_request: types:` adds `labeled` so the `claude-review` label fires the bot-PR gesture.
- **Caller-side `permissions:` block at the calling-job level**:

```yaml
jobs:
  review:
    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@<sha>
    permissions:
      contents: read
      pull-requests: write
      id-token: write
```

Union of what the reusable's two jobs (`authorize`: `contents: read`; `review`: `contents: read + pull-requests: write + id-token: write`) need. Placement at the calling-job level — not workflow-level — per [GitHub's canonical pattern](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations).

## Empirical verification (from the superseded #84)

Same caller-side pattern was already run on #84's CI:

- ✅ `review / authorize` — **passed** (~10s)
- ✅ `review / review` — **started successfully**, ran for 34s
- ❌ `review / review` — bailed at the end with the documented upstream OIDC ref-validation gotcha (workflow-modifying PR — _"this is normal and you should ignore this error"_)

That's proof the permissions pattern gets the workflow past startup and into the reusable's jobs. Once merged, the next non-workflow-modifying PR exercises the full review path normally.

## Prerequisite (already applied via `gh label create`)

- `claude-review` label exists on this repo.

## Not in this PR (queued separately)

- **gemini-review.yml pin bump** — deferred until the Gemini reviewer's reliability issues clear up.
- **Same hardening on harper-pro and harper** — will roll after this lands and a non-workflow-modifying PR confirms end-to-end behavior on oauth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)