### PR TITLE
Bump both reviewer pins to ai-review-prompts@ea19009

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@f22bf7dcb7d22d5de94c938daa9d790f2b5c776b # main 2026-05-18 (post #37 + #38 + #40 — calibration layer update + label-gated bot-PR review; gemini-review.yml pin intentionally NOT in lockstep here — Gemini reviewer has known issues being worked separately, no need to drag it along)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@ea190091328bcee674c4739ccc97dda177ecf0c5 # main 2026-05-20 (post #41 — Gemini calibration promoted; both reviewers back in lockstep on the same ai-review-prompts SHA, no _claude-review.yml changes vs the prior pin)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job
     # grants below what they need and breaks the workflow at startup;
@@ -51,7 +51,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: f22bf7dcb7d22d5de94c938daa9d790f2b5c776b
+      ai-review-prompts-ref: ea190091328bcee674c4739ccc97dda177ecf0c5
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -34,13 +34,13 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@128656e40c87c0e1293c542a5500df4f68dbff85 # main 2026-05-12 (post #25 — workflow posts Gemini response, output-name fix, default model gemini-3-flash-preview)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@ea190091328bcee674c4739ccc97dda177ecf0c5 # main 2026-05-20 (post #41 — Gemini calibration from oauth#87 promoted; single-shot supersedes the MCP rewrite, prior-body continuity, marker-check robustness)
     with:
       # Same SHA as the `uses:` ref above. See claude-review.yml
       # in this repo for why the duplication is unavoidable
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
-      ai-review-prompts-ref: 128656e40c87c0e1293c542a5500df4f68dbff85
+      ai-review-prompts-ref: ea190091328bcee674c4739ccc97dda177ecf0c5
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -35,6 +35,22 @@ concurrency:
 jobs:
   review:
     uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@ea190091328bcee674c4739ccc97dda177ecf0c5 # main 2026-05-20 (post #41 — Gemini calibration from oauth#87 promoted; single-shot supersedes the MCP rewrite, prior-body continuity, marker-check robustness)
+    # Caller-side permissions, scoped at the calling-job level (NOT
+    # workflow-level — that placement caps the reusable's per-job
+    # grants below what they need and breaks the workflow at startup;
+    # see ai-review-prompts#39/#40 for the incident). Union of what
+    # the reusable's `authorize` (`contents: read`) and `review`
+    # (`contents: read + pull-requests: write + id-token: write`)
+    # jobs declare. GitHub's rule: caller's GITHUB_TOKEN permissions
+    # can only be DOWNGRADED (not elevated) by the called workflow,
+    # so the caller must grant at least the union the reusable needs.
+    # Mirrors claude-review.yml in this repo — surfaced as a finding
+    # by Gemini's own review on PR #88.
+    # Reference: https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     with:
       # Same SHA as the `uses:` ref above. See claude-review.yml
       # in this repo for why the duplication is unavoidable


### PR DESCRIPTION
## Summary

Adopts the promoted Gemini calibration ([ai-review-prompts#41](https://github.com/HarperFast/ai-review-prompts/pull/41)) and restores both reviewers to a single shared pin (``ea190091328bcee674c4739ccc97dda177ecf0c5``).

## Gemini changes vs the prior pin (``128656e40``)

- **Single-shot architecture validated empirically** over 5 iteration rounds in #87 (``gemini/inline-calibrate``). The ai-review-prompts main branch had drifted onto an MCP-based rewrite that nothing in production was using; #41 replaces it with the calibrated single-shot.
- **Prior-review body injection for continuity** — the workflow now fetches the prior comment body when one exists and the prior had ``### N.``-shaped findings, and injects it into the prompt as a "Continuity reference" section. Skipped on no-blockers priors so the model isn't primed to hunt for issues against uninformative context.
- **Prompt's "your output IS the PR comment" section reworded** to allow shell/file research tools (``gemini-cli`` has them by default and the model does use them to research the diff) while still forbidding self-posting (the workflow handles posting). Resolves a latent self-contradicting prompt that surfaced as a finding once the calibration loop got fast enough to see it.
- **``post-review-comment.sh`` marker check now strips leading whitespace** from the first non-blank line so a non-whitespace-stable provider can't break the marker check.

## Claude lockstep restored

``_claude-review.yml`` is byte-identical between ``f22bf7d`` and ``ea19009`` in ai-review-prompts (the divergence period only touched Gemini files). Bumping Claude's pin in lockstep is a no-op for Claude behavior but restores both reviewers to a single shared upgrade motion — the "intentionally NOT in lockstep" comment from the divergence period is replaced with a note that lockstep is restored.

## Follow-ups

- [ ] PR #87 (``gemini/inline-calibrate``) is now superseded by this PR — will close without merging once this lands.
- [ ] Test the production setup on the meaty open issue.

## Test plan

- [ ] Both ``claude-review`` and ``gemini-review`` workflows fire on this PR
- [ ] Claude posts a "Reviewed; no blockers found" (or reasonable equivalent) — the change is pin bumps only, no logic changes
- [ ] Gemini posts a "Reviewed; no blockers found" (or reasonable equivalent) — same
- [ ] Both review-log entries thread correctly (per-PR, per-provider issues with the right markers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)