### PR TITLE
Bump both reviewer pins to ai-review-prompts@533f841

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@ea190091328bcee674c4739ccc97dda177ecf0c5 # main 2026-05-20 (post #41 — Gemini calibration promoted; both reviewers back in lockstep on the same ai-review-prompts SHA, no _claude-review.yml changes vs the prior pin)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@533f841137114315b0b4d02dabf367e376d9922e # main 2026-05-21 (post #42 — log-script counts from "N blockers found" line + tolerates markdown wrapping, fixing Claude-recap titles undercounting; _claude-review.yml itself unchanged)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job
     # grants below what they need and breaks the workflow at startup;
@@ -51,7 +51,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: ea190091328bcee674c4739ccc97dda177ecf0c5
+      ai-review-prompts-ref: 533f841137114315b0b4d02dabf367e376d9922e
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@ea190091328bcee674c4739ccc97dda177ecf0c5 # main 2026-05-20 (post #41 — Gemini calibration from oauth#87 promoted; single-shot supersedes the MCP rewrite, prior-body continuity, marker-check robustness)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@533f841137114315b0b4d02dabf367e376d9922e # main 2026-05-21 (post #42 — continuity preamble now mandatory when prior findings exist so Gemini updates narrate the round, plus log-script count-line fix)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job
     # grants below what they need and breaks the workflow at startup;
@@ -56,7 +56,7 @@ jobs:
       # in this repo for why the duplication is unavoidable
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
-      ai-review-prompts-ref: ea190091328bcee674c4739ccc97dda177ecf0c5
+      ai-review-prompts-ref: 533f841137114315b0b4d02dabf367e376d9922e
       review-layers: |
         universal
         harper/common


### PR DESCRIPTION
## Summary

Adopts [HarperFast/ai-review-prompts#42](https://github.com/HarperFast/ai-review-prompts/pull/42) — two production-PR-driven fixes from oauth#89's first real run.

### 1. Log script counts from the standardized count line

ai-review-prompts#42 changes ``log-review-to-ai-review-log.sh`` to count findings from the ``N blockers found.`` / ``Reviewed; no blockers found.`` line both reviewers' prompts emit, with header-counting (``^### [0-9]\.``) as the fallback for unknown formats. The new regex also tolerates optional markdown wrapping (``**2 blockers found.**`` / ``_1 blocker found._``).

The prior ``^### [0-9]\.`` regex undercounted on Claude's evolved inline-comment + terse-recap pattern. On oauth#89, Claude posted 2 inline blockers + a top-level recap formatted as ``1. **path:line** — short. See inline.``, but the ai-review-log title said ``no blockers``. Now it'll title as ``2 finding(s) — triage pending`` matching the actual count.

### 2. Gemini continuity preamble now mandatory

Round 2 on oauth#89 showed Gemini correctly behaving with continuity (dropping resolved findings, adding new ones) but not narrating it. Claude's parallel comment said ``Reviewed; no blockers found. All three findings from the prior run are addressed in acc5147.`` Gemini just posted the new finding with no preamble — the updated comment read like an unrelated fresh review.

ai-review-prompts#42 tightens the Gemini prompt: when the continuity-reference section is non-empty, the top-level summary line must append a brief continuity note on the same line as the count:

    Reviewed; no blockers found. Prior <K> finding(s) resolved by <sha>.
    N blockers found. Prior <K> resolved by <sha>; new findings below.

Same-line so the ``^[0-9]+ blockers? found`` count-line pattern still matches for fix #1.

## Pin bump scope

Both reviewer callers move in lockstep. ``_claude-review.yml`` is byte-identical between ``ea19009`` and ``533f841``; Claude behavior is unchanged. ``_gemini-review.yml`` gets the tightened continuity prompt.

## Test plan

- [ ] Both ``claude-review`` and ``gemini-review`` workflows fire on this PR
- [ ] On a follow-up push (to test continuity), Gemini's updated comment leads with a continuity acknowledgment
- [ ] The ai-review-log issue titles correctly reflect finding counts on both providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)