### PR TITLE
Add integration test: OAuth Resource path-segment routing

### DIFF
--- a/integrationTests/fixtures/path-segment-routing-app/config.yaml
+++ b/integrationTests/fixtures/path-segment-routing-app/config.yaml
@@ -3,9 +3,19 @@
 #
 # Two providers are configured with distinctive client_ids. A request to
 # /oauth/<name>/login should redirect with that provider's client_id. If
-# parseRoute were to extract the literal "oauth" path segment (the symptom
-# Dawson reported on 2026-05-22 from CM/Studio), the request would route
-# to the provider literally named "oauth" and we'd see the wrong client_id.
+# parseRoute were to extract the literal "oauth" path segment as providerName
+# (the symptom Dawson reported on 2026-05-22 from CM/Studio), the request
+# would NOT produce a tenant-shaped 302 — it would either route to the
+# oauth-named decoy provider with action='oac-oauth-tenant' (an unknown
+# action → 404) or route to some other unintended state. The exact failure
+# shape depends on parseRoute's specific regression; the assertion only
+# requires that the tenant.test authorizationUrl + tenant client_id
+# appear in the redirect.
+#
+# The tenant provider name deliberately contains the substring "oauth" so
+# this fixture also guards against an over-aggressive stripping regression
+# (e.g., parseRoute mangling /oauth/ matches that occur inside the segment
+# rather than only at the prefix).
 
 rest: true
 
@@ -14,7 +24,7 @@ rest: true
   providers:
     # Provider literally named "oauth" — present specifically as a decoy.
     # If parseRoute is broken and treats "oauth" as the providerName, this
-    # is what would (incorrectly) handle requests for other tenants.
+    # is what would (incorrectly) be selected as the provider.
     oauth:
       provider: generic
       clientId: ${OAUTH_DECOY_CLIENT_ID}
@@ -23,7 +33,9 @@ rest: true
       tokenUrl: 'http://decoy.test/token'
       userInfoUrl: 'http://decoy.test/userinfo'
     # Tenant-style provider with a distinctive client_id we can assert on.
-    oac-tenant-acme:
+    # The name contains "oauth" as a substring to catch over-aggressive
+    # path-stripping regressions in addition to the prefix-extraction case.
+    oac-oauth-tenant:
       provider: generic
       clientId: ${OAUTH_TENANT_CLIENT_ID}
       clientSecret: tenant-secret

--- a/integrationTests/fixtures/path-segment-routing-app/config.yaml
+++ b/integrationTests/fixtures/path-segment-routing-app/config.yaml
@@ -1,0 +1,32 @@
+# Integration test fixture: verifies the OAuth Resource correctly extracts
+# the providerName from the URL path segment, NOT the literal "oauth" prefix.
+#
+# Two providers are configured with distinctive client_ids. A request to
+# /oauth/<name>/login should redirect with that provider's client_id. If
+# parseRoute were to extract the literal "oauth" path segment (the symptom
+# Dawson reported on 2026-05-22 from CM/Studio), the request would route
+# to the provider literally named "oauth" and we'd see the wrong client_id.
+
+rest: true
+
+'@harperfast/oauth':
+  package: '@harperfast/oauth'
+  providers:
+    # Provider literally named "oauth" — present specifically as a decoy.
+    # If parseRoute is broken and treats "oauth" as the providerName, this
+    # is what would (incorrectly) handle requests for other tenants.
+    oauth:
+      provider: generic
+      clientId: ${OAUTH_DECOY_CLIENT_ID}
+      clientSecret: decoy-secret
+      authorizationUrl: 'http://decoy.test/authorize'
+      tokenUrl: 'http://decoy.test/token'
+      userInfoUrl: 'http://decoy.test/userinfo'
+    # Tenant-style provider with a distinctive client_id we can assert on.
+    oac-tenant-acme:
+      provider: generic
+      clientId: ${OAUTH_TENANT_CLIENT_ID}
+      clientSecret: tenant-secret
+      authorizationUrl: 'http://tenant.test/authorize'
+      tokenUrl: 'http://tenant.test/token'
+      userInfoUrl: 'http://tenant.test/userinfo'

--- a/integrationTests/fixtures/path-segment-routing-app/package.json
+++ b/integrationTests/fixtures/path-segment-routing-app/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "path-segment-routing-app-fixture",
+	"private": true,
+	"type": "module",
+	"description": "Integration-test fixture for OAuth Resource path-segment routing. The @harperfast/oauth dep is installed at test setup time via scripts/install-fixtures.js (npm pack + install); harper is resolved from the repo root."
+}

--- a/integrationTests/path-segment-routing.test.ts
+++ b/integrationTests/path-segment-routing.test.ts
@@ -4,17 +4,18 @@
  *
  *   "providerName is 'oauth', not the {configId} described, that isn't passed"
  *
- * Diagnosis would be that the plugin extracts the literal "oauth" path
- * prefix as providerName instead of the segment after it. If true, requests
- * to /oauth/<tenantId>/login would dispatch to the provider literally named
- * "oauth" regardless of what tenantId the caller asked for.
+ * If parseRoute extracted the literal "oauth" path prefix as providerName
+ * (rather than the segment after it), requests to /oauth/<tenantId>/login
+ * would resolve to whatever provider is registered under the name "oauth" —
+ * with the rest of the URL becoming the action — and would NOT produce the
+ * expected tenant-shaped 302.
  *
- * This test configures TWO providers — one literally named "oauth" (a
- * decoy) and one named "oac-tenant-acme" — with distinctive client_ids,
- * then asserts a request to /oauth/oac-tenant-acme/login redirects with
- * the TENANT's client_id, not the decoy's. If parseRoute ever regresses
- * into returning the literal "oauth" segment, the assertion will fail
- * because the decoy provider's authorization URL would be used.
+ * This test configures two providers — one literally named "oauth" (a decoy)
+ * and one named "oac-oauth-tenant" (deliberately containing the substring
+ * "oauth" to also catch over-aggressive stripping) — with distinctive
+ * client_ids, then asserts that /oauth/oac-oauth-tenant/login redirects to
+ * the tenant provider's authorizationUrl with the tenant's client_id. Any
+ * regression that breaks path-segment routing will fail this assertion.
  */
 import { suite, test, before, after } from 'node:test';
 import { strictEqual } from 'node:assert/strict';
@@ -30,7 +31,7 @@ function getHarperBinPath(): string {
 
 const fixturePath = join(import.meta.dirname, 'fixtures', 'path-segment-routing-app');
 
-const TENANT_CLIENT_ID = 'tenant-acme-client-id';
+const TENANT_CLIENT_ID = 'oauth-tenant-client-id';
 const DECOY_CLIENT_ID = 'decoy-oauth-client-id';
 
 suite('OAuth Resource routes by URL path segment (not literal "oauth")', (ctx: ContextWithHarper) => {
@@ -49,8 +50,8 @@ suite('OAuth Resource routes by URL path segment (not literal "oauth")', (ctx: C
 		await teardownHarper(ctx);
 	});
 
-	test('/oauth/oac-tenant-acme/login dispatches to the tenant provider', async () => {
-		const response = await fetch(`${ctx.harper.httpURL}/oauth/oac-tenant-acme/login`, {
+	test('/oauth/oac-oauth-tenant/login dispatches to the tenant provider', async () => {
+		const response = await fetch(`${ctx.harper.httpURL}/oauth/oac-oauth-tenant/login`, {
 			redirect: 'manual',
 		});
 
@@ -60,13 +61,11 @@ suite('OAuth Resource routes by URL path segment (not literal "oauth")', (ctx: C
 		const url = new URL(location!);
 
 		// The tenant provider's authorizationUrl is http://tenant.test/authorize;
-		// the decoy's is http://decoy.test/authorize. If parseRoute returned
-		// "oauth" instead of "oac-tenant-acme", we'd land at decoy.test.
-		strictEqual(
-			url.origin + url.pathname,
-			'http://tenant.test/authorize',
-			`request was routed to ${url.origin} — expected tenant.test (decoy is decoy.test)`
-		);
+		// the decoy's is http://decoy.test/authorize. A parseRoute that returned
+		// "oauth" as providerName would either 404 (action mismatch) or pull
+		// the decoy's client_id — both fail these assertions.
+		strictEqual(url.origin, 'http://tenant.test');
+		strictEqual(url.pathname, '/authorize');
 		strictEqual(
 			url.searchParams.get('client_id'),
 			TENANT_CLIENT_ID,

--- a/integrationTests/path-segment-routing.test.ts
+++ b/integrationTests/path-segment-routing.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression guard for the symptom Dawson reported on 2026-05-22 (CM/Studio
+ * Okta SSO):
+ *
+ *   "providerName is 'oauth', not the {configId} described, that isn't passed"
+ *
+ * Diagnosis would be that the plugin extracts the literal "oauth" path
+ * prefix as providerName instead of the segment after it. If true, requests
+ * to /oauth/<tenantId>/login would dispatch to the provider literally named
+ * "oauth" regardless of what tenantId the caller asked for.
+ *
+ * This test configures TWO providers — one literally named "oauth" (a
+ * decoy) and one named "oac-tenant-acme" — with distinctive client_ids,
+ * then asserts a request to /oauth/oac-tenant-acme/login redirects with
+ * the TENANT's client_id, not the decoy's. If parseRoute ever regresses
+ * into returning the literal "oauth" segment, the assertion will fail
+ * because the decoy provider's authorization URL would be used.
+ */
+import { suite, test, before, after } from 'node:test';
+import { strictEqual } from 'node:assert/strict';
+import { join, dirname } from 'node:path';
+import { createRequire } from 'node:module';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+
+const require = createRequire(import.meta.url);
+
+function getHarperBinPath(): string {
+	return join(dirname(require.resolve('harper')), 'bin', 'harper.js');
+}
+
+const fixturePath = join(import.meta.dirname, 'fixtures', 'path-segment-routing-app');
+
+const TENANT_CLIENT_ID = 'tenant-acme-client-id';
+const DECOY_CLIENT_ID = 'decoy-oauth-client-id';
+
+suite('OAuth Resource routes by URL path segment (not literal "oauth")', (ctx: ContextWithHarper) => {
+	before(async () => {
+		await setupHarperWithFixture(ctx, fixturePath, {
+			harperBinPath: getHarperBinPath(),
+			env: {
+				OAUTH_TENANT_CLIENT_ID: TENANT_CLIENT_ID,
+				OAUTH_DECOY_CLIENT_ID: DECOY_CLIENT_ID,
+			},
+			config: { logging: { stdStreams: true } },
+		});
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	test('/oauth/oac-tenant-acme/login dispatches to the tenant provider', async () => {
+		const response = await fetch(`${ctx.harper.httpURL}/oauth/oac-tenant-acme/login`, {
+			redirect: 'manual',
+		});
+
+		strictEqual(response.status, 302, `expected 302 redirect, got ${response.status}`);
+		const location = response.headers.get('location');
+		strictEqual(typeof location, 'string', 'Location header missing');
+		const url = new URL(location!);
+
+		// The tenant provider's authorizationUrl is http://tenant.test/authorize;
+		// the decoy's is http://decoy.test/authorize. If parseRoute returned
+		// "oauth" instead of "oac-tenant-acme", we'd land at decoy.test.
+		strictEqual(
+			url.origin + url.pathname,
+			'http://tenant.test/authorize',
+			`request was routed to ${url.origin} — expected tenant.test (decoy is decoy.test)`
+		);
+		strictEqual(
+			url.searchParams.get('client_id'),
+			TENANT_CLIENT_ID,
+			`client_id was ${url.searchParams.get('client_id')} — expected tenant's (${TENANT_CLIENT_ID}), decoy's is ${DECOY_CLIENT_ID}`
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Adds an integration test that asserts the OAuth Resource correctly routes by URL path segment (the provider name from the URL) and not by the literal `oauth` prefix.

Originally motivated by Dawson's report from 2026-05-22 (CM/Studio Okta SSO):

> the oauth plugin doesn't appear to consider the providerName in the way you programmed in central manager
> providerName is "oauth", not the {configId} described, that isn't passed

The new test configures **two static providers** — one literally named `"oauth"` (a decoy) and one named `"oac-tenant-acme"` with a distinctive `client_id` — then fires `GET /oauth/oac-tenant-acme/login` and asserts the redirect went to the tenant provider's `authorizationUrl` with the tenant's `client_id`. If `parseRoute` ever regressed into Dawson's described behavior, the decoy provider would handle the request and the assertion would fail.

## Investigation result

**The test PASSES on `main` + Harper 5.0.7.** When I temporarily logged `target.id` inside `parseRoute`, Harper v5 was passing `"oac-fake-12345/login"` (i.e. the `/oauth/` resource mount prefix already stripped). So on this stack, `providerName` is correctly the URL path segment — Dawson's diagnosis is not reproducible in this code path.

That doesn't rule the bug out for Dawson's stack:

- **v1.x / Harper v4 isn't covered.** CM (`central-manager`, `main`) consumes `@harperfast/oauth ^1.4.0` against `harperdb ^4.7.28`. `parseRoute` is byte-for-byte identical between v1.4.0 and `main`, but **Harper v4 may surface `target.id` differently than v5**. Porting this test to the `v1.x` line would require bootstrapping `@harperfast/integration-testing` against `harperdb` (its peer dep is `harper ^5.0.0`), so we deferred that for now.
- **The session-middleware path isn't covered.** `src/index.ts:226` calls the resolver with `request.session.oauth.providerConfigId` — session data, not URL-derived. A stale session containing `providerConfigId === 'oauth'` would invoke CM's resolver with `'oauth'` and produce the exact symptom Dawson observed, independent of any routing bug.
- **The 500 Dawson saw is unexplained.** `Failed to resolve OAuth provider` (`resource.ts:343-346`) only fires when the hook *throws*; a hook returning `null` produces a 404. There's a separate exception path on the CM side worth tracking down.

## Why no fix in this PR

`oauth#101` proposes stripping a leading `oauth` segment in `parseRoute` defensively. Given this test passes without that change, the patch is unnecessary on `main` and would actively break a provider literally named `oauth` (which is the decoy this test now exercises).

## Test plan

- [x] `npm run install:fixtures && npm run test:integration` — both suites pass (env-var + new path-segment-routing).
- [ ] (Out of scope for this PR) Reproduce or rule out on `v1.x` + Harper v4.
- [ ] (Out of scope for this PR) Inspect Dawson's session data for `providerConfigId === 'oauth'` to confirm the session-middleware hypothesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)