### PR TITLE
Address #106/#107 review: Set of active provider caches + doc fixes (v1.x)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -227,6 +227,55 @@ registerHooks({
 
 ---
 
+### invalidateDynamicProvider()
+
+Evict a single dynamically-resolved provider (one resolved via the `onResolveProvider` hook) from the in-memory cache, so the next request re-resolves it via the hook. Call this after the backing config for `providerConfigId` changes — disabled, deleted, or credentials rotated — to make the change take effect without waiting out the cache TTL.
+
+**Import:**
+
+```javascript
+import { invalidateDynamicProvider } from '@harperfast/oauth';
+```
+
+**Signature:**
+
+```typescript
+function invalidateDynamicProvider(providerConfigId: string): boolean;
+```
+
+Returns `true` if a cached entry was present and removed in this worker thread.
+
+**Example:**
+
+```javascript
+// After updating an org's OAuth config in your datastore:
+invalidateDynamicProvider(configId);
+```
+
+**Note:** The cache is per-worker-thread, so this evicts only in the thread that runs the call. Other worker threads converge within the configured `cacheDynamicProviders` TTL (default 300s). For immediate cluster-wide effect, pair invalidation with a short TTL.
+
+---
+
+### clearDynamicProviderCache()
+
+Clear **all** dynamically-resolved providers from the in-memory cache (in the calling worker thread). Useful when many configs change at once.
+
+**Import:**
+
+```javascript
+import { clearDynamicProviderCache } from '@harperfast/oauth';
+```
+
+**Signature:**
+
+```typescript
+function clearDynamicProviderCache(): void;
+```
+
+**Note:** Same per-worker-thread caveat as `invalidateDynamicProvider()`.
+
+---
+
 ## Session Structure
 
 The OAuth plugin stores the following data in `request.session`:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,12 +20,12 @@ Complete configuration options for the `@harperfast/oauth` plugin.
 
 ### Global Options
 
-| Option                  | Type              | Default    | Description                                                                                                       |
-| ----------------------- | ----------------- | ---------- | ----------------------------------------------------------------------------------------------------------------- |
-| `debug`                 | boolean           | `false`    | Enable debug endpoints and logging                                                                                |
-| `redirectUri`           | string            | (auto-gen) | OAuth callback URL where providers redirect back to                                                               |
-| `postLoginRedirect`     | string            | `/`        | Default URL to redirect users after successful OAuth login                                                        |
-| `cacheDynamicProviders` | boolean \| number | `true`     | Cache providers resolved via `onResolveProvider` hook. `true` = forever, `false` = never, number = TTL in seconds |
+| Option                  | Type              | Default    | Description                                                                                                                                                                                                        |
+| ----------------------- | ----------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `debug`                 | boolean           | `false`    | Enable debug endpoints and logging                                                                                                                                                                                 |
+| `redirectUri`           | string            | (auto-gen) | OAuth callback URL where providers redirect back to                                                                                                                                                                |
+| `postLoginRedirect`     | string            | `/`        | Default URL to redirect users after successful OAuth login                                                                                                                                                         |
+| `cacheDynamicProviders` | boolean \| number | `300`      | Cache providers resolved via `onResolveProvider` hook. `true` = forever, `false` = never, number = TTL in seconds. Defaults to 300s (bounded) so a disabled/rotated provider stops being served without a restart. |
 
 ### Provider Configuration
 

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -142,14 +142,15 @@ async function resolveOAuthProvider(providerName, logger) {
 
 **Caching Behavior:**
 
-By default, the plugin caches the resolved provider config in memory permanently after the first `onResolveProvider` call. This is efficient but means config changes (domain, credentials, etc.) won't take effect until server restart.
+By default, the plugin caches the resolved provider config in memory for **300 seconds** after each `onResolveProvider` call. This avoids a hook/database lookup on every request while bounding how long a stale config (changed domain, credentials, or a disabled provider) is served — at most one TTL window, rather than until a server restart. For immediate effect, call `invalidateDynamicProvider()` from your app when the backing config changes (see the API reference).
 
 Control caching with `cacheDynamicProviders` in your plugin config:
 
 ```yaml
 '@harperfast/oauth':
-  cacheDynamicProviders: true   # Cache forever (default)
+  cacheDynamicProviders: 300    # Cache for 300 seconds (default)
   cacheDynamicProviders: 60     # Cache for 60 seconds (recommended for multi-tenant)
+  cacheDynamicProviders: true   # Cache forever — only safe if you call invalidateDynamicProvider() on change
   cacheDynamicProviders: false  # Never cache — hook called on every request
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,34 +39,44 @@ export { getProvider } from './lib/providers/index.ts';
 let pendingHooks: OAuthHooks | null = null;
 let activeHookManager: HookManager | null = null;
 
-// Active dynamic-provider cache for the loaded plugin instance, so consumers
-// can invalidate entries when their backing config changes. Per-worker-thread:
-// this references the cache in the thread that ran handleApplication.
-let activeDynamicProviderCache: DynamicProviderCache | null = null;
+// Active dynamic-provider caches for every plugin instance loaded in this worker
+// thread, so consumers can invalidate entries when their backing config changes.
+// A Set (not a single reference) so multiple plugin instances in one thread each
+// stay invalidatable and closing one doesn't orphan the others' caches.
+// Per-worker-thread: these are the caches in the thread that ran handleApplication;
+// other threads converge via the cache TTL.
+const activeDynamicProviderCaches = new Set<DynamicProviderCache>();
 
 /**
- * Invalidate a single dynamically-resolved provider in the in-memory cache.
- * Call this from application code after the backing config for `providerConfigId`
- * changes (disabled, deleted, or credentials rotated) so the next request
- * re-resolves it via the `onResolveProvider` hook instead of serving stale data.
+ * Invalidate a single dynamically-resolved provider across every plugin instance
+ * loaded in this worker thread. Call this from application code after the backing
+ * config for `providerConfigId` changes (disabled, deleted, or credentials
+ * rotated) so the next request re-resolves it via the `onResolveProvider` hook
+ * instead of serving stale data.
  *
- * NOTE: the cache is per-worker-thread, so this evicts only in the thread that
+ * NOTE: the caches are per-worker-thread, so this evicts only in the thread that
  * runs the call. Other threads converge within the configured TTL
  * (`cacheDynamicProviders`, default {@link DEFAULT_DYNAMIC_PROVIDER_CACHE_TTL_SECONDS}s).
  * For immediate cluster-wide effect, pair invalidation with a short TTL.
  *
- * @returns true if an entry was present and removed in this thread.
+ * @returns true if an entry was present and removed in any instance in this thread.
  */
 export function invalidateDynamicProvider(providerConfigId: string): boolean {
-	return activeDynamicProviderCache?.delete(providerConfigId) ?? false;
+	let deleted = false;
+	for (const cache of activeDynamicProviderCaches) {
+		if (cache.delete(providerConfigId)) deleted = true;
+	}
+	return deleted;
 }
 
 /**
- * Clear every dynamically-resolved provider from the in-memory cache (this
- * worker thread only — see {@link invalidateDynamicProvider} for cross-thread notes).
+ * Clear every dynamically-resolved provider from every plugin instance's cache in
+ * this worker thread (see {@link invalidateDynamicProvider} for cross-thread notes).
  */
 export function clearDynamicProviderCache(): void {
-	activeDynamicProviderCache?.clear();
+	for (const cache of activeDynamicProviderCaches) {
+		cache.clear();
+	}
 }
 
 /**
@@ -113,9 +123,6 @@ export async function handleApplication(scope: Scope): Promise<void> {
 	let isInitialized = false;
 	let pluginDefaults: any = {}; // Store plugin defaults for dynamic provider resolution
 	const dynamicProviderCache = new DynamicProviderCache(); // TTL cache for dynamically-resolved providers
-
-	// Expose this thread's cache for consumer-driven invalidation
-	activeDynamicProviderCache = dynamicProviderCache;
 
 	// Create hookManager instance scoped to this application
 	const hookManager = new HookManager(logger);
@@ -313,10 +320,14 @@ export async function handleApplication(scope: Scope): Promise<void> {
 	});
 
 	// Clean up on scope close
+	// Expose this thread's cache for consumer-driven invalidation, paired with its
+	// removal on close. Registered here (after the initial config load above, which
+	// propagates errors to the plugin loader) so a failed init never leaves an
+	// orphaned cache in the set. The request middleware uses the closure reference
+	// directly, so it doesn't depend on set membership.
+	activeDynamicProviderCaches.add(dynamicProviderCache);
 	scope.on('close', () => {
 		logger?.info?.('OAuth plugin shutting down');
-		if (activeDynamicProviderCache === dynamicProviderCache) {
-			activeDynamicProviderCache = null;
-		}
+		activeDynamicProviderCaches.delete(dynamicProviderCache);
 	});
 }

--- a/test/dynamic-provider-invalidation.test.js
+++ b/test/dynamic-provider-invalidation.test.js
@@ -1,14 +1,16 @@
 /**
  * Tests for the module-level dynamic-provider cache invalidation wiring in
  * src/index.ts: invalidateDynamicProvider(), clearDynamicProviderCache(), and
- * the scope-close ownership guard. The DynamicProviderCache class itself is
- * covered in test/lib/dynamicProviderCache.test.js — this exercises the
- * handleApplication wiring around it.
+ * the set of active caches (added on handleApplication, removed on scope close).
+ * The DynamicProviderCache class itself is covered in
+ * test/lib/dynamicProviderCache.test.js — this exercises the handleApplication
+ * wiring around it, including the multi-instance behavior that motivated tracking
+ * a Set of caches rather than a single reference.
  *
- * Everything runs in one test because the exported functions read module-level
- * state (the active cache + active hookManager) that is shared across the file;
- * node --test isolates each file in its own subprocess, so a single sequence
- * keeps the state deterministic without cross-test contamination.
+ * The exported functions read module-level state (the active-cache set + active
+ * hookManager) shared across the file; node --test isolates each file in its own
+ * subprocess, and each test tears down the scopes it creates so the set is empty
+ * between tests.
  */
 
 import { describe, it } from 'node:test';
@@ -119,9 +121,66 @@ describe('dynamic provider cache invalidation wiring', () => {
 		await middleware({ session: oacSession('oac-1') }, next);
 		assert.strictEqual(resolveCalls, 3, 'request after clear re-resolves');
 
-		// Scope close releases the active-cache reference → invalidate becomes a no-op.
+		// Scope close removes this cache from the active set → invalidate becomes a no-op.
 		assert.strictEqual(closeListeners.length, 1, 'a close listener is registered');
 		closeListeners[0]();
 		assert.strictEqual(invalidateDynamicProvider('oac-1'), false, 'invalidate is a no-op after close');
+	});
+
+	it('invalidation reaches every plugin instance in the thread; closing one does not orphan the others', async () => {
+		let resolveCalls = 0;
+		const resolver = {
+			async onResolveProvider(name) {
+				if (!name.startsWith('oac-')) return null;
+				resolveCalls++;
+				return {
+					provider: 'generic',
+					clientId: 'oac-client',
+					clientSecret: 'oac-secret',
+					authorizationUrl: 'https://idp.test/authorize',
+					tokenUrl: 'https://idp.test/token',
+					userInfoUrl: 'https://idp.test/userinfo',
+					scope: 'openid',
+				};
+			},
+		};
+		const next = (req) => req;
+		const req = () => ({ session: oacSession('oac-x') });
+
+		// Two plugin instances loaded in the same thread/module. Register the hook
+		// after each handleApplication so it binds to that instance's hookManager.
+		const a = makeScope();
+		await handleApplication(a.scope);
+		registerHooks(resolver);
+		const midA = a.getMiddleware();
+		await midA(req(), next); // A resolves + caches oac-x (resolveCalls: 1)
+
+		const b = makeScope();
+		await handleApplication(b.scope);
+		registerHooks(resolver);
+		const midB = b.getMiddleware();
+		await midB(req(), next); // B resolves + caches oac-x (resolveCalls: 2)
+		assert.strictEqual(resolveCalls, 2, 'each instance resolved and cached once');
+
+		// invalidate must reach BOTH instances. (The old single-reference design
+		// tracked only the last-loaded instance, so A's cache was never reachable.)
+		assert.strictEqual(invalidateDynamicProvider('oac-x'), true);
+		await midA(req(), next); // A re-resolves → proves A was cleared (3)
+		await midB(req(), next); // B re-resolves → proves B was cleared (4)
+		assert.strictEqual(resolveCalls, 4, 'invalidate reached both instances, not just the last-loaded one');
+
+		// Close B — the LAST-loaded instance. With the old `=== ` single-ref guard
+		// this nulled the shared reference and broke invalidation for every still-
+		// active instance. With the Set, A stays invalidatable.
+		b.closeListeners[0]();
+		assert.strictEqual(
+			invalidateDynamicProvider('oac-x'),
+			true,
+			'closing the last-loaded instance must not orphan invalidation for the still-active one'
+		);
+
+		// Tear down A too; with no active caches, invalidate is a no-op.
+		a.closeListeners[0]();
+		assert.strictEqual(invalidateDynamicProvider('oac-x'), false, 'no active caches after all instances close');
 	});
 });


### PR DESCRIPTION
Follow-up to #107 — resolves the review feedback that #106/#107 were merged over (the merge happened before that feedback was read).

## What

1. **`Set<DynamicProviderCache>` instead of a single `activeDynamicProviderCache` reference.** The exported `invalidateDynamicProvider()` / `clearDynamicProviderCache()` iterate the set, so multiple plugin instances in one worker thread each stay invalidatable, and closing one instance no longer orphans the others' caches (the gemini-review blocker on #107). The set `.add()` and its `close`-handler `.delete()` are registered together **after** the initial `updateConfiguration()`, so a failed init can't leave an orphaned cache in the set.
2. **Multi-instance regression test** (`test/dynamic-provider-invalidation.test.js`): asserts invalidation reaches *every* instance in the thread and that closing the last-loaded instance does not break invalidation for still-active ones. Fails against the old single-ref design; passes against the Set.
3. **Docs** (the 3 doc-drift blockers): `configuration.md` default `true`→`300`; `lifecycle-hooks.md` "permanent"→bounded-300s wording + example; `api-reference.md` documents the new `invalidateDynamicProvider()` / `clearDynamicProviderCache()` exports.

No behavior change beyond what #107 already introduced (the cache itself is unchanged; this only fixes the multi-instance bookkeeping + docs).

## Cross-model review (codex + gemini + Harper adjudication)

**Clean — no blockers, no significant concerns.**
- **Codex:** no defects (Set lifecycle/ordering correct, regression test validates the fix).
- **Gemini:** cache fix sound; flagged `activeHookManager` as carrying the same pre-existing singleton pattern.
- **Adjudication:** the `activeHookManager` finding is **pre-existing, out of scope, and doesn't bite Harper's one-instance-per-thread model** — and it's *not* a 1:1 "make it a Set" fix (`registerHooks` fan-out semantics need a decision). Filed as a separate follow-up: #108. Not a blocker for this PR.

## Tests

v1.x suite: **426 pass / 0 fail / 2 skip**. Lint + prettier clean.

Closes the review gap on #105/#107 (v1.x line). Once this lands, the v1.x line is ready for the `1.5.0` release that unblocks central-manager#378.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
