### PR TITLE
Release 1.5.0 (v1.x)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "1.4.0",
+	"version": "1.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@harperfast/oauth",
-			"version": "1.4.0",
+			"version": "1.5.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "1.4.0",
+	"version": "1.5.0",
 	"description": "OAuth 2.0 authentication plugin for Harper",
 	"license": "Apache-2.0",
 	"author": {


### PR DESCRIPTION
Release prep for **`@harperfast/oauth@1.5.0`** on the `v1.x` line. Pure version bump (`package.json` + `package-lock.json`, `1.4.0` → `1.5.0`).

Release notes go in the GitHub Release (the org convention — no in-repo CHANGELOG).

## After merge

1. Cut a GitHub Release **`v1.5.0`** off `v1.x` → `release.yml` publishes to npm. (Suggested release notes below.)
2. Follow-up CM PR to regenerate `package-lock.json` so central-manager picks up `1.5.0` (its committed lock pins `1.4.0`).

## Suggested GitHub Release notes

> **Changed**
> - Dynamic-provider cache now defaults to a bounded **300s TTL** instead of caching forever. Providers resolved via the `onResolveProvider` hook are re-resolved once their cache entry expires, so a config change (disabled provider, rotated credentials) takes effect within one TTL window instead of persisting until restart. Configure with `cacheDynamicProviders`: seconds (number), `false` to disable caching, or `true` for the previous cache-forever behavior. Freshness is TTL-only — no manual invalidation API.
>
> **Docs**
> - Documented the dynamic-provider caching model, including `cacheDynamicProviders: false` to disable the plugin cache and cache at your `onResolveProvider` lookup layer instead.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
