### PR TITLE
Release 2.0.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "2.0.0-alpha.1",
+	"version": "2.0.0-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@harperfast/oauth",
-			"version": "2.0.0-alpha.1",
+			"version": "2.0.0-alpha.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "2.0.0-alpha.1",
+	"version": "2.0.0-alpha.2",
 	"description": "OAuth 2.0 authentication plugin for Harper",
 	"license": "Apache-2.0",
 	"author": {


### PR DESCRIPTION
Release prep for **`@harperfast/oauth@2.0.0-alpha.2`** (the 2.x / Harper v5 prerelease line). Pure version bump (`package.json` + `package-lock.json`), `2.0.0-alpha.1` → `2.0.0-alpha.2`.

## Why

`alpha.1` was published **2026-02-18**; `main` has moved well past it without a version bump. `alpha.2` captures the unpublished work: Harper v5 migration, MCP (well-known + DCR), path-segment routing, the `withOAuthValidation` Resource-API-v2 refactor + fail-closed security fixes, and the TTL-only dynamic-provider cache. (No `CHANGELOG.md` — per repo convention the notes live in the GitHub Release.)

## ⚠️ Publishing notes (prerelease)

- **Publish with `npm publish --tag alpha`** — *not* bare `npm publish`, which would set the `latest` dist-tag and make `npm install @harperfast/oauth` resolve to the 2.x alpha over the stable `1.5.0`. (`release.yml` uses bare `npm publish`, so don't rely on it for prereleases even once its npm auth is fixed.)
- Mark the **GitHub Release as a pre-release**.
- Auto-publish is still blocked on the missing `NPM_ACCESS_KEY` secret, so this is a manual `npm publish --tag alpha` from `main`.

## Supersedes

Replaces #80 (also `2.0.0-alpha.2`) — that branch is 16 commits behind main, its lockfile optional-native-deps fix already landed on main, and it carried a `CHANGELOG.md` we're dropping. I'll close #80.

## Suggested GitHub Release notes

> Prerelease catching the 2.x line up with everything since `alpha.1` (2026-02-18):
> - Harper v5 migration (`harper` peer)
> - MCP OAuth: `/.well-known/*` discovery + Dynamic Client Registration
> - OAuth Resource path-segment routing
> - `withOAuthValidation` rewritten for Resource API v2 (`getContext()`), with fail-closed fixes (missing-context → 401, `onValidationError` undefined → deny, static-dispatch bypass closed) and full test coverage
> - Dynamic-provider cache is TTL-only (bounded 300s default; no manual invalidation)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
