### PR TITLE
ci: add always-on toggle to Claude + Gemini callers

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -26,6 +26,11 @@ concurrency:
 
 jobs:
   review:
+    # Always-on toggle — see ai-review-prompts USAGE.md "Reviewers & the
+    # always-on toggle". CLAUDE_ALWAYS_ON=true (repo/org variable) → auto-
+    # review trusted-author PRs; unset → opt-in via the claude-review
+    # label. The reusable's authorize job still owns WHO is admitted.
+    if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
     uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@2be0f702b114e39b90eed90962922ef64df58482 # main 2026-06-03 (post #52 — week-of-05-25 calibration: Harper-aware best-practices wiring, skills-ref v1.7.0, surface-findings rule, access-control blocker guidance, public-skill dedup)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -22,7 +22,10 @@ name: Gemini PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # `labeled` admits the `gemini-review` opt-in gesture. `vars.*`
+    # can't be read in `on:` (only in a job `if:`), so the trigger
+    # lists the union and the `review` job gates on GEMINI_ALWAYS_ON.
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   # Different group key from claude-review so the two providers can
@@ -34,6 +37,12 @@ concurrency:
 
 jobs:
   review:
+    # Always-on toggle — see ai-review-prompts USAGE.md "Reviewers & the
+    # always-on toggle". This repo sets GEMINI_ALWAYS_ON=true to keep the
+    # Gemini calibration baseline running on every PR; unset → opt-in via
+    # the gemini-review label. The reusable's authorize job still owns
+    # WHO is admitted (CODEOWNERS trust set; the labeler on `labeled`).
+    if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
     uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@2be0f702b114e39b90eed90962922ef64df58482 # main 2026-06-03 (post #52 — calibration: Harper-aware wiring for the Gemini leg, skills-ref v1.7.0, surface-findings rule, access-control blocker guidance, public-skill dedup)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job


### PR DESCRIPTION
## Always-on toggle on both reviewers

Brings the dogfood repo onto the unified review-toggle model (ai-review-prompts#48, USAGE "Reviewers & the always-on toggle"). Both callers are already pinned to `2be0f70`; this only adds the toggle:

**`claude-review.yml`** — add the `CLAUDE_ALWAYS_ON` job `if:`.
**`gemini-review.yml`** — add `labeled` to the trigger + the `GEMINI_ALWAYS_ON` job `if:`.

```yaml
if: ${{ vars.<PROVIDER>_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
```

Identical shape on both, differing only in the variable name. The `claude-review` / `gemini-review` label opt-in works on top of either; the reusable's authorize job still owns who is admitted.

### Maintainer actions before merge
- **Set `CLAUDE_ALWAYS_ON=true`** and **`GEMINI_ALWAYS_ON=true`** (repo Variables) to preserve today's behavior — oauth is the calibration baseline that runs both reviewers on every PR. Without the variables, both flip to opt-in-only.

(The `gemini-review` label + `GEMINI_API_KEY` are already present on this repo.)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
