### PR TITLE
ci: point caller comments at where the opt-in label is matched

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,6 +30,8 @@ jobs:
     # always-on toggle". CLAUDE_ALWAYS_ON=true (repo/org variable) → auto-
     # review trusted-author PRs; unset → opt-in via the claude-review
     # label. The reusable's authorize job still owns WHO is admitted.
+    # Note: the `claude-review` label name is matched there too —
+    # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
     uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@2be0f702b114e39b90eed90962922ef64df58482 # main 2026-06-03 (post #52 — week-of-05-25 calibration: Harper-aware best-practices wiring, skills-ref v1.7.0, surface-findings rule, access-control blocker guidance, public-skill dedup)
     # Caller-side permissions, scoped at the calling-job level (NOT

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -42,6 +42,8 @@ jobs:
     # Gemini calibration baseline running on every PR; unset → opt-in via
     # the gemini-review label. The reusable's authorize job still owns
     # WHO is admitted (CODEOWNERS trust set; the labeler on `labeled`).
+    # Note: the `gemini-review` label name is matched there too —
+    # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
     uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@2be0f702b114e39b90eed90962922ef64df58482 # main 2026-06-03 (post #52 — calibration: Harper-aware wiring for the Gemini leg, skills-ref v1.7.0, surface-findings rule, access-control blocker guidance, public-skill dedup)
     # Caller-side permissions, scoped at the calling-job level (NOT


### PR DESCRIPTION
Docs-only follow-up to #116. Adds a one-line `Note:` above each reviewer's toggle `if:` clarifying that the `claude-review` / `gemini-review` label name is matched in the reusable's `authorize` job (`_claude-review.yml` / `_gemini-review.yml`), not in this caller — the caller `if:` deliberately doesn't name the label. Mirrors the ai-review-prompts USAGE clarification (ai-review-prompts#55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)