### PR TITLE
ci: bump ai-review-prompts pin to 3f2300a3 (week-of-06-01 calibration)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -58,7 +58,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 2be0f702b114e39b90eed90962922ef64df58482
+      ai-review-prompts-ref: 3f2300a39910a0983eb74967dedeebd8c3c98adc
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@2be0f702b114e39b90eed90962922ef64df58482 # main 2026-06-03 (post #52 — week-of-05-25 calibration: Harper-aware best-practices wiring, skills-ref v1.7.0, surface-findings rule, access-control blocker guidance, public-skill dedup)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@3f2300a39910a0983eb74967dedeebd8c3c98adc # main 2026-06-08 (post #57 — week-of-06-01 calibration: severity-discipline non-blocker bullets, async-commit-ordering check, non-critical-work-on-critical-path guard)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job
     # grants below what they need and breaks the workflow at startup;

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -67,7 +67,7 @@ jobs:
       # in this repo for why the duplication is unavoidable
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
-      ai-review-prompts-ref: 2be0f702b114e39b90eed90962922ef64df58482
+      ai-review-prompts-ref: 3f2300a39910a0983eb74967dedeebd8c3c98adc
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -45,7 +45,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@2be0f702b114e39b90eed90962922ef64df58482 # main 2026-06-03 (post #52 — calibration: Harper-aware wiring for the Gemini leg, skills-ref v1.7.0, surface-findings rule, access-control blocker guidance, public-skill dedup)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@3f2300a39910a0983eb74967dedeebd8c3c98adc # main 2026-06-08 (post #57 — week-of-06-01 calibration: severity-discipline non-blocker bullets, async-commit-ordering check, non-critical-work-on-critical-path guard)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job
     # grants below what they need and breaks the workflow at startup;


### PR DESCRIPTION
Bumps the `ai-review-prompts` reusable-workflow pin (`_claude-review.yml` + `_gemini-review.yml`) from `2be0f70` → `3f2300a3`, picking up the week-of-2026-06-01 calibration changes merged in HarperFast/ai-review-prompts#57:

- **Severity discipline** (`universal.md`) — cosmetic / by-design / pre-existing / CI-skip items are explicitly *not* blockers.
- **Async work must settle before the transaction commits** (`harper/common.md`) — an unawaited Promise on a write/commit path is a correctness blocker (harper repos).
- **Non-critical work on a critical path** (`universal.md`) — cleanup/purge injected into startup/recovery/commit must be guarded.

Pin bump only — no other changes to this repo.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)