### PR TITLE
test: cover routing for a provider literally named "oauth"

### DIFF
--- a/integrationTests/path-segment-routing.test.ts
+++ b/integrationTests/path-segment-routing.test.ts
@@ -72,4 +72,34 @@ suite('OAuth Resource routes by URL path segment (not literal "oauth")', (ctx: C
 			`client_id was ${url.searchParams.get('client_id')} — expected tenant's (${TENANT_CLIENT_ID}), decoy's is ${DECOY_CLIENT_ID}`
 		);
 	});
+
+	// Regression guard: a provider whose configured name is literally "oauth"
+	// must still be reachable at /oauth/oauth/login. Harper strips the mount
+	// segment, so parseRoute sees target.id = "oauth/login" → providerName
+	// "oauth". Any "detect and omit a leading oauth path segment" change would
+	// instead resolve providerName "login" (unknown) and make this provider
+	// unreachable. The sibling oac-oauth-tenant test does not exercise this case
+	// because its first path segment isn't "oauth", so this assertion is the one
+	// that fails under such a change.
+	test('/oauth/oauth/login dispatches to the provider literally named "oauth"', async () => {
+		const response = await fetch(`${ctx.harper.httpURL}/oauth/oauth/login`, {
+			redirect: 'manual',
+		});
+
+		strictEqual(response.status, 302, `expected 302 redirect, got ${response.status}`);
+		const location = response.headers.get('location');
+		strictEqual(typeof location, 'string', 'Location header missing');
+		const url = new URL(location!);
+
+		// The "oauth"-named provider's authorizationUrl is http://decoy.test/authorize
+		// with the decoy client_id. A parseRoute that strips a leading "oauth"
+		// segment would resolve providerName "login" → never reach this provider.
+		strictEqual(url.origin, 'http://decoy.test');
+		strictEqual(url.pathname, '/authorize');
+		strictEqual(
+			url.searchParams.get('client_id'),
+			DECOY_CLIENT_ID,
+			`client_id was ${url.searchParams.get('client_id')} — expected the "oauth"-named provider's (${DECOY_CLIENT_ID})`
+		);
+	});
 });


### PR DESCRIPTION
## What

Adds an integration test to `integrationTests/path-segment-routing.test.ts` covering a routing case the existing suite missed: a provider whose **configured name is literally `oauth`** must be reachable at `/oauth/oauth/login`.

## Why

Harper strips the resource mount segment before the OAuth resource runs, so `parseRoute` receives `target.id = "oauth/login"` and must resolve `providerName = "oauth"`. The existing suite only asserts `oac-oauth-tenant` (whose first path segment isn't `oauth`), so it does **not** exercise this case.

This came out of reviewing #101 ("detect and omit oauth prefix from path parts"), which strips a leading `oauth` segment in `parseRoute`. Verified empirically against real Harper:

- **main (this PR's base):** `GET /oauth/oauth/login` → `302` to the `oauth`-named provider's `authorizationUrl` ✅
- **with #101's strip applied:** `GET /oauth/oauth/login` → `200`, provider unreachable ❌ (`providerName` becomes `login`)

So the prefix-strip isn't a harmless no-op — it breaks any provider legitimately named `oauth`. This test is the regression guard for that invariant: green on `main`, red under such a change.

## Test

Reuses the existing `path-segment-routing-app` fixture (which already configures an `oauth`-named decoy provider) — no fixture changes. Boots real Harper and asserts the `302` + `authorizationUrl` origin/path + `client_id`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
