### PR TITLE
ci: bump issue-to-pr pin (Opus for :bug/:test, efficiency guidance)

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -22,11 +22,11 @@ concurrency:
 
 jobs:
   work:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@f6daed301f8a7ece74593506de38c6e80820b00b # main 2026-05-06 (post #11/#12/#14)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@441d2a310cb360adf419d3546dd27566164f1ec2 # main 2026-06-09 (post #58: Opus for :bug/:test, efficiency guidance)
     with:
       # Same SHA as the `uses:` ref above. See the comment in
       # claude-mention.yml for why the duplication is unavoidable.
-      ai-review-prompts-ref: f6daed301f8a7ece74593506de38c6e80820b00b
+      ai-review-prompts-ref: 441d2a310cb360adf419d3546dd27566164f1ec2
       # Plugin repo — bun is part of the test path.
       setup-bun: true
       repo-specific-conventions: |


### PR DESCRIPTION
Bumps the `claude-issue-to-pr` reusable pin (both `uses:` ref and `ai-review-prompts-ref:`) from `f6daed30` to [HarperFast/ai-review-prompts#58](https://github.com/HarperFast/ai-review-prompts/pull/58)'s merge commit `441d2a31` — keeping this repo on the **same issue-to-PR version as harper and harper-pro**.

Clean forward bump (`441d2a31` descends from `f6daed30`). What this repo picks up:
- **Model by label:** `:bug` / `:test` now run on `claude-opus-4-8`; `:typo` / `:docs` / `:deps` stay on `claude-sonnet-4-6`. Sub-task agents still default to Haiku.
- **"Working efficiently" prompt guidance:** delegate broad exploration to a sub-agent (Task tool) instead of spelunking; stop-and-comment when out of scope.
- **allowlist:** read-only `gh pr list` / `gh search prs` / `gh search issues`.
- **`max-turns` 72 → 100.**
- Plus the interim `:test` `format:check` tweak and the `authorize-ai-workflow.sh` rename that moved in with the pin.

`setup-bun: true` and this repo's conventions are untouched. Motivated by harper run [`27222718790`](https://github.com/HarperFast/harper/actions/runs/27222718790/job/80381556260), which hit the 72-turn cap on read-only exploration. No-op until the next `claude-fix:*` labeled issue.

Companion PRs: harper#1218, harper-pro#305.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)