### PR TITLE
chore: bump @harperfast/integration-testing to 0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 			},
 			"devDependencies": {
 				"@harperdb/code-guidelines": "^0.0.5",
-				"@harperfast/integration-testing": "0.3.0",
+				"@harperfast/integration-testing": "0.5.1",
 				"@types/jsonwebtoken": "^9.0.5",
 				"@types/node": "^22.0.0",
 				"eslint": "^9.35.0",
@@ -1740,9 +1740,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@harperfast/integration-testing": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@harperfast/integration-testing/-/integration-testing-0.3.0.tgz",
-			"integrity": "sha512-q8R6k+aYtYQ7iyVuiWFJ9uB2f1OPEh4hXd07VTv12LxsmUY3XFXGuiLh2buDi36SAB4Y5++IZcF7lZQ/CIDbvA==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/@harperfast/integration-testing/-/integration-testing-0.5.1.tgz",
+			"integrity": "sha512-hHkDf9mgxdKFPqnlc1Dtz9je9WafUWGIofyzgfpmPWECxWqEo4NIa5CesJANtdKHSVsUtSiEt0E05y6+ZsBtPw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 	},
 	"devDependencies": {
 		"@harperdb/code-guidelines": "^0.0.5",
-		"@harperfast/integration-testing": "0.3.0",
+		"@harperfast/integration-testing": "0.5.1",
 		"@types/jsonwebtoken": "^9.0.5",
 		"@types/node": "^22.0.0",
 		"eslint": "^9.35.0",


### PR DESCRIPTION
Bumps the `@harperfast/integration-testing` harness to **0.5.1**, picking up the startup-readiness and teardown/loopback-recycle race fixes (HarperFast/integration-testing#8).

This repo was on `0.3.0`, so the jump crosses two behavioral changes worth watching in CI:
- loopback pool now starts at `127.0.0.2` (was `127.0.0.1`)
- `startupTimeoutMs` / `…_STARTUP_TIMEOUT_MS` now means the idle / no-output window, not an absolute deadline

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
