### PR TITLE
ci: bump ai-review-prompts pin to 9eb635a9 (week-of-06-08 calibration)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@3f2300a39910a0983eb74967dedeebd8c3c98adc # main 2026-06-08 (post #57 — week-of-06-01 calibration: severity-discipline non-blocker bullets, async-commit-ordering check, non-critical-work-on-critical-path guard)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@9eb635a9221ffcc1e467016b525a7655277d2d6c # main 2026-06-15 (post #59 — week-of-06-08 calibration: mechanical-diff no-log gate, setup/teardown-leak + undefined-context robustness, commit/replication atomicity)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job
     # grants below what they need and breaks the workflow at startup;
@@ -58,7 +58,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 3f2300a39910a0983eb74967dedeebd8c3c98adc
+      ai-review-prompts-ref: 9eb635a9221ffcc1e467016b525a7655277d2d6c
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -45,7 +45,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@3f2300a39910a0983eb74967dedeebd8c3c98adc # main 2026-06-08 (post #57 — week-of-06-01 calibration: severity-discipline non-blocker bullets, async-commit-ordering check, non-critical-work-on-critical-path guard)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@9eb635a9221ffcc1e467016b525a7655277d2d6c # main 2026-06-15 (post #59 — week-of-06-08 calibration: mechanical-diff no-log gate, setup/teardown-leak + undefined-context robustness, commit/replication atomicity)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job
     # grants below what they need and breaks the workflow at startup;
@@ -67,7 +67,7 @@ jobs:
       # in this repo for why the duplication is unavoidable
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
-      ai-review-prompts-ref: 3f2300a39910a0983eb74967dedeebd8c3c98adc
+      ai-review-prompts-ref: 9eb635a9221ffcc1e467016b525a7655277d2d6c
       review-layers: |
         universal
         harper/common


### PR DESCRIPTION
Bumps the `ai-review-prompts` pin from `3f2300a3` → `9eb635a9` (HarperFast/ai-review-prompts#59, week-of-2026-06-08 calibration) — both the `uses:` ref and the `ai-review-prompts-ref` input, in both reviewer workflows.

Picks up: the mechanical-diff no-log gate (version/CI/pin/submodule/scaffold/dead-code PRs stop generating triage-only log entries), setup/teardown-leak + undefined-context robustness rules, and the Harper commit/replication source-apply atomicity check.

Pin bump only.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)