### PR TITLE
ci: bump Gemini reviewer pin to main@441d544 (dogfood inline comments)

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -45,7 +45,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@9eb635a9221ffcc1e467016b525a7655277d2d6c # main 2026-06-15 (post #59 — week-of-06-08 calibration: mechanical-diff no-log gate, setup/teardown-leak + undefined-context robustness, commit/replication atomicity)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@441d5441e348ab6a2ab97c60f645e7053999b619 # main 2026-06-18 (post #65 — inline resolvable severity-badged review comments + non-blocking Suggestions tier; also #56 SHA-pin fix, #29 run-notes split, #63 test coverage)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job
     # grants below what they need and breaks the workflow at startup;
@@ -67,7 +67,7 @@ jobs:
       # in this repo for why the duplication is unavoidable
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
-      ai-review-prompts-ref: 9eb635a9221ffcc1e467016b525a7655277d2d6c
+      ai-review-prompts-ref: 441d5441e348ab6a2ab97c60f645e7053999b619
       review-layers: |
         universal
         harper/common


### PR DESCRIPTION
Bumps the **Gemini** reviewer's `ai-review-prompts` pin from `9eb635a` (main @ 06-15, post-#59) to **`441d544`** (main @ 06-18), to dogfood the new inline-comments feature in a real consumer repo.

### What this picks up
- **#65 — inline, resolvable, severity-badged Gemini review comments** + the **non-blocking Suggestions tier**. The Gemini leg now posts findings/suggestions as per-line, resolvable threads badged `🔴 Blocker` / `💡 Suggestion (non-blocking)` — parity with the Claude leg and with the **sunsetting** third-party gemini-code-assist.
- Also in this range: #56 (transitive SHA-pin fix that let Gemini run in strict-pin repos), #29 (run-notes split to the log surface), #63 (zero-dep script test coverage).

### Scope
- **Gemini pin only** (`gemini-review.yml`, both the `uses:` ref and the `ai-review-prompts-ref:` input). The **Claude pin is unchanged** — Claude already posts inline.

### Note on this PR's own review
This is a mechanical 2-line pin bump, so Gemini's review of *this* PR will be a clean "no blockers" with no inline comments (nothing in the diff to anchor to). It confirms the new `_gemini-review.yml@441d544` resolves and runs cleanly in oauth; the inline comments themselves will visibly fire on the next substantive oauth PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
