### PR TITLE
MCP OAuth Stage 4: /oauth/mcp/token endpoint + JWT issuer

### DIFF
--- a/schema/oauth.graphql
+++ b/schema/oauth.graphql
@@ -51,6 +51,39 @@ type mcp_auth_codes @table(database: "oauth", expiration: 300) {
 	created_at: Float
 }
 
+## MCP JWT signing keys (Stage 4)
+## Persisted here (not on disk) so all replicated Harper nodes share one key
+## set — file storage would diverge across nodes. No expiration: keys are
+## retained for verification until explicitly rotated. RS256 only in v1
+## (jsonwebtoken cannot emit EdDSA); the public half is published at
+## /.well-known/jwks.json, the private half never leaves the server.
+type harper_oauth_mcp_keys @table(database: "oauth") {
+	kid: ID @primaryKey
+	alg: String # "RS256"
+	public_key_pem: String
+	private_key_pem: String
+	created_at: Float # Unix seconds
+}
+
+## MCP refresh-token families (Stage 4, OAuth 2.1 single-use rotation)
+## One row per refresh-token family. The token handed to the client is
+## "<family_id>.<secret>"; only the SHA-256 hash of the whole value is stored
+## (current_token_hash). A presented token whose hash != current_token_hash is
+## a replay of an already-rotated token → the family is revoked. Real TTL is
+## enforced at runtime via expires_at; the table expiration is a generous GC
+## backstop (30d) so abandoned families are eventually evicted.
+type mcp_refresh_families @table(database: "oauth", expiration: 2592000) {
+	family_id: ID @primaryKey
+	current_token_hash: String
+	revoked: Boolean
+	client_id: String
+	user: String
+	resource: String
+	scope: String
+	created_at: Float # Unix seconds
+	expires_at: Float # Unix seconds; refresh rejected once exceeded
+}
+
 ## OAuth User Session table (optional, for future use)
 ## Could store OAuth-specific user data
 # type oauth_sessions @table(database: "oauth") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,24 @@ import { DynamicProviderCache, DEFAULT_DYNAMIC_PROVIDER_CACHE_TTL_SECONDS } from
 import { registerWellKnownHandlers } from './lib/mcp/wellKnown.ts';
 import type { Scope, OAuthPluginConfig, ProviderRegistry, OAuthHooks } from './types.ts';
 
+// Config can carry literal secrets (provider clientSecret, mcp.signingKeyPem,
+// mcp.dynamicClientRegistration.initialAccessToken). Redact them before logging
+// the options blob — logs are frequently shipped/retained outside the trust
+// boundary. Deny-list by key-name substring; over-redaction in a log is safe.
+const SENSITIVE_KEY_PATTERN = /secret|signingkeypem|initialaccesstoken|privatekey|password/i;
+
+function redactSecrets(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(redactSecrets);
+	if (value && typeof value === 'object') {
+		const out: Record<string, unknown> = {};
+		for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+			out[key] = SENSITIVE_KEY_PATTERN.test(key) ? '[REDACTED]' : redactSecrets(val);
+		}
+		return out;
+	}
+	return value;
+}
+
 // Export HookManager class, OAuthResource class, and types
 export { HookManager } from './lib/hookManager.ts';
 export { OAuthResource } from './lib/resource.ts';
@@ -134,7 +152,7 @@ export async function handleApplication(scope: Scope): Promise<void> {
 		if (isInitialized) {
 			logger?.info?.('OAuth configuration changed, updating providers...');
 		} else {
-			logger?.info?.('OAuth plugin loading with options:', JSON.stringify(options, null, 2));
+			logger?.info?.('OAuth plugin loading with options:', JSON.stringify(redactSecrets(options), null, 2));
 			isInitialized = true;
 		}
 

--- a/src/lib/mcp/authCodeStore.ts
+++ b/src/lib/mcp/authCodeStore.ts
@@ -109,4 +109,17 @@ export class MCPAuthCodeStore {
 			this.logger?.warn?.('Failed to delete MCP auth code:', error);
 		}
 	}
+
+	/**
+	 * Strict single-use consume for the /token exchange. Unlike `delete`, a
+	 * failure is NOT swallowed — the caller must refuse to issue a token if the
+	 * code could still be replayed. (A residual race remains: with a
+	 * get/put/delete-only table there is no atomic compare-and-delete, so two
+	 * concurrent exchanges of the same code could both pass before either
+	 * delete lands. Accepted given PKCE binding, the 5-minute TTL, and Harper's
+	 * single-trust-domain model.)
+	 */
+	async consume(code: string): Promise<void> {
+		await getAuthCodesTable().delete(code);
+	}
 }

--- a/src/lib/mcp/index.ts
+++ b/src/lib/mcp/index.ts
@@ -10,12 +10,17 @@ import type { RequestTarget } from 'harper';
 import type { Logger, MCPConfig, ProviderRegistry, Request } from '../../types.ts';
 import { handleAuthorize } from './authorize.ts';
 import { handleRegister } from './dcr.ts';
+import { handleToken } from './token.ts';
 
 export { MCPAuthCodeStore, resetMCPAuthCodesTableCache } from './authCodeStore.ts';
 export { handleAuthorize, selectMCPProvider } from './authorize.ts';
 export { handleMCPCallback } from './callback.ts';
 export { MCPClientStore, resetMCPClientsTableCache } from './clientStore.ts';
 export { handleRegister } from './dcr.ts';
+export { MCPKeyStore, resetMCPKeysTableCache, SIGNING_KEY_ID } from './keyStore.ts';
+export { MCPRefreshFamilyStore, resetMCPRefreshFamiliesTableCache } from './refreshTokenStore.ts';
+export { handleToken } from './token.ts';
+export { publicKeyToJwk, signAccessToken, verifyAccessToken } from './tokenIssuer.ts';
 
 /**
  * Dispatch POST /oauth/mcp/<action>.
@@ -36,6 +41,10 @@ export async function handleMCPPost(
 
 	if (action === 'register') {
 		return handleRegister(request, body, mcpConfig, logger);
+	}
+
+	if (action === 'token') {
+		return handleToken(request, body, mcpConfig, logger);
 	}
 
 	return { status: 404, body: { error: 'Not found' } };

--- a/src/lib/mcp/keyStore.ts
+++ b/src/lib/mcp/keyStore.ts
@@ -1,0 +1,176 @@
+/**
+ * MCP JWT Signing Key Store
+ *
+ * Persists the RS256 signing keypair in the `harper_oauth_mcp_keys` Harper
+ * table so every replicated node shares one key set (file storage would
+ * diverge). v1 keeps a SINGLE key under a fixed primary key (`SIGNING_KEY_ID`)
+ * because the plugin's table abstraction is get/put/delete only — no
+ * enumeration — and #86 defers key rotation. The private half never leaves the
+ * server; only the public half is published at /.well-known/jwks.json.
+ *
+ * The key is resolved lazily (first token mint) from the persisted row — not
+ * cached in-process, so a node always picks up the converged value. First boot
+ * generates a keypair unless one is provided via `mcp.signingKeyPem`.
+ *
+ * CLUSTERED PRODUCTION should set `mcp.signingKeyPem` (the same PEM on every
+ * node). Without it, two nodes can both miss the row on their first mint and
+ * generate different keys; until replication converges, a node may sign tokens
+ * with a key JWKS does not publish (so those tokens fail verification). A
+ * configured key is identical everywhere and removes the race entirely.
+ *
+ * Explicit field access on encode/decode (no `{ ...raw }`) — Harper
+ * tracked-object Proxies return empty own-keys. See CLAUDE.md gotcha.
+ */
+
+import { createPublicKey, generateKeyPair } from 'node:crypto';
+import { promisify } from 'node:util';
+import type { Logger, MCPConfig, MCPSigningKeyRecord, Table } from '../../types.ts';
+
+const generateKeyPairAsync = promisify(generateKeyPair);
+
+/** Fixed primary key for the singleton v1 signing key. */
+export const SIGNING_KEY_ID = 'rs256-default';
+
+declare const databases: any;
+
+let keysTable: Table | undefined;
+
+function getKeysTable(): Table {
+	if (!keysTable) {
+		if (!databases?.oauth?.harper_oauth_mcp_keys) {
+			throw new Error(
+				'OAuth MCP keys table (oauth.harper_oauth_mcp_keys) not found. ' +
+					'Please ensure the OAuth plugin is properly installed with its schema.'
+			);
+		}
+		keysTable = databases.oauth.harper_oauth_mcp_keys;
+	}
+	return keysTable as Table;
+}
+
+/**
+ * Reset cached table reference and resolved key (for testing only).
+ * @internal
+ */
+export function resetMCPKeysTableCache(): void {
+	keysTable = undefined;
+}
+
+function encodeRecord(record: MCPSigningKeyRecord): Record<string, any> {
+	return {
+		kid: record.kid,
+		alg: record.alg,
+		public_key_pem: record.public_key_pem,
+		private_key_pem: record.private_key_pem,
+		created_at: record.created_at,
+	};
+}
+
+function decodeRecord(raw: Record<string, any>): MCPSigningKeyRecord {
+	return {
+		kid: raw.kid,
+		alg: raw.alg,
+		public_key_pem: raw.public_key_pem,
+		private_key_pem: raw.private_key_pem,
+		created_at: raw.created_at,
+	};
+}
+
+async function generateRsaKeyPair(): Promise<{ publicKeyPem: string; privateKeyPem: string }> {
+	const { publicKey, privateKey } = await generateKeyPairAsync('rsa', {
+		modulusLength: 2048,
+		publicKeyEncoding: { type: 'spki', format: 'pem' },
+		privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+	});
+	return { publicKeyPem: publicKey as string, privateKeyPem: privateKey as string };
+}
+
+export class MCPKeyStore {
+	private logger?: Logger;
+
+	constructor(logger?: Logger) {
+		this.logger = logger;
+	}
+
+	/** Read the persisted signing key, or null if none exists yet. */
+	async get(): Promise<MCPSigningKeyRecord | null> {
+		const table = getKeysTable();
+		try {
+			const raw = await table.get(SIGNING_KEY_ID);
+			if (!raw || !raw.kid) {
+				return null;
+			}
+			return decodeRecord(raw);
+		} catch (error) {
+			this.logger?.error?.('Failed to retrieve MCP signing key:', error);
+			return null;
+		}
+	}
+
+	/**
+	 * Resolve the active signing key, generating and persisting one on first use
+	 * if absent.
+	 *
+	 * Deliberately NOT cached in-process: in a replicated deployment without a
+	 * configured `mcp.signingKeyPem`, two nodes can both miss the row on their
+	 * first mint and generate different keys. Always reading the persisted row
+	 * (and re-reading after a generate) means a node adopts the converged winner
+	 * on its next mint instead of being stuck signing with a key JWKS no longer
+	 * publishes. The narrow pre-convergence window where a node signs with a
+	 * soon-to-be-overwritten key is only fully avoided by setting
+	 * `mcp.signingKeyPem` (identical on every node) — required for clustered
+	 * production; see the module header.
+	 */
+	async getSigningKey(mcpConfig?: MCPConfig): Promise<MCPSigningKeyRecord> {
+		const existing = await this.get();
+		if (existing) {
+			return existing;
+		}
+
+		let publicKeyPem: string;
+		let privateKeyPem: string;
+		if (mcpConfig?.signingKeyPem) {
+			privateKeyPem = mcpConfig.signingKeyPem;
+			publicKeyPem = createPublicKey(privateKeyPem).export({ type: 'spki', format: 'pem' }) as string;
+		} else {
+			({ publicKeyPem, privateKeyPem } = await generateRsaKeyPair());
+		}
+
+		const record: MCPSigningKeyRecord = {
+			kid: SIGNING_KEY_ID,
+			alg: 'RS256',
+			public_key_pem: publicKeyPem,
+			private_key_pem: privateKeyPem,
+			created_at: Math.floor(Date.now() / 1000),
+		};
+		const table = getKeysTable();
+		try {
+			await table.put(encodeRecord(record));
+		} catch (error) {
+			this.logger?.error?.('Failed to persist MCP signing key:', error);
+			throw error;
+		}
+		this.logger?.info?.('MCP: generated and persisted RS256 signing key');
+		// Re-read so we adopt the persisted value (the winner if another node or
+		// request wrote concurrently) rather than our local candidate.
+		const persisted = await this.get();
+		return persisted ?? record;
+	}
+
+	/**
+	 * Public keys to publish at the JWKS endpoint. Read-only — never triggers
+	 * generation (an unauthenticated JWKS fetch must not mint key material), so
+	 * the set is empty until the first token is issued.
+	 */
+	async getAllPublicKeys(): Promise<MCPSigningKeyRecord[]> {
+		try {
+			const existing = await this.get();
+			return existing ? [existing] : [];
+		} catch (error) {
+			// Don't 500 the public discovery endpoint if the table isn't ready —
+			// publish an empty set. Token minting (which needs the key) still errors.
+			this.logger?.error?.('Failed to read MCP signing keys for JWKS:', error);
+			return [];
+		}
+	}
+}

--- a/src/lib/mcp/refreshTokenStore.ts
+++ b/src/lib/mcp/refreshTokenStore.ts
@@ -1,0 +1,149 @@
+/**
+ * MCP Refresh-Token Family Store (OAuth 2.1 single-use rotation)
+ *
+ * Persists one row per refresh-token family in `mcp_refresh_families`. The
+ * opaque token handed to the client is `"<family_id>.<secret>"`; only the
+ * SHA-256 hash of the whole value is stored (`current_token_hash`). On a valid
+ * refresh the hash is overwritten (rotation); a presented token whose hash no
+ * longer matches is a replay of a superseded token, which revokes the family.
+ *
+ * This keeps replay revocation O(1) with a get/put-only table abstraction: we
+ * store family state, not individual tokens, so it stays correct even after
+ * old tokens age out of any per-token store. Tokens are never stored in the
+ * clear.
+ *
+ * Rotation is not atomic (no compare-and-set on the table, same constraint as
+ * authCodeStore.consume): two concurrent refreshes of the same current token
+ * both pass the hash check before either write lands, so one of the two new
+ * tokens is orphaned (last write wins). The orphan fails safe — its next use is
+ * a hash mismatch, which revokes the family. Benign under the real
+ * single-client-per-refresh pattern; accepted for v1.
+ *
+ * Explicit field access on encode/decode (no `{ ...raw }`) — Harper
+ * tracked-object Proxies return empty own-keys. See CLAUDE.md gotcha.
+ */
+
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import type { Logger, MCPRefreshFamilyRecord, Table } from '../../types.ts';
+
+declare const databases: any;
+
+let familiesTable: Table | undefined;
+
+function getFamiliesTable(): Table {
+	if (!familiesTable) {
+		if (!databases?.oauth?.mcp_refresh_families) {
+			throw new Error(
+				'OAuth MCP refresh families table (oauth.mcp_refresh_families) not found. ' +
+					'Please ensure the OAuth plugin is properly installed with its schema.'
+			);
+		}
+		familiesTable = databases.oauth.mcp_refresh_families;
+	}
+	return familiesTable as Table;
+}
+
+/**
+ * Reset the cached table reference (for testing only).
+ * @internal
+ */
+export function resetMCPRefreshFamiliesTableCache(): void {
+	familiesTable = undefined;
+}
+
+/** SHA-256 of a token value, base64url-encoded. */
+export function hashRefreshToken(token: string): string {
+	return createHash('sha256').update(token).digest('base64url');
+}
+
+/** Mint a fresh token for a family and return both the token and its hash. */
+export function makeRefreshToken(familyId: string): { token: string; hash: string } {
+	const token = `${familyId}.${randomBytes(32).toString('base64url')}`;
+	return { token, hash: hashRefreshToken(token) };
+}
+
+/**
+ * Extract the family id from a presented refresh token. Returns null when the
+ * token is not in the expected `<family_id>.<secret>` shape.
+ */
+export function parseRefreshToken(token: unknown): { familyId: string } | null {
+	if (typeof token !== 'string') return null;
+	const dot = token.indexOf('.');
+	if (dot <= 0 || dot === token.length - 1) return null;
+	return { familyId: token.slice(0, dot) };
+}
+
+/** Generate a new, unique family id. */
+export function newFamilyId(): string {
+	return randomUUID();
+}
+
+function encodeRecord(record: MCPRefreshFamilyRecord): Record<string, any> {
+	return {
+		family_id: record.family_id,
+		current_token_hash: record.current_token_hash,
+		revoked: record.revoked,
+		client_id: record.client_id,
+		user: record.user,
+		resource: record.resource,
+		scope: record.scope,
+		created_at: record.created_at,
+		expires_at: record.expires_at,
+	};
+}
+
+function decodeRecord(raw: Record<string, any>): MCPRefreshFamilyRecord {
+	return {
+		family_id: raw.family_id,
+		current_token_hash: raw.current_token_hash,
+		revoked: raw.revoked ?? false,
+		client_id: raw.client_id,
+		user: raw.user,
+		resource: raw.resource,
+		scope: raw.scope ?? undefined,
+		created_at: raw.created_at,
+		expires_at: raw.expires_at,
+	};
+}
+
+export class MCPRefreshFamilyStore {
+	private logger?: Logger;
+
+	constructor(logger?: Logger) {
+		this.logger = logger;
+	}
+
+	async set(record: MCPRefreshFamilyRecord): Promise<void> {
+		const table = getFamiliesTable();
+		try {
+			await table.put(encodeRecord(record));
+		} catch (error) {
+			this.logger?.error?.('Failed to store MCP refresh family:', error);
+			throw error;
+		}
+	}
+
+	async get(familyId: string): Promise<MCPRefreshFamilyRecord | null> {
+		const table = getFamiliesTable();
+		try {
+			const raw = await table.get(familyId);
+			if (!raw || !raw.family_id) {
+				return null;
+			}
+			return decodeRecord(raw);
+		} catch (error) {
+			this.logger?.error?.('Failed to retrieve MCP refresh family:', error);
+			return null;
+		}
+	}
+
+	async delete(familyId: string): Promise<void> {
+		const table = getFamiliesTable();
+		try {
+			await table.delete(familyId);
+		} catch (error) {
+			// Non-critical: TTL will eventually evict.
+			this.logger?.warn?.('Failed to delete MCP refresh family:', error);
+		}
+	}
+}

--- a/src/lib/mcp/token.ts
+++ b/src/lib/mcp/token.ts
@@ -43,7 +43,11 @@ type TokenResponse = {
 const NO_STORE_HEADERS = { 'Cache-Control': 'no-store', 'Pragma': 'no-cache' };
 
 function errorResponse(status: number, error: string, description?: string): TokenResponse {
-	return { status, body: description ? { error, error_description: description } : { error } };
+	return {
+		status,
+		body: description ? { error, error_description: description } : { error },
+		headers: NO_STORE_HEADERS,
+	};
 }
 
 function nowSeconds(): number {
@@ -306,13 +310,12 @@ async function handleRefreshTokenGrant(
 		return errorResponse(400, 'invalid_grant', 'Refresh token has been superseded; family revoked');
 	}
 
-	// Rotate: overwrite the family's current token, keep the original expiry.
+	// Sign the access token BEFORE committing the rotation. If key fetch or
+	// signing throws, the family is left untouched so the client's current
+	// refresh token still works on retry — otherwise a transient failure would
+	// orphan their token and trip replay-revocation on the next attempt.
 	const issuer = resolveIssuer(request as any, mcpConfig);
 	const accessTtl = coerceTtl(mcpConfig.accessTokenTtl, DEFAULT_ACCESS_TOKEN_TTL);
-	const { token: newRefreshToken, hash: newHash } = makeRefreshToken(family.family_id);
-	family.current_token_hash = newHash;
-	await familyStore.set(family);
-
 	const key = await new MCPKeyStore(logger).getSigningKey(mcpConfig);
 	const accessToken = signAccessToken(
 		{
@@ -325,6 +328,11 @@ async function handleRefreshTokenGrant(
 		},
 		key
 	);
+
+	// Rotate only once the new access token is in hand (keep the original expiry).
+	const { token: newRefreshToken, hash: newHash } = makeRefreshToken(family.family_id);
+	family.current_token_hash = newHash;
+	await familyStore.set(family);
 
 	const responseBody: Record<string, unknown> = {
 		access_token: accessToken,

--- a/src/lib/mcp/token.ts
+++ b/src/lib/mcp/token.ts
@@ -1,0 +1,363 @@
+/**
+ * MCP Token Endpoint (POST /oauth/mcp/token)
+ *
+ * Exchanges an authorization code (PKCE-verified) or a refresh token for an
+ * audience-bound RS256 JWT access token. Mirrors DCR's JSON request/response
+ * shape (`{ status, body }` with OAuth 2.0 error objects).
+ *
+ * Access tokens are stateless (no token-table round trip); refresh tokens use
+ * single-use family rotation (see refreshTokenStore.ts). The upstream IdP token
+ * never appears in claims or the response.
+ */
+
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type { Logger, MCPClientRecord, MCPConfig, Request } from '../../types.ts';
+import { MCPAuthCodeStore } from './authCodeStore.ts';
+import { MCPClientStore } from './clientStore.ts';
+import { MCPKeyStore } from './keyStore.ts';
+import {
+	hashRefreshToken,
+	makeRefreshToken,
+	MCPRefreshFamilyStore,
+	newFamilyId,
+	parseRefreshToken,
+} from './refreshTokenStore.ts';
+import { signAccessToken } from './tokenIssuer.ts';
+import { resolveIssuer } from './wellKnown.ts';
+
+const DEFAULT_ACCESS_TOKEN_TTL = 3600; // 1 hour
+const DEFAULT_REFRESH_TOKEN_TTL = 2592000; // 30 days
+
+// RFC 7636 §4.1: code_verifier = 43*128unreserved. Mirrors the code_challenge
+// check at authorize.ts so a malformed verifier fails fast here too.
+const CODE_VERIFIER_PATTERN = /^[A-Za-z0-9._~-]{43,128}$/;
+
+type TokenResponse = {
+	status: number;
+	body: Record<string, unknown>;
+	headers?: Record<string, string>;
+};
+
+// RFC 6749 §5.1: token responses carry credentials, so intermediaries and
+// browsers must not cache them.
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store', 'Pragma': 'no-cache' };
+
+function errorResponse(status: number, error: string, description?: string): TokenResponse {
+	return { status, body: description ? { error, error_description: description } : { error } };
+}
+
+function nowSeconds(): number {
+	return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Coerce a configured TTL to a positive number of seconds. Config from `${ENV}`
+ * expansion or quoted YAML can arrive as a string; jsonwebtoken would treat a
+ * bare numeric string as milliseconds and `now + "86400"` would concatenate, so
+ * normalize here and fall back to the default on any non-positive/non-finite value.
+ */
+function coerceTtl(value: unknown, fallback: number): number {
+	const n = typeof value === 'number' ? value : Number(value);
+	return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/** Does the client's registered grant_types permit refresh tokens? Defaults to true when unspecified (DCR default includes refresh_token). */
+function allowsRefresh(client: MCPClientRecord): boolean {
+	return !client.grant_types || client.grant_types.includes('refresh_token');
+}
+
+/** Constant-time string compare; length-checks first (timingSafeEqual needs equal length). */
+function safeEqual(a: string, b: string): boolean {
+	const ab = Buffer.from(a);
+	const bb = Buffer.from(b);
+	return ab.length === bb.length && timingSafeEqual(ab, bb);
+}
+
+function parseBasicAuth(authHeader: string | undefined): { clientId: string; clientSecret: string } | null {
+	if (!authHeader || !authHeader.startsWith('Basic ')) return null;
+	let decoded: string;
+	try {
+		decoded = Buffer.from(authHeader.slice('Basic '.length).trim(), 'base64').toString('utf8');
+	} catch {
+		return null;
+	}
+	const sep = decoded.indexOf(':');
+	if (sep < 0) return null;
+	return { clientId: decoded.slice(0, sep), clientSecret: decoded.slice(sep + 1) };
+}
+
+type ClientAuthResult = { client: MCPClientRecord } | { error: TokenResponse };
+
+/**
+ * Authenticate the client per its registered `token_endpoint_auth_method`.
+ * Credentials come from the Authorization: Basic header (client_secret_basic)
+ * or the body (client_secret_post); public clients (`none`) present only a
+ * client_id and rely on PKCE. Mixing methods is rejected (RFC 6749 §2.3).
+ */
+async function authenticateClient(request: Request | undefined, body: any, logger?: Logger): Promise<ClientAuthResult> {
+	const basic = parseBasicAuth(request?.headers?.authorization);
+	const bodyClientId = typeof body?.client_id === 'string' ? body.client_id : undefined;
+	const bodyClientSecret = typeof body?.client_secret === 'string' ? body.client_secret : undefined;
+
+	if (basic && bodyClientSecret) {
+		return { error: errorResponse(400, 'invalid_request', 'Multiple client authentication methods') };
+	}
+	if (basic && bodyClientId && bodyClientId !== basic.clientId) {
+		return { error: errorResponse(400, 'invalid_request', 'client_id mismatch between header and body') };
+	}
+
+	const clientId = basic?.clientId ?? bodyClientId;
+	if (!clientId) {
+		return { error: errorResponse(400, 'invalid_request', 'client_id is required') };
+	}
+
+	const client = await new MCPClientStore(logger).get(clientId);
+	if (!client) {
+		return { error: errorResponse(401, 'invalid_client', 'Unknown client') };
+	}
+
+	const method = client.token_endpoint_auth_method ?? 'none';
+
+	if (method === 'none') {
+		// Public client: PKCE is the proof. A presented secret signals misuse.
+		if (basic || bodyClientSecret) {
+			return { error: errorResponse(401, 'invalid_client', 'Public client must not present a secret') };
+		}
+		return { client };
+	}
+
+	let presentedSecret: string | undefined;
+	if (method === 'client_secret_basic') {
+		if (!basic) {
+			return { error: errorResponse(401, 'invalid_client', 'client_secret_basic requires Authorization: Basic') };
+		}
+		presentedSecret = basic.clientSecret;
+	} else if (method === 'client_secret_post') {
+		if (!bodyClientSecret) {
+			return { error: errorResponse(401, 'invalid_client', 'client_secret_post requires client_secret in body') };
+		}
+		presentedSecret = bodyClientSecret;
+	} else {
+		return { error: errorResponse(401, 'invalid_client', 'Unsupported token endpoint auth method') };
+	}
+
+	if (!presentedSecret || !client.client_secret || !safeEqual(presentedSecret, client.client_secret)) {
+		return { error: errorResponse(401, 'invalid_client', 'Invalid client credentials') };
+	}
+	return { client };
+}
+
+/** PKCE S256: base64url(sha256(code_verifier)) must equal the stored challenge. */
+function pkceMatches(codeVerifier: string, storedChallenge: string): boolean {
+	const computed = createHash('sha256').update(codeVerifier).digest('base64url');
+	return safeEqual(computed, storedChallenge);
+}
+
+async function mintTokenPair(
+	request: Request | undefined,
+	mcpConfig: MCPConfig,
+	grant: { user: string; resource: string; scope?: string; clientId: string; issueRefresh: boolean },
+	logger?: Logger
+): Promise<TokenResponse> {
+	const issuer = resolveIssuer(request as any, mcpConfig);
+	const accessTtl = coerceTtl(mcpConfig.accessTokenTtl, DEFAULT_ACCESS_TOKEN_TTL);
+	const refreshTtl = coerceTtl(mcpConfig.refreshTokenTtl, DEFAULT_REFRESH_TOKEN_TTL);
+
+	const key = await new MCPKeyStore(logger).getSigningKey(mcpConfig);
+	const accessToken = signAccessToken(
+		{
+			issuer,
+			subject: grant.user,
+			audience: grant.resource,
+			clientId: grant.clientId,
+			scope: grant.scope,
+			ttlSeconds: accessTtl,
+		},
+		key
+	);
+
+	const responseBody: Record<string, unknown> = {
+		access_token: accessToken,
+		token_type: 'Bearer',
+		expires_in: accessTtl,
+	};
+	if (grant.scope) responseBody.scope = grant.scope;
+
+	// Only issue a refresh token if the client registered the refresh_token grant.
+	if (grant.issueRefresh) {
+		const familyId = newFamilyId();
+		const { token: refreshToken, hash } = makeRefreshToken(familyId);
+		const now = nowSeconds();
+		await new MCPRefreshFamilyStore(logger).set({
+			family_id: familyId,
+			current_token_hash: hash,
+			revoked: false,
+			client_id: grant.clientId,
+			user: grant.user,
+			resource: grant.resource,
+			scope: grant.scope,
+			created_at: now,
+			expires_at: now + refreshTtl,
+		});
+		responseBody.refresh_token = refreshToken;
+	}
+
+	return { status: 200, body: responseBody, headers: NO_STORE_HEADERS };
+}
+
+async function handleAuthorizationCodeGrant(
+	request: Request | undefined,
+	body: any,
+	client: MCPClientRecord,
+	mcpConfig: MCPConfig,
+	logger?: Logger
+): Promise<TokenResponse> {
+	const code = typeof body?.code === 'string' ? body.code : undefined;
+	const codeVerifier = typeof body?.code_verifier === 'string' ? body.code_verifier : undefined;
+	const redirectUri = typeof body?.redirect_uri === 'string' ? body.redirect_uri : undefined;
+
+	if (!code || !codeVerifier || !redirectUri) {
+		return errorResponse(400, 'invalid_request', 'code, code_verifier, and redirect_uri are required');
+	}
+	if (!CODE_VERIFIER_PATTERN.test(codeVerifier)) {
+		return errorResponse(400, 'invalid_grant', 'code_verifier must be 43-128 unreserved characters (RFC 7636)');
+	}
+
+	const codeStore = new MCPAuthCodeStore(logger);
+	const record = await codeStore.get(code);
+	if (!record) {
+		return errorResponse(400, 'invalid_grant', 'Authorization code is invalid or expired');
+	}
+	if (record.client_id !== client.client_id) {
+		return errorResponse(400, 'invalid_grant', 'Authorization code was issued to a different client');
+	}
+	if (record.redirect_uri !== redirectUri) {
+		return errorResponse(400, 'invalid_grant', 'redirect_uri does not match the authorization request');
+	}
+	if (!pkceMatches(codeVerifier, record.code_challenge)) {
+		return errorResponse(400, 'invalid_grant', 'PKCE verification failed');
+	}
+
+	// Strict single-use consume: if the delete fails, the code might still be
+	// replayable, so refuse to issue rather than risk a double-spend.
+	try {
+		await codeStore.consume(code);
+	} catch (error) {
+		logger?.error?.('MCP token: failed to consume authorization code:', (error as Error).message);
+		return errorResponse(500, 'server_error', 'Failed to consume authorization code');
+	}
+
+	return mintTokenPair(
+		request,
+		mcpConfig,
+		{
+			user: record.user,
+			resource: record.resource,
+			scope: record.scope,
+			clientId: client.client_id,
+			issueRefresh: allowsRefresh(client),
+		},
+		logger
+	);
+}
+
+async function handleRefreshTokenGrant(
+	request: Request | undefined,
+	body: any,
+	client: MCPClientRecord,
+	mcpConfig: MCPConfig,
+	logger?: Logger
+): Promise<TokenResponse> {
+	if (!allowsRefresh(client)) {
+		return errorResponse(400, 'unauthorized_client', 'Client is not authorized for the refresh_token grant');
+	}
+
+	const presented = body?.refresh_token;
+	const parsed = parseRefreshToken(presented);
+	if (!parsed) {
+		return errorResponse(400, 'invalid_grant', 'Malformed refresh_token');
+	}
+
+	const familyStore = new MCPRefreshFamilyStore(logger);
+	const family = await familyStore.get(parsed.familyId);
+	if (!family || family.revoked || family.expires_at <= nowSeconds()) {
+		return errorResponse(400, 'invalid_grant', 'Refresh token is invalid, revoked, or expired');
+	}
+	if (family.client_id !== client.client_id) {
+		return errorResponse(400, 'invalid_grant', 'Refresh token was issued to a different client');
+	}
+
+	if (!safeEqual(hashRefreshToken(presented), family.current_token_hash)) {
+		// A superseded (already-rotated) token was replayed — revoke the family.
+		// Rejecting the replay must not depend on the revoke write succeeding: a
+		// hash mismatch NEVER reissues, and we still try to persist the
+		// revocation (logging if that fails) so a transient write error can't
+		// leave the family live for a retry.
+		family.revoked = true;
+		try {
+			await familyStore.set(family);
+		} catch (error) {
+			logger?.error?.(
+				`MCP token: failed to persist revocation for family ${family.family_id}:`,
+				(error as Error).message
+			);
+		}
+		logger?.warn?.(`MCP token: refresh replay detected; revoked family ${family.family_id}`);
+		return errorResponse(400, 'invalid_grant', 'Refresh token has been superseded; family revoked');
+	}
+
+	// Rotate: overwrite the family's current token, keep the original expiry.
+	const issuer = resolveIssuer(request as any, mcpConfig);
+	const accessTtl = coerceTtl(mcpConfig.accessTokenTtl, DEFAULT_ACCESS_TOKEN_TTL);
+	const { token: newRefreshToken, hash: newHash } = makeRefreshToken(family.family_id);
+	family.current_token_hash = newHash;
+	await familyStore.set(family);
+
+	const key = await new MCPKeyStore(logger).getSigningKey(mcpConfig);
+	const accessToken = signAccessToken(
+		{
+			issuer,
+			subject: family.user,
+			audience: family.resource,
+			clientId: client.client_id,
+			scope: family.scope,
+			ttlSeconds: accessTtl,
+		},
+		key
+	);
+
+	const responseBody: Record<string, unknown> = {
+		access_token: accessToken,
+		token_type: 'Bearer',
+		expires_in: accessTtl,
+		refresh_token: newRefreshToken,
+	};
+	if (family.scope) responseBody.scope = family.scope;
+	return { status: 200, body: responseBody, headers: NO_STORE_HEADERS };
+}
+
+/**
+ * Handle POST /oauth/mcp/token. Returns `{ status, body }`; the `enabled` gate
+ * is applied upstream in handleMCPPost.
+ */
+export async function handleToken(
+	request: Request | undefined,
+	body: any,
+	mcpConfig: MCPConfig,
+	logger?: Logger
+): Promise<TokenResponse> {
+	const grantType = typeof body?.grant_type === 'string' ? body.grant_type : undefined;
+	if (grantType !== 'authorization_code' && grantType !== 'refresh_token') {
+		return errorResponse(400, 'unsupported_grant_type', 'grant_type must be authorization_code or refresh_token');
+	}
+
+	const auth = await authenticateClient(request, body, logger);
+	if ('error' in auth) {
+		return auth.error;
+	}
+
+	if (grantType === 'authorization_code') {
+		return handleAuthorizationCodeGrant(request, body, auth.client, mcpConfig, logger);
+	}
+	return handleRefreshTokenGrant(request, body, auth.client, mcpConfig, logger);
+}

--- a/src/lib/mcp/tokenIssuer.ts
+++ b/src/lib/mcp/tokenIssuer.ts
@@ -1,0 +1,79 @@
+/**
+ * MCP Access-Token Issuer
+ *
+ * Mints and verifies RS256 JWT access tokens, and serializes public keys to
+ * JWK form for the JWKS endpoint. Tokens are stateless and audience-bound
+ * (RFC 8707 / RFC 9068-aligned): the `aud` claim carries the canonical MCP
+ * resource URI, so Stage 5's `withMCPAuth` can reject tokens minted for a
+ * different resource. No upstream IdP token is ever embedded.
+ *
+ * RS256 only in v1 — `jsonwebtoken` cannot emit EdDSA. EdDSA would require a
+ * JOSE implementation and is deferred (see #86 follow-up).
+ */
+
+import { createPublicKey, randomUUID } from 'node:crypto';
+import jwt from 'jsonwebtoken';
+import type { MCPSigningKeyRecord } from '../../types.ts';
+
+export interface MintAccessTokenParams {
+	issuer: string;
+	subject: string;
+	/** Canonical resource URI — becomes the `aud` claim (RFC 8707). */
+	audience: string;
+	clientId: string;
+	scope?: string;
+	/** Access-token lifetime in seconds. */
+	ttlSeconds: number;
+}
+
+/**
+ * Sign an access token. `iat`/`exp` are set from `ttlSeconds`, `jti` is a fresh
+ * UUID, and registered claims are populated via jsonwebtoken's options so the
+ * payload carries only `client_id` + `scope`.
+ */
+export function signAccessToken(params: MintAccessTokenParams, key: MCPSigningKeyRecord): string {
+	const payload: Record<string, unknown> = { client_id: params.clientId };
+	if (params.scope) payload.scope = params.scope;
+	return jwt.sign(payload, key.private_key_pem, {
+		algorithm: 'RS256',
+		keyid: key.kid,
+		issuer: params.issuer,
+		audience: params.audience,
+		subject: params.subject,
+		jwtid: randomUUID(),
+		expiresIn: params.ttlSeconds,
+	});
+}
+
+export interface VerifyOptions {
+	audience?: string;
+	issuer?: string;
+}
+
+/**
+ * Verify an access token against a public key. Primarily for tests; Stage 5
+ * performs production verification against the published JWKS.
+ */
+export function verifyAccessToken(token: string, publicKeyPem: string, options?: VerifyOptions): jwt.JwtPayload {
+	return jwt.verify(token, publicKeyPem, {
+		algorithms: ['RS256'],
+		audience: options?.audience,
+		issuer: options?.issuer,
+	}) as jwt.JwtPayload;
+}
+
+/**
+ * Serialize an RSA public key (PEM) to a JWK for publication at the JWKS
+ * endpoint. Includes `use`, `alg`, and `kid` so verifiers can select the key.
+ */
+export function publicKeyToJwk(publicKeyPem: string, kid: string, alg = 'RS256'): Record<string, string> {
+	const jwk = createPublicKey(publicKeyPem).export({ format: 'jwk' }) as { n: string; e: string };
+	return {
+		kty: 'RSA',
+		n: jwk.n,
+		e: jwk.e,
+		alg,
+		use: 'sig',
+		kid,
+	};
+}

--- a/src/lib/mcp/wellKnown.ts
+++ b/src/lib/mcp/wellKnown.ts
@@ -23,6 +23,8 @@
  */
 
 import type { Logger, MCPConfig } from '../../types.ts';
+import { MCPKeyStore } from './keyStore.ts';
+import { publicKeyToJwk } from './tokenIssuer.ts';
 
 interface HarperRequest {
 	pathname?: string;
@@ -117,10 +119,9 @@ export function buildAuthorizationServerMetadata(
 		grant_types_supported: ['authorization_code', 'refresh_token'],
 		code_challenge_methods_supported: ['S256'],
 		token_endpoint_auth_methods_supported: ['none', 'client_secret_basic', 'client_secret_post'],
-		// Advertise both signing algorithms; the concrete key is selected at
-		// token-mint time (Stage 4). Empty until that lands; clients see this
-		// advertisement and the empty JWKS together for now.
-		id_token_signing_alg_values_supported: ['RS256', 'EdDSA'],
+		// RS256 only in v1 — jsonwebtoken cannot emit EdDSA. Matches the key
+		// served at the JWKS endpoint; EdDSA is deferred (would need a JOSE lib).
+		id_token_signing_alg_values_supported: ['RS256'],
 		// RFC 8707 §2: server understands the `resource` parameter.
 		resource_parameter_supported: true,
 		// CORS-friendly metadata is the spec norm; we serve cross-origin reads.
@@ -129,16 +130,19 @@ export function buildAuthorizationServerMetadata(
 }
 
 /**
- * JWKS document. Placeholder until Stage 4 generates and persists signing keys
- * in the `harper_oauth_mcp_keys` table.
+ * JWKS document — the public half of the signing key(s) in
+ * `harper_oauth_mcp_keys`, serialized to JWK. Read-only: it never triggers key
+ * generation (an unauthenticated fetch must not mint key material), so the set
+ * is empty until the first access token is issued.
  */
-export function buildJWKS(_mcpConfig: MCPConfig): Record<string, unknown> {
-	return { keys: [] };
+export async function buildJWKS(_mcpConfig: MCPConfig): Promise<Record<string, unknown>> {
+	const keys = await new MCPKeyStore().getAllPublicKeys();
+	return { keys: keys.map((k) => publicKeyToJwk(k.public_key_pem, k.kid, k.alg)) };
 }
 
 type WellKnownMatch = {
 	exactPath: string;
-	build: (request: HarperRequest, mcpConfig: MCPConfig) => Record<string, unknown>;
+	build: (request: HarperRequest, mcpConfig: MCPConfig) => Record<string, unknown> | Promise<Record<string, unknown>>;
 };
 
 const HANDLERS: WellKnownMatch[] = [
@@ -161,12 +165,12 @@ function makeHandler(
 	getConfig: () => MCPConfig | undefined,
 	logger?: Logger
 ): (req: HarperRequest, next: (r: HarperRequest) => any) => any {
-	return (req, next) => {
+	return async (req, next) => {
 		const cfg = getConfig();
 		if (!cfg?.enabled) return next(req);
 		if (req.pathname !== match.exactPath) return next(req);
 		try {
-			return jsonResponse(match.build(req, cfg));
+			return jsonResponse(await match.build(req, cfg));
 		} catch (error) {
 			logger?.error?.(`MCP well-known handler ${match.exactPath} failed:`, (error as Error).message);
 			return jsonResponse({ error: 'server_error' }, 500);

--- a/src/lib/mcp/wellKnown.ts
+++ b/src/lib/mcp/wellKnown.ts
@@ -72,7 +72,11 @@ function jsonResponse(body: unknown, status = 200): HttpResponse {
  * explicitly regardless. Documented in docs/configuration.md.
  */
 export function resolveIssuer(request: HarperRequest, mcpConfig: MCPConfig): string {
-	if (mcpConfig.issuer) return mcpConfig.issuer;
+	if (mcpConfig.issuer) {
+		// Strip trailing slashes so the `iss` claim and `${issuer}/oauth/...`
+		// endpoint URLs don't end up with a doubled slash.
+		return mcpConfig.issuer.replace(/\/+$/, '');
+	}
 	const host = request.host ?? request.headers?.host ?? 'localhost';
 	const scheme = request.protocol ?? 'https';
 	return `${scheme}://${host}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,23 @@ export interface MCPConfig {
 	providers?: string[];
 	/** Dynamic Client Registration settings (RFC 7591) */
 	dynamicClientRegistration?: MCPDynamicClientRegistrationConfig;
+	/**
+	 * JWT signing algorithm for issued access tokens. Only "RS256" is supported
+	 * in v1 — jsonwebtoken cannot emit EdDSA. Reserved for a future EdDSA option.
+	 * Default: "RS256".
+	 */
+	signingAlgorithm?: 'RS256';
+	/**
+	 * PEM-encoded RS256 private key (PKCS#8) to sign access tokens with. When
+	 * set, it is persisted to the keys table on first use instead of generating
+	 * one — operators provide the same key on every node for deterministic,
+	 * race-free key material. When unset, a keypair is generated on first boot.
+	 */
+	signingKeyPem?: string;
+	/** Access-token lifetime in seconds. Default: 3600 (1h). */
+	accessTokenTtl?: number;
+	/** Refresh-token (family) lifetime in seconds. Default: 2592000 (30d). */
+	refreshTokenTtl?: number;
 }
 
 /**
@@ -174,6 +191,41 @@ export interface MCPAuthCodeRecord {
 	redirect_uri: string;
 	scope?: string;
 	created_at: number;
+}
+
+/**
+ * MCP JWT signing key record (table `harper_oauth_mcp_keys`).
+ *
+ * The private half never leaves the server; only the public half is published
+ * at /.well-known/jwks.json. `kid` is surfaced in the JWT header so verifiers
+ * can select the right key.
+ */
+export interface MCPSigningKeyRecord {
+	kid: string;
+	alg: string;
+	public_key_pem: string;
+	private_key_pem: string;
+	created_at: number;
+}
+
+/**
+ * MCP refresh-token family record (table `mcp_refresh_families`).
+ *
+ * The opaque token issued to the client is `<family_id>.<secret>`; only the
+ * SHA-256 hash of the full value is persisted (`current_token_hash`). Rotation
+ * overwrites the hash; replay of a superseded token (hash mismatch) sets
+ * `revoked`, which invalidates the whole family.
+ */
+export interface MCPRefreshFamilyRecord {
+	family_id: string;
+	current_token_hash: string;
+	revoked: boolean;
+	client_id: string;
+	user: string;
+	resource: string;
+	scope?: string;
+	created_at: number;
+	expires_at: number;
 }
 
 /**

--- a/test/lib/mcp/keyStore.test.js
+++ b/test/lib/mcp/keyStore.test.js
@@ -1,0 +1,96 @@
+/**
+ * Tests for MCPKeyStore — first-boot generation, reuse, config-provided keys,
+ * and JWKS publication.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createPublicKey, generateKeyPairSync } from 'node:crypto';
+import { MCPKeyStore, resetMCPKeysTableCache, SIGNING_KEY_ID } from '../../../dist/lib/mcp/keyStore.js';
+
+function asTrackedObject(plain) {
+	return new Proxy(plain, {
+		ownKeys() {
+			return [];
+		},
+		getOwnPropertyDescriptor() {
+			return undefined;
+		},
+	});
+}
+
+describe('MCPKeyStore', () => {
+	let store;
+	let originalDatabases;
+	let stored;
+
+	before(() => {
+		originalDatabases = global.databases;
+	});
+	after(() => {
+		global.databases = originalDatabases;
+	});
+
+	beforeEach(() => {
+		resetMCPKeysTableCache();
+		store = new MCPKeyStore();
+		stored = new Map();
+		global.databases = {
+			oauth: {
+				harper_oauth_mcp_keys: {
+					get: async (id) => {
+						const raw = stored.get(id);
+						return raw ? asTrackedObject(raw) : null;
+					},
+					put: async (rec) => {
+						stored.set(rec.kid, rec);
+					},
+					delete: async (id) => {
+						stored.delete(id);
+					},
+				},
+			},
+		};
+	});
+
+	it('returns null and an empty JWKS set before any key exists', async () => {
+		assert.equal(await store.get(), null);
+		assert.deepEqual(await store.getAllPublicKeys(), []);
+	});
+
+	it('generates and persists an RS256 keypair on first use', async () => {
+		const key = await store.getSigningKey();
+		assert.equal(key.kid, SIGNING_KEY_ID);
+		assert.equal(key.alg, 'RS256');
+		assert.match(key.public_key_pem, /BEGIN PUBLIC KEY/);
+		assert.match(key.private_key_pem, /BEGIN PRIVATE KEY/);
+		assert.equal(stored.size, 1, 'persisted to the table');
+	});
+
+	it('reuses the persisted key on subsequent calls (cached)', async () => {
+		const first = await store.getSigningKey();
+		resetMCPKeysTableCache(); // drop the in-process cache; force a table read
+		const second = await new MCPKeyStore().getSigningKey();
+		assert.equal(second.public_key_pem, first.public_key_pem, 'same key reused, not regenerated');
+		assert.equal(stored.size, 1);
+	});
+
+	it('uses a config-provided signing key instead of generating one', async () => {
+		const { privateKey } = generateKeyPairSync('rsa', {
+			modulusLength: 2048,
+			publicKeyEncoding: { type: 'spki', format: 'pem' },
+			privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+		});
+		const key = await store.getSigningKey({ signingKeyPem: privateKey });
+		assert.equal(key.private_key_pem, privateKey);
+		const expectedPublic = createPublicKey(privateKey).export({ type: 'spki', format: 'pem' });
+		assert.equal(key.public_key_pem, expectedPublic, 'public half derived from the provided private key');
+	});
+
+	it('publishes the public key in the JWKS set once a key exists', async () => {
+		await store.getSigningKey();
+		const keys = await store.getAllPublicKeys();
+		assert.equal(keys.length, 1);
+		assert.equal(keys[0].kid, SIGNING_KEY_ID);
+	});
+});

--- a/test/lib/mcp/refreshTokenStore.test.js
+++ b/test/lib/mcp/refreshTokenStore.test.js
@@ -1,0 +1,134 @@
+/**
+ * Tests for the refresh-token family store and its token helpers.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import {
+	MCPRefreshFamilyStore,
+	resetMCPRefreshFamiliesTableCache,
+	makeRefreshToken,
+	hashRefreshToken,
+	parseRefreshToken,
+	newFamilyId,
+} from '../../../dist/lib/mcp/refreshTokenStore.js';
+
+function asTrackedObject(plain) {
+	return new Proxy(plain, {
+		ownKeys() {
+			return [];
+		},
+		getOwnPropertyDescriptor() {
+			return undefined;
+		},
+	});
+}
+
+describe('refresh-token helpers', () => {
+	it('hashes a token as base64url sha256', () => {
+		const expected = createHash('sha256').update('abc.def').digest('base64url');
+		assert.equal(hashRefreshToken('abc.def'), expected);
+	});
+
+	it('mints a token of the form <family_id>.<secret> with a matching hash', () => {
+		const familyId = newFamilyId();
+		const { token, hash } = makeRefreshToken(familyId);
+		assert.ok(token.startsWith(`${familyId}.`));
+		assert.equal(hash, hashRefreshToken(token));
+		assert.deepEqual(parseRefreshToken(token), { familyId });
+	});
+
+	it('mints distinct secrets each call', () => {
+		const familyId = newFamilyId();
+		assert.notEqual(makeRefreshToken(familyId).token, makeRefreshToken(familyId).token);
+	});
+
+	it('rejects malformed refresh tokens', () => {
+		assert.equal(parseRefreshToken(undefined), null);
+		assert.equal(parseRefreshToken(42), null);
+		assert.equal(parseRefreshToken('no-dot'), null);
+		assert.equal(parseRefreshToken('.leading'), null);
+		assert.equal(parseRefreshToken('trailing.'), null);
+	});
+});
+
+describe('MCPRefreshFamilyStore', () => {
+	let store;
+	let originalDatabases;
+	let stored;
+
+	before(() => {
+		originalDatabases = global.databases;
+	});
+	after(() => {
+		global.databases = originalDatabases;
+	});
+
+	beforeEach(() => {
+		resetMCPRefreshFamiliesTableCache();
+		store = new MCPRefreshFamilyStore();
+		stored = new Map();
+		global.databases = {
+			oauth: {
+				mcp_refresh_families: {
+					get: async (id) => {
+						const raw = stored.get(id);
+						return raw ? asTrackedObject(raw) : null;
+					},
+					put: async (rec) => {
+						stored.set(rec.family_id, rec);
+					},
+					delete: async (id) => {
+						stored.delete(id);
+					},
+				},
+			},
+		};
+	});
+
+	const sample = {
+		family_id: 'fam-1',
+		current_token_hash: 'hash-abc',
+		revoked: false,
+		client_id: 'client-123',
+		user: 'alice@example.com',
+		resource: 'https://app.example.com/mcp',
+		scope: 'mcp:read',
+		created_at: 1700000000,
+		expires_at: 1700086400,
+	};
+
+	it('persists and retrieves a family through the tracked-object Proxy', async () => {
+		await store.set(sample);
+		const got = await store.get('fam-1');
+		assert.ok(got);
+		assert.equal(got.family_id, 'fam-1');
+		assert.equal(got.current_token_hash, 'hash-abc');
+		assert.equal(got.revoked, false);
+		assert.equal(got.client_id, 'client-123');
+		assert.equal(got.user, 'alice@example.com');
+		assert.equal(got.resource, 'https://app.example.com/mcp');
+		assert.equal(got.scope, 'mcp:read');
+		assert.equal(got.expires_at, 1700086400);
+	});
+
+	it('returns null for an unknown family', async () => {
+		assert.equal(await store.get('nope'), null);
+	});
+
+	it('decodes a missing revoked flag as false', async () => {
+		const { revoked, ...withoutRevoked } = sample;
+		void revoked;
+		await store.set(withoutRevoked);
+		const got = await store.get('fam-1');
+		assert.equal(got.revoked, false);
+	});
+
+	it('propagates set() errors so the caller can fail the request', async () => {
+		global.databases.oauth.mcp_refresh_families.put = async () => {
+			throw new Error('db write failure');
+		};
+		await assert.rejects(() => store.set(sample));
+	});
+});

--- a/test/lib/mcp/token.test.js
+++ b/test/lib/mcp/token.test.js
@@ -1,0 +1,565 @@
+/**
+ * Tests for the MCP token endpoint (handleToken): authorization_code exchange,
+ * PKCE verification, single-use consume, client authentication (all methods),
+ * and refresh-token rotation / replay revocation.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash, generateKeyPairSync, randomBytes } from 'node:crypto';
+import { handleToken } from '../../../dist/lib/mcp/token.js';
+import { resetMCPAuthCodesTableCache } from '../../../dist/lib/mcp/authCodeStore.js';
+import { resetMCPClientsTableCache } from '../../../dist/lib/mcp/clientStore.js';
+import { resetMCPKeysTableCache, SIGNING_KEY_ID } from '../../../dist/lib/mcp/keyStore.js';
+import { resetMCPRefreshFamiliesTableCache, makeRefreshToken } from '../../../dist/lib/mcp/refreshTokenStore.js';
+import { verifyAccessToken } from '../../../dist/lib/mcp/tokenIssuer.js';
+
+function asTrackedObject(plain) {
+	return new Proxy(plain, {
+		ownKeys() {
+			return [];
+		},
+		getOwnPropertyDescriptor() {
+			return undefined;
+		},
+	});
+}
+
+function makeTable(map, pkField) {
+	return {
+		get: async (id) => {
+			const raw = map.get(id);
+			return raw ? asTrackedObject(raw) : null;
+		},
+		put: async (rec) => {
+			map.set(rec[pkField], rec);
+		},
+		delete: async (id) => {
+			map.delete(id);
+		},
+	};
+}
+
+const keypair = generateKeyPairSync('rsa', {
+	modulusLength: 2048,
+	publicKeyEncoding: { type: 'spki', format: 'pem' },
+	privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+const CODE_VERIFIER = randomBytes(32).toString('base64url'); // 43 chars, valid
+const CODE_CHALLENGE = createHash('sha256').update(CODE_VERIFIER).digest('base64url');
+
+const RESOURCE = 'https://app.example.com/mcp';
+const ISSUER = 'https://as.example.com';
+const REDIRECT = 'https://mcp.example.com/cb';
+const CONF_SECRET = 's3cret-value-xyz-0123456789';
+
+const mcpConfig = {
+	enabled: true,
+	issuer: ISSUER,
+	resource: RESOURCE,
+	accessTokenTtl: 3600,
+	refreshTokenTtl: 86400,
+};
+
+function basicHeader(clientId, secret) {
+	return { authorization: `Basic ${Buffer.from(`${clientId}:${secret}`).toString('base64')}` };
+}
+
+describe('handleToken', () => {
+	let originalDatabases;
+	let clients;
+	let codes;
+	let families;
+	let keys;
+
+	before(() => {
+		originalDatabases = global.databases;
+	});
+	after(() => {
+		global.databases = originalDatabases;
+	});
+
+	beforeEach(() => {
+		resetMCPClientsTableCache();
+		resetMCPAuthCodesTableCache();
+		resetMCPRefreshFamiliesTableCache();
+		resetMCPKeysTableCache();
+
+		clients = new Map();
+		codes = new Map();
+		families = new Map();
+		keys = new Map();
+
+		// Seed signing key so no per-test generation is needed.
+		keys.set(SIGNING_KEY_ID, {
+			kid: SIGNING_KEY_ID,
+			alg: 'RS256',
+			public_key_pem: keypair.publicKey,
+			private_key_pem: keypair.privateKey,
+			created_at: 1700000000,
+		});
+		// A public client (PKCE only) and a confidential client (basic auth).
+		clients.set('public-1', {
+			client_id: 'public-1',
+			token_endpoint_auth_method: 'none',
+			redirect_uris: JSON.stringify([REDIRECT]),
+			client_id_issued_at: 1700000000,
+		});
+		clients.set('conf-1', {
+			client_id: 'conf-1',
+			client_secret: CONF_SECRET,
+			token_endpoint_auth_method: 'client_secret_basic',
+			redirect_uris: JSON.stringify([REDIRECT]),
+			client_id_issued_at: 1700000000,
+		});
+
+		global.databases = {
+			oauth: {
+				harper_oauth_mcp_clients: makeTable(clients, 'client_id'),
+				mcp_auth_codes: makeTable(codes, 'code'),
+				mcp_refresh_families: makeTable(families, 'family_id'),
+				harper_oauth_mcp_keys: makeTable(keys, 'kid'),
+			},
+		};
+	});
+
+	function seedCode(code, overrides = {}) {
+		codes.set(code, {
+			code,
+			client_id: 'public-1',
+			user: 'alice@example.com',
+			resource: RESOURCE,
+			code_challenge: CODE_CHALLENGE,
+			code_challenge_method: 'S256',
+			redirect_uri: REDIRECT,
+			scope: 'mcp:read',
+			created_at: 1700000000,
+			...overrides,
+		});
+	}
+
+	// ---- grant_type dispatch ----
+
+	it('rejects an unsupported grant_type', async () => {
+		const res = await handleToken({ headers: {} }, { grant_type: 'password' }, mcpConfig);
+		assert.equal(res.status, 400);
+		assert.equal(res.body.error, 'unsupported_grant_type');
+	});
+
+	it('rejects a missing grant_type', async () => {
+		const res = await handleToken({ headers: {} }, {}, mcpConfig);
+		assert.equal(res.body.error, 'unsupported_grant_type');
+	});
+
+	// ---- authorization_code happy path ----
+
+	it('exchanges an authorization code for an audience-bound JWT + refresh token', async () => {
+		seedCode('code-1');
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+			},
+			mcpConfig
+		);
+		assert.equal(res.status, 200);
+		assert.equal(res.body.token_type, 'Bearer');
+		assert.equal(res.body.expires_in, 3600);
+		assert.equal(res.body.scope, 'mcp:read');
+		assert.ok(res.body.access_token);
+		assert.ok(res.body.refresh_token);
+
+		const claims = verifyAccessToken(res.body.access_token, keypair.publicKey, { audience: RESOURCE, issuer: ISSUER });
+		assert.equal(claims.sub, 'alice@example.com');
+		assert.equal(claims.client_id, 'public-1');
+		assert.equal(claims.scope, 'mcp:read');
+
+		assert.equal(codes.has('code-1'), false, 'code consumed (single-use)');
+		assert.equal(families.size, 1, 'refresh family persisted');
+	});
+
+	it('sets no-store cache headers on a successful token response (RFC 6749 §5.1)', async () => {
+		seedCode('code-1');
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+			},
+			mcpConfig
+		);
+		assert.equal(res.headers['Cache-Control'], 'no-store');
+		assert.equal(res.headers['Pragma'], 'no-cache');
+	});
+
+	it('coerces string TTLs (from ${ENV}/quoted YAML) to numeric seconds', async () => {
+		seedCode('code-1');
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+			},
+			{ ...mcpConfig, accessTokenTtl: '3600', refreshTokenTtl: '86400' }
+		);
+		assert.equal(res.body.expires_in, 3600);
+		const claims = verifyAccessToken(res.body.access_token, keypair.publicKey, { audience: RESOURCE, issuer: ISSUER });
+		assert.equal(claims.exp - claims.iat, 3600, 'JWT lifetime is 3600 seconds, not 3600 ms');
+	});
+
+	it('omits the refresh token when the client did not register the refresh_token grant', async () => {
+		clients.set('noref-1', {
+			client_id: 'noref-1',
+			token_endpoint_auth_method: 'none',
+			grant_types: JSON.stringify(['authorization_code']),
+			redirect_uris: JSON.stringify([REDIRECT]),
+			client_id_issued_at: 1700000000,
+		});
+		seedCode('code-1', { client_id: 'noref-1' });
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'noref-1',
+			},
+			mcpConfig
+		);
+		assert.equal(res.status, 200);
+		assert.ok(res.body.access_token);
+		assert.equal(res.body.refresh_token, undefined, 'no refresh token issued');
+		assert.equal(families.size, 0, 'no refresh family persisted');
+	});
+
+	// ---- authorization_code rejection branches ----
+
+	it('rejects when code, code_verifier, or redirect_uri is missing', async () => {
+		seedCode('code-1');
+		const res = await handleToken(
+			{ headers: {} },
+			{ grant_type: 'authorization_code', code: 'code-1', client_id: 'public-1' },
+			mcpConfig
+		);
+		assert.equal(res.status, 400);
+		assert.equal(res.body.error, 'invalid_request');
+	});
+
+	it('rejects a malformed code_verifier (RFC 7636 syntax)', async () => {
+		seedCode('code-1');
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: 'too-short',
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+			},
+			mcpConfig
+		);
+		assert.equal(res.body.error, 'invalid_grant');
+		assert.match(res.body.error_description, /code_verifier/);
+	});
+
+	it('rejects an unknown/expired authorization code', async () => {
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'nope',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+			},
+			mcpConfig
+		);
+		assert.equal(res.body.error, 'invalid_grant');
+	});
+
+	it('rejects a code issued to a different client', async () => {
+		seedCode('code-1', { client_id: 'someone-else' });
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+			},
+			mcpConfig
+		);
+		assert.equal(res.body.error, 'invalid_grant');
+		assert.equal(codes.has('code-1'), true, 'code NOT consumed on rejection');
+	});
+
+	it('rejects a mismatched redirect_uri', async () => {
+		seedCode('code-1');
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: 'https://evil.example.com/cb',
+				client_id: 'public-1',
+			},
+			mcpConfig
+		);
+		assert.equal(res.body.error, 'invalid_grant');
+	});
+
+	it('rejects a failed PKCE verification', async () => {
+		seedCode('code-1');
+		const wrongVerifier = randomBytes(32).toString('base64url');
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: wrongVerifier,
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+			},
+			mcpConfig
+		);
+		assert.equal(res.body.error, 'invalid_grant');
+		assert.match(res.body.error_description, /PKCE/);
+		assert.equal(codes.has('code-1'), true, 'code NOT consumed when PKCE fails');
+	});
+
+	it('returns server_error and does not issue if the code consume fails', async () => {
+		seedCode('code-1');
+		global.databases.oauth.mcp_auth_codes.delete = async () => {
+			throw new Error('delete failed');
+		};
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+			},
+			mcpConfig
+		);
+		assert.equal(res.status, 500);
+		assert.equal(res.body.error, 'server_error');
+		assert.equal(families.size, 0, 'no token issued when consume fails');
+	});
+
+	// ---- client authentication ----
+
+	it('rejects an unknown client', async () => {
+		seedCode('code-1');
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'ghost',
+			},
+			mcpConfig
+		);
+		assert.equal(res.status, 401);
+		assert.equal(res.body.error, 'invalid_client');
+	});
+
+	it('rejects a public client that presents a secret', async () => {
+		seedCode('code-1');
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+				client_secret: 'unexpected',
+			},
+			mcpConfig
+		);
+		assert.equal(res.body.error, 'invalid_client');
+	});
+
+	it('authenticates a confidential client via client_secret_basic', async () => {
+		seedCode('code-1', { client_id: 'conf-1' });
+		const res = await handleToken(
+			{ headers: basicHeader('conf-1', CONF_SECRET) },
+			{ grant_type: 'authorization_code', code: 'code-1', code_verifier: CODE_VERIFIER, redirect_uri: REDIRECT },
+			mcpConfig
+		);
+		assert.equal(res.status, 200);
+		assert.ok(res.body.access_token);
+	});
+
+	it('rejects a confidential client with a wrong secret', async () => {
+		seedCode('code-1', { client_id: 'conf-1' });
+		const res = await handleToken(
+			{ headers: basicHeader('conf-1', 'wrong-secret') },
+			{ grant_type: 'authorization_code', code: 'code-1', code_verifier: CODE_VERIFIER, redirect_uri: REDIRECT },
+			mcpConfig
+		);
+		assert.equal(res.status, 401);
+		assert.equal(res.body.error, 'invalid_client');
+	});
+
+	it('rejects mixing Basic header with a body client_secret', async () => {
+		seedCode('code-1', { client_id: 'conf-1' });
+		const res = await handleToken(
+			{ headers: basicHeader('conf-1', CONF_SECRET) },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_secret: CONF_SECRET,
+			},
+			mcpConfig
+		);
+		assert.equal(res.status, 400);
+		assert.equal(res.body.error, 'invalid_request');
+	});
+
+	// ---- refresh_token rotation ----
+
+	function seedFamily(familyId, overrides = {}) {
+		const { token, hash } = makeRefreshToken(familyId);
+		families.set(familyId, {
+			family_id: familyId,
+			current_token_hash: hash,
+			revoked: false,
+			client_id: 'public-1',
+			user: 'alice@example.com',
+			resource: RESOURCE,
+			scope: 'mcp:read',
+			created_at: 1700000000,
+			expires_at: Math.floor(Date.now() / 1000) + 86400,
+			...overrides,
+		});
+		return token;
+	}
+
+	it('rotates a refresh token and issues a fresh access token', async () => {
+		const token = seedFamily('fam-1');
+		const res = await handleToken(
+			{ headers: {} },
+			{ grant_type: 'refresh_token', refresh_token: token, client_id: 'public-1' },
+			mcpConfig
+		);
+		assert.equal(res.status, 200);
+		assert.ok(res.body.access_token);
+		assert.notEqual(res.body.refresh_token, token, 'a new refresh token is issued');
+		const claims = verifyAccessToken(res.body.access_token, keypair.publicKey, { audience: RESOURCE, issuer: ISSUER });
+		assert.equal(claims.sub, 'alice@example.com');
+	});
+
+	it('detects replay of a superseded refresh token and revokes the family', async () => {
+		const oldToken = seedFamily('fam-1');
+		const rotated = await handleToken(
+			{ headers: {} },
+			{ grant_type: 'refresh_token', refresh_token: oldToken, client_id: 'public-1' },
+			mcpConfig
+		);
+		const newToken = rotated.body.refresh_token;
+
+		// Replay the OLD token → invalid_grant + family revoked.
+		const replay = await handleToken(
+			{ headers: {} },
+			{ grant_type: 'refresh_token', refresh_token: oldToken, client_id: 'public-1' },
+			mcpConfig
+		);
+		assert.equal(replay.body.error, 'invalid_grant');
+		assert.equal(families.get('fam-1').revoked, true, 'family revoked on replay');
+
+		// The legitimate (rotated) token is now dead too — whole family is revoked.
+		const afterRevoke = await handleToken(
+			{ headers: {} },
+			{ grant_type: 'refresh_token', refresh_token: newToken, client_id: 'public-1' },
+			mcpConfig
+		);
+		assert.equal(afterRevoke.body.error, 'invalid_grant');
+	});
+
+	it('still rejects a replayed token when persisting the revocation fails', async () => {
+		const oldToken = seedFamily('fam-1');
+		await handleToken(
+			{ headers: {} },
+			{ grant_type: 'refresh_token', refresh_token: oldToken, client_id: 'public-1' },
+			mcpConfig
+		); // rotate, superseding oldToken
+		// A write failure during revocation must not turn the rejection into a 500.
+		global.databases.oauth.mcp_refresh_families.put = async () => {
+			throw new Error('write failed');
+		};
+		const res = await handleToken(
+			{ headers: {} },
+			{ grant_type: 'refresh_token', refresh_token: oldToken, client_id: 'public-1' },
+			mcpConfig
+		);
+		assert.equal(res.status, 400);
+		assert.equal(res.body.error, 'invalid_grant', 'replay rejected even though revoke persist failed');
+	});
+
+	it('rejects a refresh token presented by a different client', async () => {
+		const token = seedFamily('fam-1'); // bound to public-1
+		const res = await handleToken(
+			{ headers: basicHeader('conf-1', CONF_SECRET) },
+			{ grant_type: 'refresh_token', refresh_token: token },
+			mcpConfig
+		);
+		assert.equal(res.body.error, 'invalid_grant');
+	});
+
+	it('rejects an expired refresh family', async () => {
+		const token = seedFamily('fam-1', { expires_at: Math.floor(Date.now() / 1000) - 1 });
+		const res = await handleToken(
+			{ headers: {} },
+			{ grant_type: 'refresh_token', refresh_token: token, client_id: 'public-1' },
+			mcpConfig
+		);
+		assert.equal(res.body.error, 'invalid_grant');
+	});
+
+	it('rejects the refresh grant for a client that did not register it', async () => {
+		clients.set('noref-1', {
+			client_id: 'noref-1',
+			token_endpoint_auth_method: 'none',
+			grant_types: JSON.stringify(['authorization_code']),
+			redirect_uris: JSON.stringify([REDIRECT]),
+			client_id_issued_at: 1700000000,
+		});
+		const token = seedFamily('fam-1', { client_id: 'noref-1' });
+		const res = await handleToken(
+			{ headers: {} },
+			{ grant_type: 'refresh_token', refresh_token: token, client_id: 'noref-1' },
+			mcpConfig
+		);
+		assert.equal(res.body.error, 'unauthorized_client');
+	});
+
+	it('rejects a malformed refresh token', async () => {
+		const res = await handleToken(
+			{ headers: {} },
+			{ grant_type: 'refresh_token', refresh_token: 'garbage', client_id: 'public-1' },
+			mcpConfig
+		);
+		assert.equal(res.body.error, 'invalid_grant');
+	});
+});

--- a/test/lib/mcp/token.test.js
+++ b/test/lib/mcp/token.test.js
@@ -437,6 +437,55 @@ describe('handleToken', () => {
 		assert.equal(res.body.error, 'invalid_request');
 	});
 
+	it('authenticates a confidential client via client_secret_post (secret in body)', async () => {
+		clients.set('post-1', {
+			client_id: 'post-1',
+			client_secret: CONF_SECRET,
+			token_endpoint_auth_method: 'client_secret_post',
+			redirect_uris: JSON.stringify([REDIRECT]),
+			client_id_issued_at: 1700000000,
+		});
+		seedCode('code-1', { client_id: 'post-1' });
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'post-1',
+				client_secret: CONF_SECRET,
+			},
+			mcpConfig
+		);
+		assert.equal(res.status, 200);
+		assert.ok(res.body.access_token);
+	});
+
+	it('rejects a client_secret_post client that omits its secret', async () => {
+		clients.set('post-1', {
+			client_id: 'post-1',
+			client_secret: CONF_SECRET,
+			token_endpoint_auth_method: 'client_secret_post',
+			redirect_uris: JSON.stringify([REDIRECT]),
+			client_id_issued_at: 1700000000,
+		});
+		seedCode('code-1', { client_id: 'post-1' });
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'post-1',
+			},
+			mcpConfig
+		);
+		assert.equal(res.status, 401);
+		assert.equal(res.body.error, 'invalid_client');
+	});
+
 	// ---- refresh_token rotation ----
 
 	function seedFamily(familyId, overrides = {}) {
@@ -552,6 +601,22 @@ describe('handleToken', () => {
 			mcpConfig
 		);
 		assert.equal(res.body.error, 'unauthorized_client');
+	});
+
+	it('does not rotate the family when token signing fails (old token survives for retry)', async () => {
+		const token = seedFamily('fam-1');
+		const before = families.get('fam-1').current_token_hash;
+		// Corrupt the signing key so signAccessToken throws — this happens before
+		// the rotation is persisted, so the family must be left intact.
+		keys.set(SIGNING_KEY_ID, { ...keys.get(SIGNING_KEY_ID), private_key_pem: 'not-a-valid-pem' });
+		await assert.rejects(() =>
+			handleToken(
+				{ headers: {} },
+				{ grant_type: 'refresh_token', refresh_token: token, client_id: 'public-1' },
+				mcpConfig
+			)
+		);
+		assert.equal(families.get('fam-1').current_token_hash, before, 'family not rotated when signing fails');
 	});
 
 	it('rejects a malformed refresh token', async () => {

--- a/test/lib/mcp/tokenIssuer.test.js
+++ b/test/lib/mcp/tokenIssuer.test.js
@@ -1,0 +1,85 @@
+/**
+ * Tests for the MCP access-token issuer (sign / verify / JWK serialization).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { generateKeyPairSync } from 'node:crypto';
+import { signAccessToken, verifyAccessToken, publicKeyToJwk } from '../../../dist/lib/mcp/tokenIssuer.js';
+import { SIGNING_KEY_ID } from '../../../dist/lib/mcp/keyStore.js';
+
+const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+	modulusLength: 2048,
+	publicKeyEncoding: { type: 'spki', format: 'pem' },
+	privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+const key = {
+	kid: SIGNING_KEY_ID,
+	alg: 'RS256',
+	public_key_pem: publicKey,
+	private_key_pem: privateKey,
+	created_at: 1700000000,
+};
+
+const baseParams = {
+	issuer: 'https://as.example.com',
+	subject: 'alice@example.com',
+	audience: 'https://app.example.com/mcp',
+	clientId: 'client-123',
+	scope: 'mcp:read',
+	ttlSeconds: 3600,
+};
+
+describe('tokenIssuer', () => {
+	it('signs and verifies an access token with the expected claims', () => {
+		const token = signAccessToken(baseParams, key);
+		const claims = verifyAccessToken(token, key.public_key_pem, {
+			audience: baseParams.audience,
+			issuer: baseParams.issuer,
+		});
+		assert.equal(claims.iss, baseParams.issuer);
+		assert.equal(claims.sub, baseParams.subject);
+		assert.equal(claims.aud, baseParams.audience);
+		assert.equal(claims.client_id, baseParams.clientId);
+		assert.equal(claims.scope, baseParams.scope);
+		assert.ok(claims.jti, 'jti present');
+		assert.ok(claims.exp > claims.iat, 'exp after iat');
+		assert.equal(claims.exp - claims.iat, 3600, 'exp derived from ttlSeconds');
+	});
+
+	it('puts the kid and RS256 alg in the JWT header', () => {
+		const token = signAccessToken(baseParams, key);
+		const header = JSON.parse(Buffer.from(token.split('.')[0], 'base64url').toString('utf8'));
+		assert.equal(header.kid, SIGNING_KEY_ID);
+		assert.equal(header.alg, 'RS256');
+	});
+
+	it('rejects a token verified against the wrong audience (RFC 8707 binding)', () => {
+		const token = signAccessToken(baseParams, key);
+		assert.throws(() => verifyAccessToken(token, key.public_key_pem, { audience: 'https://evil.example.com/mcp' }));
+	});
+
+	it('rejects a token verified against the wrong issuer', () => {
+		const token = signAccessToken(baseParams, key);
+		assert.throws(() => verifyAccessToken(token, key.public_key_pem, { issuer: 'https://evil.example.com' }));
+	});
+
+	it('omits scope when none is requested', () => {
+		const { scope, ...noScope } = baseParams;
+		void scope;
+		const token = signAccessToken(noScope, key);
+		const claims = verifyAccessToken(token, key.public_key_pem);
+		assert.equal(claims.scope, undefined);
+	});
+
+	it('serializes an RSA public key to a JWK with kid/use/alg', () => {
+		const jwk = publicKeyToJwk(key.public_key_pem, key.kid);
+		assert.equal(jwk.kty, 'RSA');
+		assert.ok(jwk.n, 'modulus present');
+		assert.equal(jwk.e, 'AQAB', 'standard RSA public exponent (65537)');
+		assert.equal(jwk.use, 'sig');
+		assert.equal(jwk.alg, 'RS256');
+		assert.equal(jwk.kid, SIGNING_KEY_ID);
+		assert.equal(jwk.d, undefined, 'private exponent must NOT be present');
+	});
+});

--- a/test/lib/mcp/wellKnown.test.js
+++ b/test/lib/mcp/wellKnown.test.js
@@ -107,9 +107,9 @@ describe('MCP well-known: AS metadata document (RFC 8414)', () => {
 		assert.ok(methods.includes('client_secret_post'));
 	});
 
-	it('advertises both RS256 and EdDSA signing algorithms', () => {
+	it('advertises RS256 as the only signing algorithm (EdDSA deferred)', () => {
 		const doc = buildAuthorizationServerMetadata(makeRequest(), { enabled: true });
-		assert.deepEqual(doc.id_token_signing_alg_values_supported, ['RS256', 'EdDSA']);
+		assert.deepEqual(doc.id_token_signing_alg_values_supported, ['RS256']);
 	});
 
 	it('signals RFC 8707 resource-parameter support', () => {
@@ -119,8 +119,8 @@ describe('MCP well-known: AS metadata document (RFC 8414)', () => {
 });
 
 describe('MCP well-known: JWKS document', () => {
-	it('returns an empty key set (placeholder until Stage 4)', () => {
-		const doc = buildJWKS({ enabled: true });
+	it('returns an empty key set when no signing key has been minted yet', async () => {
+		const doc = await buildJWKS({ enabled: true });
 		assert.deepEqual(doc, { keys: [] });
 	});
 });
@@ -171,7 +171,7 @@ describe('MCP well-known: handler registration', () => {
 			return reg.handler;
 		}
 
-		it('falls through to next when MCP is disabled', () => {
+		it('falls through to next when MCP is disabled', async () => {
 			currentConfig = { enabled: false };
 			const handler = findHandler('/.well-known/oauth-protected-resource');
 			let nextCalled = false;
@@ -179,7 +179,7 @@ describe('MCP well-known: handler registration', () => {
 				nextCalled = true;
 				return 'fallthrough';
 			};
-			const result = handler(makeRequest(), next);
+			const result = await handler(makeRequest(), next);
 			assert.equal(nextCalled, true);
 			assert.equal(result, 'fallthrough');
 		});
@@ -208,10 +208,10 @@ describe('MCP well-known: handler registration', () => {
 			assert.equal(nextCalled, true, 'sub-paths should fall through, not be served');
 		});
 
-		it('serves PRM as JSON with Content-Type when enabled and path matches', () => {
+		it('serves PRM as JSON with Content-Type when enabled and path matches', async () => {
 			currentConfig = { enabled: true };
 			const handler = findHandler('/.well-known/oauth-protected-resource');
-			const response = handler(makeRequest(), () => null);
+			const response = await handler(makeRequest(), () => null);
 			assert.equal(response.status, 200);
 			assert.equal(response.headers['Content-Type'], 'application/json');
 			const body = JSON.parse(response.body);
@@ -219,28 +219,28 @@ describe('MCP well-known: handler registration', () => {
 			assert.deepEqual(body.authorization_servers, ['https://app.example.com']);
 		});
 
-		it('serves PRM with CORS headers so browser MCP clients can fetch cross-origin', () => {
+		it('serves PRM with CORS headers so browser MCP clients can fetch cross-origin', async () => {
 			currentConfig = { enabled: true };
 			const handler = findHandler('/.well-known/oauth-protected-resource');
-			const response = handler(makeRequest(), () => null);
+			const response = await handler(makeRequest(), () => null);
 			assert.equal(response.headers['Access-Control-Allow-Origin'], '*');
 			assert.equal(response.headers['Access-Control-Allow-Methods'], 'GET, OPTIONS');
 		});
 
-		it('serves AS metadata and JWKS with the same CORS headers', () => {
+		it('serves AS metadata and JWKS with the same CORS headers', async () => {
 			currentConfig = { enabled: true };
 			for (const path of ['/.well-known/oauth-authorization-server', '/.well-known/jwks.json']) {
 				const handler = findHandler(path);
-				const response = handler(makeRequest({ pathname: path }), () => null);
+				const response = await handler(makeRequest({ pathname: path }), () => null);
 				assert.equal(response.headers['Access-Control-Allow-Origin'], '*', `${path} should set CORS`);
 				assert.equal(response.headers['Access-Control-Allow-Methods'], 'GET, OPTIONS');
 			}
 		});
 
-		it('serves AS metadata as JSON with Content-Type when path matches', () => {
+		it('serves AS metadata as JSON with Content-Type when path matches', async () => {
 			currentConfig = { enabled: true };
 			const handler = findHandler('/.well-known/oauth-authorization-server');
-			const response = handler(makeRequest({ pathname: '/.well-known/oauth-authorization-server' }), () => null);
+			const response = await handler(makeRequest({ pathname: '/.well-known/oauth-authorization-server' }), () => null);
 			assert.equal(response.status, 200);
 			assert.equal(response.headers['Content-Type'], 'application/json');
 			const body = JSON.parse(response.body);
@@ -248,19 +248,19 @@ describe('MCP well-known: handler registration', () => {
 			assert.deepEqual(body.code_challenge_methods_supported, ['S256']);
 		});
 
-		it('serves JWKS as JSON with empty keys', () => {
+		it('serves JWKS as JSON with empty keys', async () => {
 			currentConfig = { enabled: true };
 			const handler = findHandler('/.well-known/jwks.json');
-			const response = handler(makeRequest({ pathname: '/.well-known/jwks.json' }), () => null);
+			const response = await handler(makeRequest({ pathname: '/.well-known/jwks.json' }), () => null);
 			assert.equal(response.status, 200);
 			assert.equal(response.headers['Content-Type'], 'application/json');
 			assert.deepEqual(JSON.parse(response.body), { keys: [] });
 		});
 
-		it('falls back to localhost when the request omits scheme/host', () => {
+		it('falls back to localhost when the request omits scheme/host', async () => {
 			currentConfig = { enabled: true };
 			const handler = findHandler('/.well-known/oauth-protected-resource');
-			const response = handler({ pathname: '/.well-known/oauth-protected-resource' }, () => null);
+			const response = await handler({ pathname: '/.well-known/oauth-protected-resource' }, () => null);
 			assert.equal(response.status, 200);
 			const body = JSON.parse(response.body);
 			assert.equal(body.resource, 'https://localhost/mcp');


### PR DESCRIPTION
## Summary

Stage 4 of the MCP OAuth epic (#86): adds `POST /oauth/mcp/token`, which exchanges a PKCE-verified authorization code (or a refresh token) for an audience-bound **RS256 JWT access token**. This completes the issuance half of the flow — Stage 5 (`withMCPAuth`) will verify these tokens. Closes #94.

- `tokenIssuer.ts` — RS256 JWT mint/verify (`jsonwebtoken`) + public-key→JWK serialization (`node:crypto`).
- `keyStore.ts` — signing key persisted in the new `harper_oauth_mcp_keys` table; generated on first use or supplied via `mcp.signingKeyPem`. JWKS publishes the public half.
- `refreshTokenStore.ts` — single-use refresh rotation via one `mcp_refresh_families` row (stores only the SHA-256 of the token); replay of a superseded token revokes the whole family, O(1).
- `token.ts` — grant dispatch, client auth (`none` / `client_secret_basic` / `client_secret_post`), PKCE-S256 verify, strict single-use code consume.
- `wellKnown.ts` — JWKS endpoint now serves the persisted key (becomes `async`); AS metadata advertises `RS256` only.

## Where to focus

These are deliberate v1 decisions / accepted constraints — worth a reviewer's eye, not unaddressed bugs:

- **Clustered deployments must set `mcp.signingKeyPem`.** v1 uses a single signing-key row (the plugin's table abstraction is get/put/delete only — no enumeration). Without a configured key, two nodes can generate different keys on first boot and, until replication converges, a node may sign with a key JWKS doesn't publish. A configured key (identical on every node) removes the race. Documented in `keyStore.ts`; Stage 8 docs (#98) should call this out for operators.
- **Two accepted non-atomic windows**, both stemming from the get/put/delete-only table (no compare-and-set), both benign under Harper's single-trust-domain model and documented inline: the single-use auth-code consume (`authCodeStore.consume`) and refresh rotation (`refreshTokenStore.ts` header).
- **RS256 only.** `jsonwebtoken@9` can't emit EdDSA, so Stage 2's optimistic `EdDSA` advertisement is trimmed to match what's served. EdDSA is deferred to a follow-up (needs a JOSE lib) — tracked separately.
- **`aud`/`iss` integrity:** `aud` is bound from the auth-code/refresh-family record (no client-supplied `resource` re-read on refresh); `iss` relies on the existing startup guard that requires `mcp.issuer` when MCP is enabled.

## Review

Cross-model review run per the engineering lifecycle:
- **Codex** (correctness/security) and a **Harper-domain reliability pass** — all findings addressed in this commit (key-convergence caching, `grant_types`-gated refresh issuance, RFC 6749 §5.1 `no-store` headers, string-TTL coercion, fail-safe replay revocation, redacting `mcp.signingKeyPem` from the load-time config log).
- **Gemini leg did not run** — the harness blocked sending source to the external Gemini API (exfiltration guard on proprietary crypto code). The perf/maintainability lens is therefore uncovered; flagging in case you want a manual pass there.

## Tests

168 MCP unit tests (40 new across token/issuer/key/refresh stores), full plugin suite green. Integration tests: the new schema loads cleanly in a real Harper instance; the only failures are pre-existing `path-segment-routing` tests that require the loopback-isolation mode unavailable in this environment (identical failures on `main` without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: Claude Opus 4.8)
