### PR TITLE
Release 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "2.0.0-alpha.2",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@harperfast/oauth",
-			"version": "2.0.0-alpha.2",
+			"version": "2.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "2.0.0-alpha.2",
+	"version": "2.0.0",
 	"description": "OAuth 2.0 authentication plugin for Harper",
 	"license": "Apache-2.0",
 	"author": {


### PR DESCRIPTION
## Release 2.0.0

First **GA** of the Harper v5 line (bumps `2.0.0-alpha.2` → `2.0.0`).

**Breaking (from 1.x):** requires **Harper v5** — `peerDependencies: harper >=5.0.0` (the `harperdb` v4 → `harper` v5 package move). Harper v4 users stay on the [`1.x`](https://github.com/HarperFast/oauth/tree/v1.x) line.

**Since alpha.2:** MCP OAuth `/oauth/mcp/token` endpoint + RS256 JWT issuer (Stage 4), and the flexible `harper` build-dep range (#129). The v5 migration itself shipped in alpha.1/alpha.2 and is alpha-soaked.

**MCP OAuth is experimental + opt-in** (`mcp.enabled`): DCR, discovery metadata, authorize, token issuance. Token verification (`withMCPAuth`) and the rest land additively in 2.0.x.

Version bump only — no code changes.

### After merge (your call)
Tag `v2.0.0` + `npm publish` (`prepublishOnly` builds). Recommend publishing to the `latest` dist-tag (alpha.x were prereleases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
