### PR TITLE
ci(release): publish via npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       # Trusted publishing (OIDC) requires npm >= 11.5.1; the Node 22 runner
       # ships npm 10.x, so upgrade before publishing.
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.5.1
 
       - name: Install dependencies
         run: npm ci
@@ -45,8 +45,10 @@ jobs:
       # don't move `latest`; full releases go to `latest`.
       - name: Determine npm dist-tag
         id: disttag
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          if [[ "${{ github.event.release.tag_name }}" == *-* ]]; then
+          if [[ "$TAG_NAME" == *-* ]]; then
             echo "tag=next" >> "$GITHUB_OUTPUT"
           else
             echo "tag=latest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
+      # Trusted publishing (OIDC) requires npm >= 11.5.1; the Node 22 runner
+      # ships npm 10.x, so upgrade before publishing.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 
@@ -36,7 +41,19 @@ jobs:
       - name: Run tests
         run: npm test
 
+      # Prereleases (tags like v2.1.0-beta.1) go to the `next` dist-tag so they
+      # don't move `latest`; full releases go to `latest`.
+      - name: Determine npm dist-tag
+        id: disttag
+        run: |
+          if [[ "${{ github.event.release.tag_name }}" == *-* ]]; then
+            echo "tag=next" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Auth is via npm trusted publishing (OIDC) using the id-token below — no
+      # NODE_AUTH_TOKEN/secret. Configured at npmjs.com: Trusted Publisher ->
+      # HarperFast/oauth, release.yml, Release environment.
       - name: Publish to npm
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_KEY }}
+        run: npm publish --provenance --access public --tag "${{ steps.disttag.outputs.tag }}"


### PR DESCRIPTION
## Why

`release.yml` authenticated `npm publish` with `secrets.NPM_ACCESS_KEY`, which was never configured — so `NODE_AUTH_TOKEN` was empty and publish failed with `ENEEDAUTH` on every run (the alphas and 2.0.0 were published manually).

## Fix — npm trusted publishing (OIDC)

Trusted publishing is now set up at npmjs.com (Trusted Publisher → `HarperFast/oauth`, `release.yml`, `Release` environment), so the workflow needs **no token**:

- Drop `NODE_AUTH_TOKEN` / `NPM_ACCESS_KEY`; auth is the existing `id-token: write` OIDC.
- Upgrade npm before publish — OIDC trusted publishing requires npm ≥ 11.5.1, and the Node 22 runner ships npm 10.x.
- Add dist-tag logic: prereleases (`vX.Y.Z-beta.N`) → `next`, full releases → `latest` (so a beta won't move `latest`).
- Keeps `environment: Release` and `--provenance`.

## Validation

The `release.yml` job only runs on `release: published`, so it can't execute on this PR — it'll be exercised on the next release (e.g. a `2.0.x` or the first beta). 2.0.0 is already published. Standard PR CI (lint/build/test) still runs here and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
