### PR TITLE
MCP OAuth Stage 5: withMCPAuth bearer-token guard (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,31 @@ When MCP OAuth is enabled (see [issue #86](https://github.com/HarperFast/oauth/i
 
 The plugin can also act as an OAuth authorization server for **Model Context Protocol** clients (Claude Desktop, Cursor, `mcp-remote`), letting them authenticate against the same upstream providers. Enable it with `mcp.enabled: true` (see [`docs/configuration.md`](./docs/configuration.md)).
 
-**Status: experimental, opt-in.** Available now: RFC 7591 Dynamic Client Registration, discovery metadata (`/.well-known/*`), the authorization endpoint, and audience-bound JWT token issuance. Token _verification_ for app-owned MCP routes (`withMCPAuth`) and the remaining pieces land in 2.0.x — see [issue #86](https://github.com/HarperFast/oauth/issues/86).
+**Status: experimental, opt-in.** Available now: RFC 7591 Dynamic Client Registration, discovery metadata (`/.well-known/*`), the authorization endpoint, audience-bound JWT token issuance, and token _verification_ for app-owned MCP routes (`withMCPAuth`, below). The remaining pieces land in 2.0.x — see [issue #86](https://github.com/HarperFast/oauth/issues/86).
+
+### Protecting an MCP route — `withMCPAuth`
+
+The plugin doesn't own the MCP endpoint — your app does. `withMCPAuth` wraps your handler so it enforces the spec contract once, centrally: it validates the `Authorization: Bearer` access token (signature against the published JWKS, `exp`/`nbf`, and audience binding to `mcp.resource` per RFC 8707), and on any failure returns `401` with `WWW-Authenticate: Bearer resource_metadata="…"` (RFC 9728) pointing MCP clients at discovery. On success it attaches the verified claims as `request.mcp = { sub, client_id, aud, scope }` and invokes your handler unchanged.
+
+```ts
+import { server } from 'harper';
+import { withMCPAuth } from '@harperfast/oauth';
+
+const mcpHandler = (request) => {
+	// request.mcp is guaranteed present here: { sub, client_id, aud, scope }
+	return { status: 200, body: JSON.stringify({ user: request.mcp.sub }) };
+};
+
+// Recommended: register on a urlPath subroute.
+server.http(withMCPAuth(mcpHandler), { urlPath: '/mcp' });
+```
+
+**Registration matters — Harper's core auth will otherwise reject the token.** Core auth consumes `Authorization: Bearer` and rejects any non-Harper token with `WWW-Authenticate: Basic`, which breaks the MCP discovery loop. Register `withMCPAuth` so it owns the response for its route:
+
+- **urlPath subroute (recommended):** `server.http(withMCPAuth(handler), { urlPath: '/mcp' })`. Harper routes the request to this chain alone, so core auth never runs for it — the same isolation the `/.well-known/*` endpoints use. No extra options needed.
+- **Default-group fallback:** `server.http(withMCPAuth(handler, { path: '/mcp' }), { before: 'authentication' })`. When the route shares the default middleware chain with auth, pass `path` (so the guard scopes to your route and lets other paths fall through) and register `before: 'authentication'` so it runs ahead of core auth.
+
+`withMCPAuth(handler, options?)` options: `path` (default-group scoping, above), `onAuthError(request, reason)` (custom denial response — a falsy return still fails closed to the default `401`), plus `getConfig` / `logger` / `keyStore` overrides (default to the plugin's live MCP config, logger, and key store). The guard fails closed: while MCP is disabled or no signing key has been published, every request is rejected. Query-string tokens are ignored (header-only, RFC 6750). See [`docs/configuration.md`](./docs/configuration.md).
 
 ## Security Considerations
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,9 @@ server.http(withMCPAuth(mcpHandler), { urlPath: '/mcp' });
 - **urlPath subroute (recommended):** `server.http(withMCPAuth(handler), { urlPath: '/mcp' })`. Harper routes the request to this chain alone, so core auth never runs for it — the same isolation the `/.well-known/*` endpoints use. No extra options needed.
 - **Default-group fallback:** `server.http(withMCPAuth(handler, { path: '/mcp' }), { before: 'authentication' })`. When the route shares the default middleware chain with auth, pass `path` (so the guard scopes to your route and lets other paths fall through) and register `before: 'authentication'` so it runs ahead of core auth.
 
-`withMCPAuth(handler, options?)` options: `path` (default-group scoping, above), `onAuthError(request, reason)` (custom denial response — a falsy return still fails closed to the default `401`), plus `getConfig` / `logger` / `keyStore` overrides (default to the plugin's live MCP config, logger, and key store). The guard fails closed: while MCP is disabled or no signing key has been published, every request is rejected. Query-string tokens are ignored (header-only, RFC 6750). See [`docs/configuration.md`](./docs/configuration.md).
+`withMCPAuth(handler, options?)` options: `path` (default-group scoping, above), `onAuthError(request, reason)` (custom denial response — a falsy return still fails closed to the default `401`), plus `getConfig` / `logger` / `keyStore` overrides (default to the plugin's live MCP config, logger, and key store). The guard fails closed: while MCP is disabled or no signing key has been published, every request is rejected. Query-string tokens are ignored (header-only, RFC 6750).
+
+If your MCP route lives in a **different component** than the one declaring `@harperfast/oauth`, inject `getConfig` (the consumer's copy of `OAuthResource.mcpConfig` is unpopulated) — signing keys still resolve from the shared `oauth` database. See [`docs/configuration.md`](./docs/configuration.md).
 
 ## Security Considerations
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,7 @@ Each provider requires:
 
 ### MCP OAuth (work in progress)
 
-Opt-in support for the Model Context Protocol authorization flow ([issue #86](https://github.com/HarperFast/oauth/issues/86)). Implemented so far: Dynamic Client Registration at `POST /oauth/mcp/register` (RFC 7591), the discovery documents under `/.well-known/*` (RFCs 8414, 9728) so MCP clients (Claude Desktop, Cursor, `mcp-remote`) can find and register themselves, and the authorization endpoint `GET /oauth/mcp/authorize` (OAuth 2.1 + PKCE-S256). The `/token` exchange and the `withMCPAuth` wrapper land in subsequent releases.
+Opt-in support for the Model Context Protocol authorization flow ([issue #86](https://github.com/HarperFast/oauth/issues/86)). Implemented so far: Dynamic Client Registration at `POST /oauth/mcp/register` (RFC 7591), the discovery documents under `/.well-known/*` (RFCs 8414, 9728) so MCP clients (Claude Desktop, Cursor, `mcp-remote`) can find and register themselves, the authorization endpoint `GET /oauth/mcp/authorize` (OAuth 2.1 + PKCE-S256), the `POST /oauth/mcp/token` exchange (audience-bound RS256 JWTs), and the `withMCPAuth` route guard (below) that verifies those tokens on your MCP endpoint.
 
 ```yaml
 '@harperfast/oauth':
@@ -103,6 +103,47 @@ Sensitive leaves inside `mcp` support `${ENV_VAR}` expansion (e.g., `initialAcce
 | `/.well-known/jwks.json`                  | —        | Public keys for verifying issued JWTs (returns an empty key set until signing lands) |
 
 All three documents include `Access-Control-Allow-Origin: *` so browser-based MCP clients and discovery tools can fetch them cross-origin.
+
+#### Protecting your MCP route — `withMCPAuth`
+
+The plugin issues and verifies tokens, but your app owns the MCP endpoint. Wrap your handler with `withMCPAuth` to enforce the spec contract on it:
+
+```ts
+import { server } from 'harper';
+import { withMCPAuth } from '@harperfast/oauth';
+
+const mcpHandler = (request) => {
+	// On success, the verified claims are attached: { sub, client_id, aud, scope }
+	return { status: 200, body: JSON.stringify({ user: request.mcp.sub }) };
+};
+
+// Recommended registration — a urlPath subroute (see "Registration", below):
+server.http(withMCPAuth(mcpHandler), { urlPath: '/mcp' });
+```
+
+What it enforces on every request, failing closed with `401 + WWW-Authenticate: Bearer resource_metadata="<issuer>/.well-known/oauth-protected-resource"`:
+
+- Bearer token present in the `Authorization` header (header-only; query-string tokens are ignored, RFC 6750).
+- Valid RS256 signature against the published JWKS, selecting the key by the token's `kid`.
+- `exp`/`nbf` within bounds, and `aud` equal to `mcp.resource` (audience binding, RFC 8707).
+- MCP enabled and a signing key published — while either is missing, all requests are rejected.
+
+On success it sets `request.mcp = { sub, client_id, aud, scope }` and calls your handler, returning its response unchanged.
+
+**Registration.** Harper's core auth is a default-group middleware that consumes `Authorization: Bearer` and rejects any non-Harper token with `WWW-Authenticate: Basic` — which would break MCP discovery. Register `withMCPAuth` so it owns the response for its route:
+
+- **urlPath subroute (recommended):** `server.http(withMCPAuth(handler), { urlPath: '/mcp' })`. Harper's routed dispatch runs only this chain, so core auth never runs for the route — the same isolation the `/.well-known/*` endpoints rely on. No extra options needed.
+- **Default-group fallback:** `server.http(withMCPAuth(handler, { path: '/mcp' }), { before: 'authentication' })`. When the route shares the default chain with auth, pass `path` (the guard then scopes to that path and calls `next()` for everything else) and register `before: 'authentication'` so it runs ahead of core auth. In this mode the wrapped handler must terminate the request rather than call `next`, or core auth runs afterward and re-rejects the token.
+
+**Options** — `withMCPAuth(handler, options?)`:
+
+| Option        | Type                           | Default                | Description                                                                                        |
+| ------------- | ------------------------------ | ---------------------- | -------------------------------------------------------------------------------------------------- |
+| `path`        | string                         | (none)                 | Default-group scoping only — the path this guard owns. Omit for the urlPath-subroute registration. |
+| `onAuthError` | `(request, reason) => any`     | (none)                 | Custom denial response. A falsy return still falls back to the default `401` (fail closed).        |
+| `getConfig`   | `() => MCPConfig \| undefined` | live plugin MCP config | Override the MCP config source (read per request).                                                 |
+| `logger`      | Logger                         | plugin logger          | Override the logger.                                                                               |
+| `keyStore`    | `{ getAllPublicKeys() }`       | plugin `MCPKeyStore`   | Override the signing-key source (used by tests).                                                   |
 
 ## Environment Variables
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,7 +121,7 @@ const mcpHandler = (request) => {
 server.http(withMCPAuth(mcpHandler), { urlPath: '/mcp' });
 ```
 
-What it enforces on every request, failing closed with `401 + WWW-Authenticate: Bearer resource_metadata="<issuer>/.well-known/oauth-protected-resource"`:
+What it enforces on every request, failing closed with `401 + WWW-Authenticate: Bearer resource_metadata="<PRM URL>"`. The PRM URL is the RFC 9728 §3.1 location for the configured `mcp.resource` — `<resource-origin>/.well-known/oauth-protected-resource` with the resource's path appended when it has one (e.g. `https://app.example.com/.well-known/oauth-protected-resource/mcp` for resource `https://app.example.com/mcp`), matching exactly what the well-known handler serves:
 
 - Bearer token present in the `Authorization` header (header-only; query-string tokens are ignored, RFC 6750).
 - Valid RS256 signature against the published JWKS, selecting the key by the token's `kid`.
@@ -144,6 +144,29 @@ On success it sets `request.mcp = { sub, client_id, aud, scope }` and calls your
 | `getConfig`   | `() => MCPConfig \| undefined` | live plugin MCP config | Override the MCP config source (read per request).                                                 |
 | `logger`      | Logger                         | plugin logger          | Override the logger.                                                                               |
 | `keyStore`    | `{ getAllPublicKeys() }`       | plugin `MCPKeyStore`   | Override the signing-key source (used by tests).                                                   |
+
+##### Using `withMCPAuth` from a different component than the plugin
+
+By default `withMCPAuth` reads the live MCP config from the OAuth plugin via `OAuthResource.mcpConfig`. That works when the component that **declares** `@harperfast/oauth` is the same one that exposes the MCP route. If your MCP tools live in a **separate** component (it imports `withMCPAuth` as a function but doesn't declare the plugin in its own `config.yaml`), that consumer resolves its **own** `node_modules` copy of the package, where `OAuthResource.mcpConfig` is a module-local static that is never populated — so it reads as `undefined` and the guard fails closed.
+
+In that setup, **inject `getConfig`** so the wrapper sees the config:
+
+```ts
+server.http(
+	withMCPAuth(mcpHandler, {
+		// Pin issuer/resource to the values the plugin component issues tokens with,
+		// so the iss/aud checks match the minted tokens.
+		getConfig: () => ({
+			enabled: true,
+			issuer: 'https://my-app.example.com',
+			resource: 'https://my-app.example.com/mcp',
+		}),
+	}),
+	{ urlPath: '/mcp' }
+);
+```
+
+Signing keys need no extra wiring: the default `MCPKeyStore` reads `databases.oauth.harper_oauth_mcp_keys`, which is cluster-global, so the consumer verifies against the same JWKS the plugin component mints with. Importing `withMCPAuth` as a function does **not** spin up a second plugin instance.
 
 ## Environment Variables
 

--- a/integrationTests/fixtures/mcp-auth-app/config.yaml
+++ b/integrationTests/fixtures/mcp-auth-app/config.yaml
@@ -1,0 +1,37 @@
+# Integration-test fixture for withMCPAuth (Stage 5).
+#
+# Loads the OAuth plugin with MCP enabled and a pinned issuer/resource, plus an
+# app JS file (mcp-app.js) that registers an MCP route guarded by withMCPAuth in
+# BOTH supported registration models:
+#   - /mcp     via urlPath subroute (Harper's routed dispatch isolates it from
+#              the default-group core-auth middleware)
+#   - /mcp-dg  via a default-group middleware ordered `before: authentication`
+#
+# The test asserts both routes answer an unauthenticated (or non-Harper-bearer)
+# request with the spec `401 + WWW-Authenticate: Bearer resource_metadata="..."`
+# — proving core auth never clobbers it with its `WWW-Authenticate: Basic`.
+#
+# A provider is configured so OAuthResource.configure() runs and the pinned
+# mcp.issuer reaches OAuthResource.mcpConfig (withMCPAuth's default config
+# source); without any provider the plugin registers an error resource and never
+# calls configure(), leaving mcpConfig undefined.
+
+rest: true
+
+'@harperfast/oauth':
+  package: '@harperfast/oauth'
+  providers:
+    test:
+      provider: generic
+      clientId: test-client
+      clientSecret: test-secret
+      authorizationUrl: 'http://idp.test/authorize'
+      tokenUrl: 'http://idp.test/token'
+      userInfoUrl: 'http://idp.test/userinfo'
+  mcp:
+    enabled: true
+    issuer: 'https://mcp.test'
+    resource: 'https://mcp.test/mcp'
+
+jsResource:
+  files: 'mcp-app.js'

--- a/integrationTests/fixtures/mcp-auth-app/mcp-app.js
+++ b/integrationTests/fixtures/mcp-auth-app/mcp-app.js
@@ -1,0 +1,27 @@
+/**
+ * App code (loaded via the built-in `jsResource` handler) that registers an
+ * app-owned MCP route guarded by withMCPAuth, in both registration models the
+ * wrapper supports. Route registration happens as an import side effect using
+ * the global `server` exported by Harper — `scope.server` is just a
+ * name-injecting Proxy over this same object, and our registration does not
+ * depend on the injected component name.
+ */
+import { server } from 'harper';
+import { withMCPAuth } from '@harperfast/oauth';
+
+// Echoes the verified MCP subject (null when unauthenticated requests are
+// rejected before reaching here) so an authenticated test can assert on it.
+const mcpHandler = (request) => ({
+	status: 200,
+	headers: { 'Content-Type': 'application/json' },
+	body: JSON.stringify({ ok: true, sub: request.mcp?.sub ?? null }),
+});
+
+// PRIMARY — urlPath subroute. Harper's routed dispatch runs only this chain, so
+// core auth (a default-group middleware) never runs for /mcp.
+server.http(withMCPAuth(mcpHandler), { urlPath: '/mcp' });
+
+// FALLBACK — default-group middleware ordered ahead of core auth. `path` scopes
+// the guard to /mcp-dg (other routes fall through to auth); `before:
+// 'authentication'` makes it run outermost.
+server.http(withMCPAuth(mcpHandler, { path: '/mcp-dg' }), { before: 'authentication' });

--- a/integrationTests/fixtures/mcp-auth-app/package.json
+++ b/integrationTests/fixtures/mcp-auth-app/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "mcp-auth-app-fixture",
+	"private": true,
+	"type": "module",
+	"description": "Integration-test fixture for withMCPAuth (Stage 5). The @harperfast/oauth dep is installed at test setup time via scripts/install-fixtures.js (npm pack + install) so the plugin lives as real files under node_modules — Harper's default VM sandbox rejects symlinked file: deps. harper is resolved from the repo root."
+}

--- a/integrationTests/mcp-auth.test.ts
+++ b/integrationTests/mcp-auth.test.ts
@@ -28,7 +28,9 @@ function getHarperBinPath(): string {
 }
 
 const fixturePath = join(import.meta.dirname, 'fixtures', 'mcp-auth-app');
-const PRM_URL = 'https://mcp.test/.well-known/oauth-protected-resource';
+// RFC 9728 §3.1 path-appended form (resource is https://mcp.test/mcp), which #133
+// now serves and withMCPAuth points the challenge at.
+const PRM_URL = 'https://mcp.test/.well-known/oauth-protected-resource/mcp';
 
 suite('withMCPAuth: 401 + WWW-Authenticate: Bearer survives core auth', (ctx: ContextWithHarper) => {
 	before(async () => {

--- a/integrationTests/mcp-auth.test.ts
+++ b/integrationTests/mcp-auth.test.ts
@@ -1,0 +1,69 @@
+/**
+ * End-to-end proof that withMCPAuth's spec response survives Harper's core
+ * auth. Harper's core auth is a default-group HTTP middleware that consumes
+ * `Authorization: Bearer` and 401s any token it can't validate as a Harper
+ * operation token — stamping `WWW-Authenticate: Basic`, NOT the Bearer
+ * challenge MCP clients require. This test registers withMCPAuth in both
+ * supported models and asserts the FINAL response carries
+ * `WWW-Authenticate: Bearer resource_metadata="..."`:
+ *
+ *   - /mcp     (urlPath subroute) — routed dispatch isolates the chain, so core
+ *              auth never runs for it.
+ *   - /mcp-dg  (default group, `before: authentication`) — withMCPAuth runs
+ *              outermost and short-circuits before core auth.
+ *
+ * The discriminating case is a request bearing a *non-Harper* bearer token: a
+ * `Basic` challenge in the response would mean core auth ran first and won.
+ */
+import { suite, test, before, after } from 'node:test';
+import { strictEqual, ok, match } from 'node:assert/strict';
+import { join, dirname } from 'node:path';
+import { createRequire } from 'node:module';
+import { setupHarperWithFixture, teardownHarper, type ContextWithHarper } from '@harperfast/integration-testing';
+
+const require = createRequire(import.meta.url);
+
+function getHarperBinPath(): string {
+	return join(dirname(require.resolve('harper')), 'bin', 'harper.js');
+}
+
+const fixturePath = join(import.meta.dirname, 'fixtures', 'mcp-auth-app');
+const PRM_URL = 'https://mcp.test/.well-known/oauth-protected-resource';
+
+suite('withMCPAuth: 401 + WWW-Authenticate: Bearer survives core auth', (ctx: ContextWithHarper) => {
+	before(async () => {
+		await setupHarperWithFixture(ctx, fixturePath, {
+			harperBinPath: getHarperBinPath(),
+			config: { logging: { stdStreams: true } },
+		});
+	});
+
+	after(async () => {
+		await teardownHarper(ctx);
+	});
+
+	// Both registration models must produce the same spec-compliant challenge.
+	for (const path of ['/mcp', '/mcp-dg']) {
+		test(`${path}: unauthenticated request → 401 + Bearer PRM challenge`, async () => {
+			const res = await fetch(`${ctx.harper.httpURL}${path}`, { method: 'POST' });
+			strictEqual(res.status, 401, `expected 401, got ${res.status}`);
+			const wa = res.headers.get('www-authenticate');
+			ok(wa, 'WWW-Authenticate header present');
+			match(wa!, /^Bearer /, `expected a Bearer challenge, got: ${wa}`);
+			ok(wa!.includes(`resource_metadata="${PRM_URL}"`), `challenge must point at the PRM URL; got: ${wa}`);
+		});
+
+		test(`${path}: non-Harper bearer token → still Bearer (core auth did not win)`, async () => {
+			const res = await fetch(`${ctx.harper.httpURL}${path}`, {
+				method: 'POST',
+				headers: { authorization: 'Bearer not-a-real-mcp-token' },
+			});
+			strictEqual(res.status, 401, `expected 401, got ${res.status}`);
+			const wa = res.headers.get('www-authenticate');
+			ok(
+				wa?.startsWith('Bearer '),
+				`expected Bearer (a 'Basic' challenge would mean core auth handled the token first); got: ${wa}`
+			);
+		});
+	}
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,11 @@ export { getProvider } from './lib/providers/index.ts';
 export { withOAuthValidation, getOAuthProviders } from './lib/withOAuthValidation.ts';
 export type { OAuthValidationOptions } from './lib/withOAuthValidation.ts';
 
+// Export MCP bearer-token guard (Stage 5) for app-owned MCP routes
+export { withMCPAuth } from './lib/mcp/withMCPAuth.ts';
+export type { WithMCPAuthOptions } from './lib/mcp/withMCPAuth.ts';
+export type { MCPRequestClaims } from './types.ts';
+
 // Store hooks registered at module load time and active hookManager
 let pendingHooks: OAuthHooks | null = null;
 let activeHookManager: HookManager | null = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,14 @@ export async function handleApplication(scope: Scope): Promise<void> {
 
 		// Update the resource with new providers
 		if (Object.keys(providers).length === 0) {
-			// No valid providers configured - register a simple error resource
+			// No valid providers configured - register a simple error resource.
+			// Fail closed: clear the MCP config static too. OAuthResource.configure()
+			// (the only other writer) runs only in the else branch, so without this a
+			// live reload that drops all providers would leave the PREVIOUS mcpConfig in
+			// place — and withMCPAuth's default getter (and the well-known handlers) read
+			// that static, so they'd keep verifying tokens / serving discovery against
+			// stale config after the plugin is no longer validly configured.
+			OAuthResource.mcpConfig = undefined;
 			resources.set('oauth', {
 				async get() {
 					return {

--- a/src/lib/mcp/index.ts
+++ b/src/lib/mcp/index.ts
@@ -20,7 +20,10 @@ export { handleRegister } from './dcr.ts';
 export { MCPKeyStore, resetMCPKeysTableCache, SIGNING_KEY_ID } from './keyStore.ts';
 export { MCPRefreshFamilyStore, resetMCPRefreshFamiliesTableCache } from './refreshTokenStore.ts';
 export { handleToken } from './token.ts';
-export { publicKeyToJwk, signAccessToken, verifyAccessToken } from './tokenIssuer.ts';
+export { publicKeyToJwk, signAccessToken, verifyAccessToken, verifyAccessTokenWithKeySet } from './tokenIssuer.ts';
+export type { VerifyWithKeySetOptions } from './tokenIssuer.ts';
+export { withMCPAuth } from './withMCPAuth.ts';
+export type { WithMCPAuthOptions } from './withMCPAuth.ts';
 
 /**
  * Dispatch POST /oauth/mcp/<action>.

--- a/src/lib/mcp/tokenIssuer.ts
+++ b/src/lib/mcp/tokenIssuer.ts
@@ -52,13 +52,70 @@ export interface VerifyOptions {
 
 /**
  * Verify an access token against a public key. Primarily for tests; Stage 5
- * performs production verification against the published JWKS.
+ * performs production verification against the published JWKS via
+ * {@link verifyAccessTokenWithKeySet}.
  */
 export function verifyAccessToken(token: string, publicKeyPem: string, options?: VerifyOptions): jwt.JwtPayload {
 	return jwt.verify(token, publicKeyPem, {
 		algorithms: ['RS256'],
 		audience: options?.audience,
 		issuer: options?.issuer,
+	}) as jwt.JwtPayload;
+}
+
+export interface VerifyWithKeySetOptions {
+	/** Required `aud` claim — the canonical MCP resource URI (RFC 8707). */
+	audience: string;
+	/** Required `iss` claim — the authorization-server issuer. */
+	issuer: string;
+}
+
+/**
+ * Verify an access token against a set of published signing keys (the JWKS),
+ * selecting the key by the token header's `kid`:
+ *
+ * - `kid` present → the matching key MUST exist; an unknown `kid` throws (never
+ *   silently falls back to another key — that would let a token reference a
+ *   retired/foreign key and still verify against a current one).
+ * - `kid` absent → the sole key is used. Ambiguous (the set has >1 key) or an
+ *   empty set throws.
+ *
+ * Signature is verified RS256-only (pinning `algorithms` blocks `alg: none`
+ * and RS/HS confusion), and `audience` + `issuer` are enforced. Throws on any
+ * failure so callers (withMCPAuth) can fail closed. This is the production
+ * counterpart to {@link verifyAccessToken} and keeps all `jsonwebtoken` usage
+ * inside this module.
+ */
+export function verifyAccessTokenWithKeySet(
+	token: string,
+	keys: MCPSigningKeyRecord[],
+	options: VerifyWithKeySetOptions
+): jwt.JwtPayload {
+	if (!keys || keys.length === 0) {
+		throw new Error('no signing keys available');
+	}
+
+	// Decode (without verifying) only to read the header's `kid` for key
+	// selection. The signature is still verified below against the selected key.
+	const decoded = jwt.decode(token, { complete: true });
+	if (!decoded || typeof decoded === 'string') {
+		throw new Error('malformed token');
+	}
+
+	const kid = decoded.header?.kid;
+	let key: MCPSigningKeyRecord | undefined;
+	if (kid) {
+		key = keys.find((k) => k.kid === kid);
+		if (!key) throw new Error('unknown key id');
+	} else {
+		if (keys.length !== 1) throw new Error('key id required to select among multiple keys');
+		key = keys[0];
+	}
+
+	return jwt.verify(token, key.public_key_pem, {
+		algorithms: ['RS256'],
+		audience: options.audience,
+		issuer: options.issuer,
 	}) as jwt.JwtPayload;
 }
 

--- a/src/lib/mcp/wellKnown.ts
+++ b/src/lib/mcp/wellKnown.ts
@@ -81,7 +81,8 @@ export function resolveIssuer(request: HarperRequest, mcpConfig: MCPConfig): str
 		// endpoint URLs don't end up with a doubled slash.
 		return mcpConfig.issuer.replace(/\/+$/, '');
 	}
-	const host = request.host ?? request.headers?.host ?? 'localhost';
+	const rawHost = request.host ?? request.headers?.host;
+	const host = (Array.isArray(rawHost) ? rawHost[0] : rawHost) ?? 'localhost';
 	const scheme = request.protocol ?? 'https';
 	return `${scheme}://${host}`;
 }
@@ -106,6 +107,13 @@ export function resolveResource(request: HarperRequest, mcpConfig: MCPConfig): s
  * challenge value verbatim fetches a document this server actually answers.
  * Falls back to the request-derived issuer origin (bare path) if the resource
  * URI can't be parsed, so the deny path never throws.
+ *
+ * The result is interpolated into a quoted `resource_metadata="..."` header
+ * param, so it MUST be header-safe: a client-controlled Host (when the issuer
+ * is unpinned) must never inject a `"` or control char that breaks the quoting.
+ * Every branch normalizes through `new URL().origin`, which rejects/encodes
+ * such input; if even the issuer can't be parsed, fall back to the host-less
+ * relative path, which is always safe.
  */
 export function protectedResourceMetadataUrl(request: HarperRequest, mcpConfig: MCPConfig): string {
 	try {
@@ -113,7 +121,11 @@ export function protectedResourceMetadataUrl(request: HarperRequest, mcpConfig: 
 		const path = pathname && pathname !== '/' ? pathname.replace(/\/+$/, '') : '';
 		return `${origin}${PRM_PATH}${path}`;
 	} catch {
-		return `${resolveIssuer(request, mcpConfig)}${PRM_PATH}`;
+		try {
+			return `${new URL(resolveIssuer(request, mcpConfig)).origin}${PRM_PATH}`;
+		} catch {
+			return PRM_PATH;
+		}
 	}
 }
 

--- a/src/lib/mcp/wellKnown.ts
+++ b/src/lib/mcp/wellKnown.ts
@@ -40,7 +40,10 @@ type HttpResponse = {
 	body: string;
 };
 
-const PRM_PATH = '/.well-known/oauth-protected-resource';
+// Exported so withMCPAuth (Stage 5) builds its `WWW-Authenticate: Bearer
+// resource_metadata="<issuer>${PRM_PATH}"` challenge from the same constant the
+// PRM document is served at — the discovery loop stays in sync by construction.
+export const PRM_PATH = '/.well-known/oauth-protected-resource';
 const AS_METADATA_PATH = '/.well-known/oauth-authorization-server';
 const JWKS_PATH = '/.well-known/jwks.json';
 

--- a/src/lib/mcp/wellKnown.ts
+++ b/src/lib/mcp/wellKnown.ts
@@ -96,6 +96,28 @@ export function resolveResource(request: HarperRequest, mcpConfig: MCPConfig): s
 }
 
 /**
+ * Canonical RFC 9728 §3.1 Protected Resource Metadata URL for the configured
+ * resource: `<resource-origin>/.well-known/oauth-protected-resource[/<resource-path>]`.
+ *
+ * This is exactly the URL the PRM handler serves — bare for a resource at the
+ * origin root, path-appended when the resource carries a path (e.g. `.../mcp`);
+ * see {@link wellKnownPathMatches}. withMCPAuth's `WWW-Authenticate: Bearer
+ * resource_metadata="..."` challenge points here, so a client that uses the
+ * challenge value verbatim fetches a document this server actually answers.
+ * Falls back to the request-derived issuer origin (bare path) if the resource
+ * URI can't be parsed, so the deny path never throws.
+ */
+export function protectedResourceMetadataUrl(request: HarperRequest, mcpConfig: MCPConfig): string {
+	try {
+		const { origin, pathname } = new URL(resolveResource(request, mcpConfig));
+		const path = pathname && pathname !== '/' ? pathname.replace(/\/+$/, '') : '';
+		return `${origin}${PRM_PATH}${path}`;
+	} catch {
+		return `${resolveIssuer(request, mcpConfig)}${PRM_PATH}`;
+	}
+}
+
+/**
  * RFC 9728 Protected Resource Metadata document.
  */
 export function buildProtectedResourceMetadata(request: HarperRequest, mcpConfig: MCPConfig): Record<string, unknown> {

--- a/src/lib/mcp/withMCPAuth.ts
+++ b/src/lib/mcp/withMCPAuth.ts
@@ -167,6 +167,11 @@ export function withMCPAuth(handler: HttpListener, options: WithMCPAuthOptions =
 				headers: {
 					'WWW-Authenticate': `Bearer resource_metadata="${metadataUrl}"`,
 					'Content-Type': 'application/json',
+					// CORS parity with the well-known discovery docs: lets browser-based
+					// MCP clients read the challenge (and the WWW-Authenticate header)
+					// on a cross-origin 401 so the RFC 9728 discovery loop can proceed.
+					'Access-Control-Allow-Origin': '*',
+					'Access-Control-Expose-Headers': 'WWW-Authenticate',
 				},
 				body: JSON.stringify({ error: 'invalid_token', error_description: reason }),
 			};
@@ -177,6 +182,14 @@ export function withMCPAuth(handler: HttpListener, options: WithMCPAuthOptions =
 			// turn a denial into a pass or a malformed response — fail closed.
 			return handled || defaultResponse;
 		};
+
+		// Repo invariant (CLAUDE.md; OAuthResource.parseRoute caps paths at 2048
+		// for DoS mitigation): withMCPAuth can be registered outermost and doesn't
+		// go through parseRoute, so enforce the limit independently — fail closed
+		// before any token work.
+		if ((request.pathname ?? request.url ?? '').length > 2048) {
+			return deny('request path exceeds the maximum allowed length');
+		}
 
 		const cfg = getConfig();
 		// Fail closed: a route guarded by withMCPAuth never serves while MCP is

--- a/src/lib/mcp/withMCPAuth.ts
+++ b/src/lib/mcp/withMCPAuth.ts
@@ -44,7 +44,7 @@ import type { Logger, MCPConfig, MCPRequestClaims, MCPSigningKeyRecord, Request 
 import { OAuthResource } from '../resource.ts';
 import { MCPKeyStore } from './keyStore.ts';
 import { verifyAccessTokenWithKeySet } from './tokenIssuer.ts';
-import { PRM_PATH, resolveIssuer, resolveResource } from './wellKnown.ts';
+import { protectedResourceMetadataUrl, resolveIssuer, resolveResource } from './wellKnown.ts';
 
 /** Minimal surface withMCPAuth needs from a key source (lets tests inject one). */
 interface KeySource {
@@ -154,15 +154,18 @@ export function withMCPAuth(handler: HttpListener, options: WithMCPAuthOptions =
 			return next(request);
 		}
 
-		// Build the spec 401 once we know the issuer. resolveIssuer dereferences
-		// mcpConfig.issuer, so guard a missing config with an empty object — a
-		// denial must never throw (it would surface as a 500, not a 401).
+		// Build the spec 401. protectedResourceMetadataUrl derefs mcpConfig
+		// (via resolveResource), so guard a missing config with an empty object —
+		// a denial must never throw (it would surface as a 500, not a 401). The
+		// challenge points at the SAME path-aware PRM URL the well-known handler
+		// serves (RFC 9728 §3.1: path-appended when the resource carries a path),
+		// so a client using the challenge value verbatim hits a real document.
 		const deny = async (reason: string): Promise<any> => {
-			const issuer = resolveIssuer(request as any, getConfig() ?? ({} as MCPConfig));
+			const metadataUrl = protectedResourceMetadataUrl(request as any, getConfig() ?? ({} as MCPConfig));
 			const defaultResponse = {
 				status: 401,
 				headers: {
-					'WWW-Authenticate': `Bearer resource_metadata="${issuer}${PRM_PATH}"`,
+					'WWW-Authenticate': `Bearer resource_metadata="${metadataUrl}"`,
 					'Content-Type': 'application/json',
 				},
 				body: JSON.stringify({ error: 'invalid_token', error_description: reason }),

--- a/src/lib/mcp/withMCPAuth.ts
+++ b/src/lib/mcp/withMCPAuth.ts
@@ -150,7 +150,7 @@ export function withMCPAuth(handler: HttpListener, options: WithMCPAuthOptions =
 
 		// Default-group registration: only guard our own path; let everything
 		// else continue down the chain (to core auth and other middleware).
-		if (path && !pathOwned((request as any).pathname, path)) {
+		if (path && !pathOwned(request.pathname, path)) {
 			return next(request);
 		}
 
@@ -232,7 +232,7 @@ export function withMCPAuth(handler: HttpListener, options: WithMCPAuthOptions =
 			aud: payload.aud,
 			scope: payload.scope,
 		};
-		(request as any).mcp = claims;
+		request.mcp = claims;
 
 		// Token is valid — hand off to the app's handler. Its response is returned
 		// verbatim (no double-wrapping). `next` is forwarded so the handler may

--- a/src/lib/mcp/withMCPAuth.ts
+++ b/src/lib/mcp/withMCPAuth.ts
@@ -1,0 +1,240 @@
+/**
+ * MCP Bearer-Token Guard (`withMCPAuth`)
+ *
+ * Wraps an app-owned MCP route handler so every request must present a valid
+ * RS256 access token minted by this plugin's Stage 4 issuer before the handler
+ * runs. On any failure it returns the spec-mandated
+ * `401 + WWW-Authenticate: Bearer resource_metadata="..."` (RFC 9728 §5.1) that
+ * closes the MCP discovery loop, pointing clients at the Protected Resource
+ * Metadata document Stage 2 serves. This is the bearer-token counterpart to the
+ * cookie/session `withOAuthValidation` wrapper.
+ *
+ * ── Registration (READ THIS — core auth will eat the token otherwise) ────────
+ *
+ * Harper's core auth is a default-group HTTP middleware that consumes
+ * `Authorization: Bearer` and 401s any token it can't validate as a Harper
+ * *operation* token, stamping `WWW-Authenticate: Basic` (security/auth.ts) — NOT
+ * the Bearer challenge MCP clients require. So withMCPAuth must own the response
+ * for its route and core auth must not run on top of it.
+ *
+ * PRIMARY — register on a urlPath subroute (recommended):
+ *
+ *   server.http(withMCPAuth(myMcpHandler), { urlPath: '/mcp' });
+ *
+ *   Harper's routed dispatch (server/middlewareChain.ts) runs ONLY the matched
+ *   subroute's chain and returns — the default chain (where core auth lives)
+ *   never runs for '/mcp', so the Bearer challenge can't be clobbered. This is
+ *   the same isolation the `/.well-known/*` discovery endpoints rely on to stay
+ *   unauthenticated. No `path` option and no ordering hint are needed.
+ *
+ * FALLBACK — register in the default group, ahead of core auth:
+ *
+ *   server.http(withMCPAuth(myMcpHandler, { path: '/mcp' }), { before: 'authentication' });
+ *
+ *   When the route shares the default chain with auth (no urlPath), pass `path`
+ *   so the wrapper guards only that path and calls `next()` for everything else
+ *   (otherwise it would 401 unrelated routes), and register with
+ *   `{ before: 'authentication' }` so it runs outermost — ahead of core auth.
+ *   This mirrors the precedent in Harper's own server/static.ts. In this mode
+ *   the wrapped handler MUST terminate the request (not call `next`), or core
+ *   auth runs afterward and re-rejects the bearer token.
+ */
+
+import type { Logger, MCPConfig, MCPRequestClaims, MCPSigningKeyRecord, Request } from '../../types.ts';
+import { OAuthResource } from '../resource.ts';
+import { MCPKeyStore } from './keyStore.ts';
+import { verifyAccessTokenWithKeySet } from './tokenIssuer.ts';
+import { PRM_PATH, resolveIssuer, resolveResource } from './wellKnown.ts';
+
+/** Minimal surface withMCPAuth needs from a key source (lets tests inject one). */
+interface KeySource {
+	getAllPublicKeys(): Promise<MCPSigningKeyRecord[]>;
+}
+
+export interface WithMCPAuthOptions {
+	/**
+	 * Path this guard owns. Only set this for the default-group registration
+	 * (no `urlPath`): the wrapper then guards only requests whose pathname is
+	 * `path` or a sub-path of it and calls `next()` for everything else. Leave
+	 * unset for the urlPath-subroute registration, where Harper has already
+	 * scoped the route (and strips the prefix), so every request that reaches
+	 * the wrapper should be guarded.
+	 */
+	path?: string;
+	/**
+	 * MCP config source, read per request so live config changes apply. Defaults
+	 * to the plugin's live config (`OAuthResource.mcpConfig`).
+	 */
+	getConfig?: () => MCPConfig | undefined;
+	/** Logger. Defaults to the plugin logger (`OAuthResource.logger`). */
+	logger?: Logger;
+	/**
+	 * Signing-key source. Defaults to the plugin's `MCPKeyStore` (reads the
+	 * published public keys from `harper_oauth_mcp_keys`). Injectable for tests.
+	 */
+	keyStore?: KeySource;
+	/**
+	 * Custom denial handler, invoked on every rejection (mirrors
+	 * `withOAuthValidation.onValidationError`). Receives the request and a
+	 * human-readable reason. If it returns a falsy value the wrapper still
+	 * returns its default `401` — a no-return handler can never accidentally
+	 * turn a denial into a pass (fail closed by construction).
+	 */
+	onAuthError?: (request: Request, error: string) => any;
+}
+
+type HttpListener = (request: Request, next: (req: Request) => any) => any;
+
+/**
+ * Read a header value across the shapes a Harper request can carry: a Web
+ * `Headers` object (`.get()`), Harper's headers wrapper (`.asObject`), or a
+ * plain Node `IncomingMessage.headers` object (used in tests). Returns the
+ * first value when a header is multi-valued.
+ */
+function getHeader(headers: any, name: string): string | undefined {
+	if (!headers) return undefined;
+	let raw: unknown;
+	if (typeof headers.get === 'function') {
+		raw = headers.get(name);
+	} else {
+		const obj = headers.asObject ?? headers;
+		raw = obj?.[name.toLowerCase()] ?? obj?.[name];
+	}
+	if (raw == null) return undefined;
+	return Array.isArray(raw) ? raw[0] : String(raw);
+}
+
+/**
+ * Extract a bearer token from the `Authorization` header. Header-only by design
+ * (RFC 6750 §2.1): query-string and body tokens are never read, so they are
+ * treated as "no token presented". Returns undefined for a missing or malformed
+ * header (anything that isn't `Bearer <non-empty-token>`).
+ */
+function extractBearerToken(headers: any): string | undefined {
+	const authz = getHeader(headers, 'authorization');
+	if (!authz) return undefined;
+	// Scheme is case-insensitive (RFC 7235); the token must be non-empty.
+	const match = /^Bearer[ \t]+(\S.*)$/i.exec(authz.trim());
+	const token = match?.[1]?.trim();
+	return token ? token : undefined;
+}
+
+/**
+ * True when `pathname` is `routePath` or a segment-bounded sub-path of it
+ * ('/mcp' matches '/mcp' and '/mcp/x' but not '/mcponaut'). Trailing slashes on
+ * `routePath` are ignored. Mirrors Harper's `matchesRoute` urlPath semantics so
+ * the default-group fallback behaves like the urlPath registration.
+ */
+function pathOwned(pathname: string | undefined, routePath: string): boolean {
+	const path = routePath.length > 1 && routePath.endsWith('/') ? routePath.slice(0, -1) : routePath;
+	const p = pathname ?? '/';
+	return p === path || p.startsWith(path + '/');
+}
+
+/**
+ * Wrap an app MCP handler with bearer-token validation. See the module header
+ * for registration. The returned listener has the standard Harper
+ * `(request, next)` shape, so it registers exactly where the unwrapped handler
+ * would.
+ */
+export function withMCPAuth(handler: HttpListener, options: WithMCPAuthOptions = {}): HttpListener {
+	if (typeof handler !== 'function') {
+		throw new TypeError('withMCPAuth: handler must be a function (request, next) => response');
+	}
+
+	const { path, onAuthError } = options;
+	const getConfig = options.getConfig ?? (() => OAuthResource.mcpConfig);
+
+	return async function mcpAuthListener(request: Request, next: (req: Request) => any): Promise<any> {
+		const logger = options.logger ?? OAuthResource.logger;
+
+		// Default-group registration: only guard our own path; let everything
+		// else continue down the chain (to core auth and other middleware).
+		if (path && !pathOwned((request as any).pathname, path)) {
+			return next(request);
+		}
+
+		// Build the spec 401 once we know the issuer. resolveIssuer dereferences
+		// mcpConfig.issuer, so guard a missing config with an empty object — a
+		// denial must never throw (it would surface as a 500, not a 401).
+		const deny = async (reason: string): Promise<any> => {
+			const issuer = resolveIssuer(request as any, getConfig() ?? ({} as MCPConfig));
+			const defaultResponse = {
+				status: 401,
+				headers: {
+					'WWW-Authenticate': `Bearer resource_metadata="${issuer}${PRM_PATH}"`,
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ error: 'invalid_token', error_description: reason }),
+			};
+			if (!onAuthError) return defaultResponse;
+			const handled = await onAuthError(request, reason);
+			// `||` (not `??`): ANY falsy return (undefined, null, false, '', 0) falls
+			// back to the default 401. A handler that returns a non-response can never
+			// turn a denial into a pass or a malformed response — fail closed.
+			return handled || defaultResponse;
+		};
+
+		const cfg = getConfig();
+		// Fail closed: a route guarded by withMCPAuth never serves while MCP is
+		// disabled or unconfigured.
+		if (!cfg?.enabled) {
+			return deny('MCP authentication is not enabled');
+		}
+
+		const token = extractBearerToken(request.headers);
+		if (!token) {
+			return deny('missing or malformed Authorization: Bearer header');
+		}
+
+		let keys: MCPSigningKeyRecord[];
+		try {
+			const keyStore: KeySource = options.keyStore ?? new MCPKeyStore(logger);
+			keys = await keyStore.getAllPublicKeys();
+		} catch (error) {
+			logger?.error?.('withMCPAuth: failed to load MCP signing keys:', (error as Error).message);
+			keys = [];
+		}
+		if (keys.length === 0) {
+			// No keys means no token could have been issued yet (or the table is
+			// unavailable) — reject rather than treating it as "nothing to verify
+			// against, so allow".
+			return deny('no signing keys available to verify token');
+		}
+
+		const resource = resolveResource(request as any, cfg);
+		const issuer = resolveIssuer(request as any, cfg);
+
+		let payload: any;
+		try {
+			payload = verifyAccessTokenWithKeySet(token, keys, { audience: resource, issuer });
+		} catch (error) {
+			logger?.debug?.('withMCPAuth: token verification failed:', (error as Error).message);
+			return deny('access token is invalid, expired, or not issued for this resource');
+		}
+
+		// Audience binding (RFC 8707): jwt.verify already enforced `aud` contains
+		// `resource`, but require a single string `aud` so a multi-audience token
+		// minted elsewhere can't ride in.
+		if (typeof payload.sub !== 'string' || !payload.sub) return deny('token missing subject');
+		if (typeof payload.client_id !== 'string' || !payload.client_id) return deny('token missing client_id');
+		if (typeof payload.aud !== 'string' || !payload.aud) return deny('token audience is invalid');
+		if (payload.scope !== undefined && typeof payload.scope !== 'string') {
+			return deny('token scope is invalid');
+		}
+
+		const claims: MCPRequestClaims = {
+			sub: payload.sub,
+			client_id: payload.client_id,
+			aud: payload.aud,
+			scope: payload.scope,
+		};
+		(request as any).mcp = claims;
+
+		// Token is valid — hand off to the app's handler. Its response is returned
+		// verbatim (no double-wrapping). `next` is forwarded so the handler may
+		// fall through if it wants (urlPath mode); see the module header for the
+		// default-group caveat.
+		return handler(request, next);
+	};
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -511,6 +511,28 @@ export interface Request extends IncomingMessage {
 	 * from `IncomingMessage`.)
 	 */
 	pathname?: string;
+	/**
+	 * Verified MCP access-token claims, populated by `withMCPAuth` after a
+	 * successful Bearer validation. Absent when the request was not guarded by
+	 * `withMCPAuth` or did not pass validation (those requests are rejected
+	 * before the wrapped handler runs).
+	 */
+	mcp?: MCPRequestClaims;
+}
+
+/**
+ * Verified MCP access-token claims attached to the request by `withMCPAuth`.
+ * The app's MCP handler reads these to authorize per user/client.
+ */
+export interface MCPRequestClaims {
+	/** Token subject — the end-user identifier (`sub`). */
+	sub: string;
+	/** OAuth client that obtained the token — the DCR `client_id`. */
+	client_id: string;
+	/** Audience (`aud`) — the canonical MCP resource URI the token was minted for. */
+	aud: string;
+	/** Space-separated granted scopes (`scope`), if any. */
+	scope?: string;
 }
 
 /**

--- a/test/lib/mcp/tokenIssuer.test.js
+++ b/test/lib/mcp/tokenIssuer.test.js
@@ -5,7 +5,13 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { generateKeyPairSync } from 'node:crypto';
-import { signAccessToken, verifyAccessToken, publicKeyToJwk } from '../../../dist/lib/mcp/tokenIssuer.js';
+import jwt from 'jsonwebtoken';
+import {
+	signAccessToken,
+	verifyAccessToken,
+	verifyAccessTokenWithKeySet,
+	publicKeyToJwk,
+} from '../../../dist/lib/mcp/tokenIssuer.js';
 import { SIGNING_KEY_ID } from '../../../dist/lib/mcp/keyStore.js';
 
 const { publicKey, privateKey } = generateKeyPairSync('rsa', {
@@ -81,5 +87,87 @@ describe('tokenIssuer', () => {
 		assert.equal(jwk.alg, 'RS256');
 		assert.equal(jwk.kid, SIGNING_KEY_ID);
 		assert.equal(jwk.d, undefined, 'private exponent must NOT be present');
+	});
+});
+
+function makeRsaKey(kid) {
+	const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+		modulusLength: 2048,
+		publicKeyEncoding: { type: 'spki', format: 'pem' },
+		privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+	});
+	return { kid, alg: 'RS256', public_key_pem: publicKey, private_key_pem: privateKey, created_at: 1700000000 };
+}
+
+describe('verifyAccessTokenWithKeySet', () => {
+	it('selects the key by kid and verifies aud + iss', () => {
+		const token = signAccessToken(baseParams, key);
+		const claims = verifyAccessTokenWithKeySet(token, [makeRsaKey('unrelated'), key], {
+			audience: baseParams.audience,
+			issuer: baseParams.issuer,
+		});
+		assert.equal(claims.sub, baseParams.subject);
+		assert.equal(claims.client_id, baseParams.clientId);
+	});
+
+	it('throws on an empty key set', () => {
+		const token = signAccessToken(baseParams, key);
+		assert.throws(
+			() => verifyAccessTokenWithKeySet(token, [], { audience: baseParams.audience, issuer: baseParams.issuer }),
+			/no signing keys/
+		);
+	});
+
+	it('throws on an unknown kid rather than falling back to another key', () => {
+		// Signed with `key` (kid SIGNING_KEY_ID) but that kid is absent from the set.
+		const token = signAccessToken(baseParams, key);
+		assert.throws(
+			() =>
+				verifyAccessTokenWithKeySet(token, [makeRsaKey('different-kid')], {
+					audience: baseParams.audience,
+					issuer: baseParams.issuer,
+				}),
+			/unknown key id/
+		);
+	});
+
+	it('uses the sole key when the token carries no kid', () => {
+		// signAccessToken always sets a kid, so craft a no-kid token directly.
+		const token = jwt.sign({ client_id: 'c' }, key.private_key_pem, {
+			algorithm: 'RS256',
+			issuer: baseParams.issuer,
+			audience: baseParams.audience,
+			subject: baseParams.subject,
+		});
+		const claims = verifyAccessTokenWithKeySet(token, [key], {
+			audience: baseParams.audience,
+			issuer: baseParams.issuer,
+		});
+		assert.equal(claims.sub, baseParams.subject);
+	});
+
+	it('throws when no kid and the set is ambiguous (>1 key)', () => {
+		const token = jwt.sign({ client_id: 'c' }, key.private_key_pem, {
+			algorithm: 'RS256',
+			issuer: baseParams.issuer,
+			audience: baseParams.audience,
+			subject: baseParams.subject,
+		});
+		assert.throws(
+			() =>
+				verifyAccessTokenWithKeySet(token, [key, makeRsaKey('second')], {
+					audience: baseParams.audience,
+					issuer: baseParams.issuer,
+				}),
+			/key id required/
+		);
+	});
+
+	it('throws on a malformed token', () => {
+		assert.throws(
+			() =>
+				verifyAccessTokenWithKeySet('not-a-jwt', [key], { audience: baseParams.audience, issuer: baseParams.issuer }),
+			/malformed token/
+		);
 	});
 });

--- a/test/lib/mcp/wellKnown.test.js
+++ b/test/lib/mcp/wellKnown.test.js
@@ -35,6 +35,11 @@ describe('MCP well-known: URI resolution', () => {
 		assert.equal(resolveIssuer(req, {}), 'https://auto.example.com');
 	});
 
+	it('resolveIssuer takes the first value when the Host header is an array', () => {
+		const req = makeRequest({ protocol: 'https', host: undefined, headers: { host: ['first.example.com', 'second'] } });
+		assert.equal(resolveIssuer(req, {}), 'https://first.example.com');
+	});
+
 	it('resolveResource uses configured value when set', () => {
 		const req = makeRequest();
 		const resource = resolveResource(req, { resource: 'https://canonical.example.com/mcp-v2' });

--- a/test/lib/mcp/withMCPAuth.test.js
+++ b/test/lib/mcp/withMCPAuth.test.js
@@ -1,0 +1,311 @@
+/**
+ * Tests for withMCPAuth — the MCP bearer-token guard (Stage 5).
+ *
+ * Covers every rejection branch (no/malformed Authorization, bad signature,
+ * expired, audience mismatch, unknown kid, query-string token, MCP disabled,
+ * no keys), the happy path (claims attached, handler invoked once, response
+ * returned verbatim), the WWW-Authenticate PRM contract, header-shape
+ * robustness, the default-group `path` fall-through, and onAuthError.
+ *
+ * Dependencies are injected (getConfig / keyStore) so the test never touches
+ * the live OAuthResource config or the Harper keys table.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { generateKeyPairSync } from 'node:crypto';
+import { withMCPAuth } from '../../../dist/lib/mcp/withMCPAuth.js';
+import { signAccessToken } from '../../../dist/lib/mcp/tokenIssuer.js';
+import { SIGNING_KEY_ID } from '../../../dist/lib/mcp/keyStore.js';
+
+const ISSUER = 'https://as.example.com';
+const RESOURCE = 'https://app.example.com/mcp';
+const PRM_URL = `${ISSUER}/.well-known/oauth-protected-resource`;
+const EXPECTED_CHALLENGE = `Bearer resource_metadata="${PRM_URL}"`;
+
+function makeKey(modulusKid = SIGNING_KEY_ID) {
+	const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+		modulusLength: 2048,
+		publicKeyEncoding: { type: 'spki', format: 'pem' },
+		privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+	});
+	return {
+		kid: modulusKid,
+		alg: 'RS256',
+		public_key_pem: publicKey,
+		private_key_pem: privateKey,
+		created_at: 1700000000,
+	};
+}
+
+const key = makeKey();
+
+function mint(overrides = {}, signingKey = key) {
+	const params = {
+		issuer: ISSUER,
+		subject: 'alice@example.com',
+		audience: RESOURCE,
+		clientId: 'client-123',
+		scope: 'mcp:read',
+		ttlSeconds: 3600,
+		...overrides,
+	};
+	return signAccessToken(params, signingKey);
+}
+
+const config = { enabled: true, issuer: ISSUER, resource: RESOURCE };
+const silentLogger = { error() {}, warn() {}, info() {}, debug() {} };
+
+/** Build the options bag with injected config + key set (defaults to [key]). */
+function opts(extra = {}) {
+	return {
+		getConfig: () => config,
+		keyStore: {
+			async getAllPublicKeys() {
+				return extra.keys ?? [key];
+			},
+		},
+		logger: silentLogger,
+		...extra,
+	};
+}
+
+/** A request with a plain-object headers map (Node IncomingMessage shape). */
+function req(authorization, { pathname = '/mcp', url } = {}) {
+	const headers = {};
+	if (authorization !== undefined) headers.authorization = authorization;
+	headers.host = 'app.example.com';
+	return { headers, pathname, url: url ?? pathname, method: 'POST' };
+}
+
+/** Records handler invocations; returns a unique sentinel response. */
+function spyHandler(response = { status: 200, body: 'ok' }) {
+	const calls = [];
+	const handler = (request, next) => {
+		calls.push({ request, next });
+		return response;
+	};
+	return { handler, calls, response };
+}
+
+const NEXT = (request) => ({ __next: true, request });
+
+describe('withMCPAuth — construction', () => {
+	it('throws if handler is not a function', () => {
+		assert.throws(() => withMCPAuth(undefined), TypeError);
+		assert.throws(() => withMCPAuth({}), TypeError);
+	});
+});
+
+describe('withMCPAuth — rejections (all return 401 + Bearer PRM challenge)', () => {
+	it('rejects a request with no Authorization header', async () => {
+		const { handler, calls } = spyHandler();
+		const res = await withMCPAuth(handler, opts())(req(undefined), NEXT);
+		assert.equal(res.status, 401);
+		assert.equal(res.headers['WWW-Authenticate'], EXPECTED_CHALLENGE);
+		assert.equal(res.headers['Content-Type'], 'application/json');
+		assert.equal(calls.length, 0, 'handler must not run');
+	});
+
+	it('rejects a malformed Authorization header (wrong scheme / empty token)', async () => {
+		for (const bad of ['Basic abc123', 'Bearer', 'Bearer    ', 'Token xyz', 'xyz']) {
+			const { handler, calls } = spyHandler();
+			const res = await withMCPAuth(handler, opts())(req(bad), NEXT);
+			assert.equal(res.status, 401, `"${bad}" should 401`);
+			assert.equal(res.headers['WWW-Authenticate'], EXPECTED_CHALLENGE, `"${bad}" same challenge`);
+			assert.equal(calls.length, 0);
+		}
+	});
+
+	it('rejects a token with an invalid signature', async () => {
+		// Same kid, different key material → selected by kid, fails signature.
+		const forged = makeKey(SIGNING_KEY_ID);
+		const token = mint({}, forged);
+		const { handler, calls } = spyHandler();
+		const res = await withMCPAuth(handler, opts())(req(`Bearer ${token}`), NEXT);
+		assert.equal(res.status, 401);
+		assert.equal(calls.length, 0);
+	});
+
+	it('rejects a token with an unknown kid (no silent fallback to another key)', async () => {
+		const other = makeKey('some-other-kid');
+		const token = mint({}, other);
+		const res = await withMCPAuth(spyHandler().handler, opts())(req(`Bearer ${token}`), NEXT);
+		assert.equal(res.status, 401);
+	});
+
+	it('rejects an expired token', async () => {
+		const token = mint({ ttlSeconds: -10 });
+		const res = await withMCPAuth(spyHandler().handler, opts())(req(`Bearer ${token}`), NEXT);
+		assert.equal(res.status, 401);
+	});
+
+	it('rejects a token whose audience does not match mcp.resource (RFC 8707)', async () => {
+		const token = mint({ audience: 'https://evil.example.com/mcp' });
+		const res = await withMCPAuth(spyHandler().handler, opts())(req(`Bearer ${token}`), NEXT);
+		assert.equal(res.status, 401);
+	});
+
+	it('rejects a token whose issuer does not match', async () => {
+		const token = mint({ issuer: 'https://evil.example.com' });
+		const res = await withMCPAuth(spyHandler().handler, opts())(req(`Bearer ${token}`), NEXT);
+		assert.equal(res.status, 401);
+	});
+
+	it('ignores a query-string token (header-only; never validated)', async () => {
+		const token = mint();
+		const { handler, calls } = spyHandler();
+		const request = req(undefined, { url: `/mcp?access_token=${token}` });
+		const res = await withMCPAuth(handler, opts())(request, NEXT);
+		assert.equal(res.status, 401, 'query-string token treated as no token');
+		assert.equal(calls.length, 0);
+	});
+
+	it('fails closed when MCP is disabled', async () => {
+		const token = mint();
+		const res = await withMCPAuth(spyHandler().handler, opts({ getConfig: () => ({ enabled: false }) }))(
+			req(`Bearer ${token}`),
+			NEXT
+		);
+		assert.equal(res.status, 401);
+	});
+
+	it('fails closed when config is entirely absent (challenge still well-formed)', async () => {
+		const res = await withMCPAuth(spyHandler().handler, opts({ getConfig: () => undefined }))(req(undefined), NEXT);
+		assert.equal(res.status, 401);
+		// No configured issuer → derived from the request host.
+		assert.equal(
+			res.headers['WWW-Authenticate'],
+			'Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource"'
+		);
+	});
+
+	it('fails closed when no signing keys are published', async () => {
+		const token = mint();
+		const res = await withMCPAuth(spyHandler().handler, opts({ keys: [] }))(req(`Bearer ${token}`), NEXT);
+		assert.equal(res.status, 401);
+	});
+});
+
+describe('withMCPAuth — happy path', () => {
+	it('attaches request.mcp and invokes the handler once with the response returned verbatim', async () => {
+		const token = mint();
+		const sentinel = { status: 201, body: { hello: 'world' }, headers: { 'X-Custom': '1' } };
+		const { handler, calls } = spyHandler(sentinel);
+		const request = req(`Bearer ${token}`);
+		const res = await withMCPAuth(handler, opts())(request, NEXT);
+
+		assert.equal(res, sentinel, 'response returned verbatim (no double-wrap)');
+		assert.equal(calls.length, 1, 'handler invoked exactly once');
+		assert.deepEqual(request.mcp, {
+			sub: 'alice@example.com',
+			client_id: 'client-123',
+			aud: RESOURCE,
+			scope: 'mcp:read',
+		});
+		// The handler observes request.mcp already populated.
+		assert.equal(calls[0].request.mcp.sub, 'alice@example.com');
+	});
+
+	it('forwards next to the wrapped handler', async () => {
+		const token = mint();
+		let received;
+		const handler = (_request, next) => {
+			received = next;
+			return { status: 200 };
+		};
+		await withMCPAuth(handler, opts())(req(`Bearer ${token}`), NEXT);
+		assert.equal(received, NEXT);
+	});
+
+	it('accepts a token with no scope (scope omitted from claims)', async () => {
+		const token = mint({ scope: undefined });
+		const request = req(`Bearer ${token}`);
+		await withMCPAuth(spyHandler().handler, opts())(request, NEXT);
+		assert.equal(request.mcp.scope, undefined);
+		assert.equal(request.mcp.sub, 'alice@example.com');
+	});
+
+	it('reads the bearer token from a Web Headers object (.get)', async () => {
+		const token = mint();
+		const request = {
+			headers: new Headers({ authorization: `Bearer ${token}`, host: 'app.example.com' }),
+			pathname: '/mcp',
+		};
+		const { handler, calls } = spyHandler();
+		const res = await withMCPAuth(handler, opts())(request, NEXT);
+		assert.equal(calls.length, 1);
+		assert.equal(res.status, 200);
+	});
+
+	it('reads the bearer token from a Harper headers wrapper (.asObject)', async () => {
+		const token = mint();
+		const request = {
+			headers: { asObject: { authorization: `Bearer ${token}`, host: 'app.example.com' } },
+			pathname: '/mcp',
+		};
+		const { handler, calls } = spyHandler();
+		await withMCPAuth(handler, opts())(request, NEXT);
+		assert.equal(calls.length, 1);
+	});
+});
+
+describe('withMCPAuth — default-group registration (path option)', () => {
+	it('falls through (calls next) for a path it does not own', async () => {
+		const { handler, calls } = spyHandler();
+		const wrapped = withMCPAuth(handler, opts({ path: '/mcp' }));
+		const res = await wrapped(req(undefined, { pathname: '/other' }), NEXT);
+		assert.deepEqual(res, { __next: true, request: res.request });
+		assert.equal(res.__next, true, 'next() was called for unowned path');
+		assert.equal(calls.length, 0, 'guard did not run for unowned path');
+	});
+
+	it('guards its own path and sub-paths', async () => {
+		const token = mint();
+		const wrapped = withMCPAuth(spyHandler().handler, opts({ path: '/mcp' }));
+		// Unowned look-alike must fall through, not be guarded.
+		const lookalike = await wrapped(req(undefined, { pathname: '/mcponaut' }), NEXT);
+		assert.equal(lookalike.__next, true);
+		// Owned sub-path with no token must be rejected.
+		const denied = await wrapped(req(undefined, { pathname: '/mcp/tools' }), NEXT);
+		assert.equal(denied.status, 401);
+		// Owned path with a valid token must pass.
+		const { handler, calls } = spyHandler();
+		const wrapped2 = withMCPAuth(handler, opts({ path: '/mcp' }));
+		const ok = await wrapped2(req(`Bearer ${token}`, { pathname: '/mcp' }), NEXT);
+		assert.equal(ok.status, 200);
+		assert.equal(calls.length, 1);
+	});
+});
+
+describe('withMCPAuth — onAuthError', () => {
+	it('returns the callback result when it provides one', async () => {
+		const custom = { status: 403, body: 'denied by app' };
+		const res = await withMCPAuth(spyHandler().handler, opts({ onAuthError: () => custom }))(req(undefined), NEXT);
+		assert.equal(res, custom);
+	});
+
+	it('falls back to the default 401 when the callback returns undefined (fail closed)', async () => {
+		let seen;
+		const onAuthError = (request, error) => {
+			seen = { error };
+			// no return — must NOT become a pass
+		};
+		const { handler, calls } = spyHandler();
+		const res = await withMCPAuth(handler, opts({ onAuthError }))(req(undefined), NEXT);
+		assert.equal(res.status, 401);
+		assert.equal(res.headers['WWW-Authenticate'], EXPECTED_CHALLENGE);
+		assert.equal(calls.length, 0, 'a no-return callback never lets the handler run');
+		assert.ok(seen.error, 'callback received a reason string');
+	});
+
+	it('falls back to the default 401 for ANY falsy callback return (fail closed by construction)', async () => {
+		// Guards the `||` (not `??`) fallback: a handler that returns false / '' /
+		// 0 / null must never produce a non-response that bypasses the challenge.
+		for (const falsy of [false, '', 0, null, NaN]) {
+			const res = await withMCPAuth(spyHandler().handler, opts({ onAuthError: () => falsy }))(req(undefined), NEXT);
+			assert.equal(res.status, 401, `falsy return ${String(falsy)} must yield the default 401`);
+			assert.equal(res.headers['WWW-Authenticate'], EXPECTED_CHALLENGE);
+		}
+	});
+});

--- a/test/lib/mcp/withMCPAuth.test.js
+++ b/test/lib/mcp/withMCPAuth.test.js
@@ -325,3 +325,33 @@ describe('withMCPAuth — onAuthError', () => {
 		}
 	});
 });
+
+describe('withMCPAuth — hardening', () => {
+	it('rejects an over-length request path (>2048) before any token work (repo invariant)', async () => {
+		const token = mint();
+		const { handler, calls } = spyHandler();
+		const longPath = '/mcp/' + 'a'.repeat(2100);
+		const res = await withMCPAuth(handler, opts())(req(`Bearer ${token}`, { pathname: longPath }), NEXT);
+		assert.equal(res.status, 401, 'over-length path is rejected');
+		assert.equal(calls.length, 0, 'handler must not run');
+	});
+
+	it('keeps the WWW-Authenticate challenge header-safe against a quote-injecting Host', async () => {
+		// No config → issuer derives from the request Host (RFC 9728 fallback). A
+		// Host carrying a `"` must NOT break out of resource_metadata="...".
+		const request = req(undefined, { pathname: '/mcp' });
+		request.headers.host = 'evil.com" injected_param="x';
+		const res = await withMCPAuth(spyHandler().handler, opts({ getConfig: () => undefined }))(request, NEXT);
+		assert.equal(res.status, 401);
+		const wa = res.headers['WWW-Authenticate'];
+		assert.equal((wa.match(/"/g) || []).length, 2, `exactly one quoted param; got: ${wa}`);
+		assert.ok(!wa.includes('injected_param'), `no injected header param; got: ${wa}`);
+	});
+
+	it('sets CORS headers on the deny response so browser clients can read the challenge', async () => {
+		const res = await withMCPAuth(spyHandler().handler, opts())(req(undefined), NEXT);
+		assert.equal(res.status, 401);
+		assert.equal(res.headers['Access-Control-Allow-Origin'], '*');
+		assert.equal(res.headers['Access-Control-Expose-Headers'], 'WWW-Authenticate');
+	});
+});

--- a/test/lib/mcp/withMCPAuth.test.js
+++ b/test/lib/mcp/withMCPAuth.test.js
@@ -20,7 +20,9 @@ import { SIGNING_KEY_ID } from '../../../dist/lib/mcp/keyStore.js';
 
 const ISSUER = 'https://as.example.com';
 const RESOURCE = 'https://app.example.com/mcp';
-const PRM_URL = `${ISSUER}/.well-known/oauth-protected-resource`;
+// RFC 9728 §3.1: the PRM URL is derived from the RESOURCE (origin + well-known +
+// the resource's path), not the issuer — so it's the app origin with /mcp appended.
+const PRM_URL = 'https://app.example.com/.well-known/oauth-protected-resource/mcp';
 const EXPECTED_CHALLENGE = `Bearer resource_metadata="${PRM_URL}"`;
 
 function makeKey(modulusKid = SIGNING_KEY_ID) {
@@ -173,10 +175,11 @@ describe('withMCPAuth — rejections (all return 401 + Bearer PRM challenge)', (
 	it('fails closed when config is entirely absent (challenge still well-formed)', async () => {
 		const res = await withMCPAuth(spyHandler().handler, opts({ getConfig: () => undefined }))(req(undefined), NEXT);
 		assert.equal(res.status, 401);
-		// No configured issuer → derived from the request host.
+		// No config → resource derives as <request-origin>/mcp, so the PRM URL is
+		// the request host with the /mcp path appended.
 		assert.equal(
 			res.headers['WWW-Authenticate'],
-			'Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource"'
+			'Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/mcp"'
 		);
 	});
 
@@ -184,6 +187,19 @@ describe('withMCPAuth — rejections (all return 401 + Bearer PRM challenge)', (
 		const token = mint();
 		const res = await withMCPAuth(spyHandler().handler, opts({ keys: [] }))(req(`Bearer ${token}`), NEXT);
 		assert.equal(res.status, 401);
+	});
+
+	it('emits the BARE PRM challenge when the resource is at the origin root (no path)', async () => {
+		const res = await withMCPAuth(
+			spyHandler().handler,
+			opts({ getConfig: () => ({ enabled: true, issuer: ISSUER, resource: 'https://app.example.com' }) })
+		)(req(undefined), NEXT);
+		assert.equal(res.status, 401);
+		assert.equal(
+			res.headers['WWW-Authenticate'],
+			'Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource"',
+			'a root resource has no path to append'
+		);
 	});
 });
 

--- a/test/options-watcher.test.js
+++ b/test/options-watcher.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { handleApplication } from '../dist/index.js';
+import { OAuthResource } from '../dist/lib/resource.js';
 
 describe('OAuth Plugin Options Watcher', () => {
 	let scope;
@@ -173,6 +174,33 @@ describe('OAuth Plugin Options Watcher', () => {
 		const response = await resources.oauth.get();
 		assert.equal(response.status, 503, 'Should return 503 when no providers configured');
 		assert.ok(response.body.error.includes('No valid OAuth providers'), 'Should have appropriate error message');
+	});
+
+	it('should clear MCP config when a live reload drops all providers (fail closed)', async () => {
+		// Start enabled with a valid provider so OAuthResource.mcpConfig is live.
+		scope.options._config = {
+			debug: false,
+			providers: {
+				github: { provider: 'github', clientId: 'test-client-id', clientSecret: 'test-client-secret' },
+			},
+			mcp: { enabled: true, issuer: 'https://app.example.com' },
+		};
+		await handleApplication(scope);
+		assert.equal(OAuthResource.mcpConfig?.enabled, true, 'MCP config should be live while a provider is configured');
+
+		// Reload to zero providers — the plugin is no longer validly configured.
+		scope.options._config = { debug: false, providers: {} };
+		configChangeListeners[0]();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		// Fail closed: the stale enabled MCP config must not survive, or withMCPAuth's
+		// default getter (and the well-known handlers) would keep verifying tokens /
+		// serving discovery against config the plugin no longer holds.
+		assert.equal(
+			OAuthResource.mcpConfig,
+			undefined,
+			'MCP config must be cleared on the zero-provider branch so the MCP surface fails closed'
+		);
 	});
 
 	it('should handle adding new provider', async () => {


### PR DESCRIPTION
Stage 5 of the MCP OAuth epic (#86). A plugin-provided guard for **app-owned** MCP routes: it validates the bearer access token and returns the spec-mandated `401 + WWW-Authenticate: Bearer resource_metadata="..."` so apps don't reimplement the (security-sensitive) RFC 9728 discovery contract. Bearer-token counterpart to `withOAuthValidation`.

Closes #95.

## What it does

`withMCPAuth(handler, options?)` wraps an app MCP handler so every request must present a valid RS256 access token (minted by Stage 4's issuer) before the handler runs:

- Verifies the `Authorization: Bearer` token: RS256 signature against the published JWKS (key selected by `kid`), `exp`/`nbf`, and `aud` bound to `mcp.resource` (RFC 8707).
- On any failure returns `401` with `WWW-Authenticate: Bearer resource_metadata="<issuer>/.well-known/oauth-protected-resource"` (RFC 9728).
- On success attaches `request.mcp = { sub, client_id, aud, scope }` and invokes the handler, returning its response verbatim.
- **Fails closed** (MCP disabled / no token / no keys / malformed / bad claims). Header-only token extraction per RFC 6750 — query-string tokens are ignored.

## Registration — the load-bearing detail (and a correction to the #95 example)

Harper core auth is a **default-group** middleware that consumes `Authorization: Bearer` and 401s any non-Harper token with `WWW-Authenticate: Basic`, which breaks MCP discovery. The wrapper supports both registration models so it always owns its route's response; docs lead with the first:

- **`urlPath` subroute (recommended):** `server.http(withMCPAuth(handler), { urlPath: '/mcp' })`. In harper 5.1.x, routed dispatch (`server/middlewareChain.ts` `buildRoutedChain`) runs **only the matched subroute's chain** — core auth (default group) never runs for it, the same isolation `/.well-known/*` relies on. **No `runFirst` needed.**
- **Default-group fallback:** `server.http(withMCPAuth(handler, { path: '/mcp' }), { before: 'authentication' })`. When the route shares the default chain with auth, `path` scopes the guard (other paths fall through) and `before: 'authentication'` runs it ahead of core auth — the `static.ts` precedent.

Note: the issue #95 example `server.http('/mcp', withMCPAuth(h))` is incorrect for this Harper version — `server.http` is `(listener, options)` and needs the `urlPath`/ordering hint above. The plan's original `runFirst: true` framing was modeled on an older middleware chain; `runFirst` is not the mechanism here.

## Changes

- **NEW** `src/lib/mcp/withMCPAuth.ts` — the guard.
- `src/lib/mcp/tokenIssuer.ts` — `verifyAccessTokenWithKeySet` (kid selection: unknown `kid` throws, no `kid` uses the sole key; RS256-pinned to block alg confusion; `aud`+`iss` enforced).
- `src/lib/mcp/wellKnown.ts` — export `PRM_PATH` (challenge URL stays in sync by construction).
- `src/types.ts` — `MCPRequestClaims` + `Request.mcp`.
- Exports wired in `src/lib/mcp/index.ts` and the top-level `src/index.ts`.
- Unit tests (`withMCPAuth.test.js` + `verifyAccessTokenWithKeySet` cases) and an integration test + fixture (`mcp-auth.test.ts` / `mcp-auth-app`) asserting the Bearer challenge survives core auth for **both** registration models (runs on CI — needs loopback aliases).
- README + `docs/configuration.md`.

## Testing

- Unit: 686 pass, 0 fail. Build + lint + format clean.
- Integration: added; runs on CI (loopback aliases aren't configured locally).

## Cross-model review (pre-PR, HEG step 10)

Codex + Harper-domain `reviewer` (Gemini/`agy` leg skipped — exfiltration-blocked for this repo; CI's gemini bot covers it). **No blockers.** One fix applied before this PR: `onAuthError`'s fallback used `??`, but the documented contract promises *any* falsy return fails closed — changed to `||` and added a falsy-return regression test. No-action notes: the deny-path `resource_metadata` URL derives from the `Host` header when `mcp.issuer` is unset (already documented as "pin `mcp.issuer` in production"; the fixture pins it); the undefined-`pathname` default-group fall-through is benign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
