### PR TITLE
chore(ci): bump ai-review-prompts to 1bbc562 (week-of-06-15 calibration + log-count fix)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@9eb635a9221ffcc1e467016b525a7655277d2d6c # main 2026-06-15 (post #59 — week-of-06-08 calibration: mechanical-diff no-log gate, setup/teardown-leak + undefined-context robustness, commit/replication atomicity)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@1bbc562d57d131363586fdde3e893380381f455e # main 2026-06-24 (#67 week-of-06-15 calibration: error/abort-path rule + throwaway/inert-CI-config ignore; #69 log finding-count fix)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job
     # grants below what they need and breaks the workflow at startup;
@@ -58,7 +58,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 9eb635a9221ffcc1e467016b525a7655277d2d6c
+      ai-review-prompts-ref: 1bbc562d57d131363586fdde3e893380381f455e
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -45,7 +45,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@48e539aaa50cf45bd99494427a3ce4c9f1c46f26 # main 2026-06-18 (post #66 — Suggestions must propose a change, never affirm; incl. #65 inline resolvable severity-badged comments + Suggestions tier)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@1bbc562d57d131363586fdde3e893380381f455e # main 2026-06-24 (#67 week-of-06-15 calibration: error/abort-path rule + throwaway/inert-CI-config ignore; #69 log finding-count fix)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job
     # grants below what they need and breaks the workflow at startup;
@@ -67,7 +67,7 @@ jobs:
       # in this repo for why the duplication is unavoidable
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
-      ai-review-prompts-ref: 48e539aaa50cf45bd99494427a3ce4c9f1c46f26
+      ai-review-prompts-ref: 1bbc562d57d131363586fdde3e893380381f455e
       review-layers: |
         universal
         harper/common


### PR DESCRIPTION
## What

Bumps the **claude-review** (was `9eb635a`, week-of-06-08) and **gemini-review** (was `48e539a`, post-#66) callers to ai-review-prompts main **`1bbc562`**:

- **[#67](https://github.com/HarperFast/ai-review-prompts/pull/67)** — week-of-06-15 calibration: "error/abort paths that crash or leak" Robustness rule; "explicitly-throwaway / empty-diff PRs" ignore; mechanical-diff ignore narrowed to **inert** CI-config with a workflow-security carve-out.
- **[#69](https://github.com/HarperFast/ai-review-prompts/pull/69)** — log-review **finding-count fix** (ai-review-log #683): a finding-bearing review is no longer logged as "no blockers" when the count is spelled out or inline-only.

`uses:` and `ai-review-prompts-ref:` move in lockstep. Only the two review callers change.

Part of the harper / harper-pro / oauth rollout of this batch (harper#1502 is the canary). This PR's own review run also exercises `1bbc562`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
