### PR TITLE
chore(types): declare `pathname?: string` on the Request interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -504,6 +504,13 @@ export interface Request extends IncomingMessage {
 	headers: IncomingMessage['headers'];
 	/** Client IP address */
 	ip?: string;
+	/**
+	 * Request path (no query string). Harper populates this on the runtime
+	 * request; it's declared here so middleware can read `request.pathname`
+	 * without an `(request as any)` cast. (`url` — path + query — is inherited
+	 * from `IncomingMessage`.)
+	 */
+	pathname?: string;
 }
 
 /**


### PR DESCRIPTION
Declares the optional `pathname` field on the plugin's `Request` interface. Harper populates `pathname` on the runtime request, but the interface (which extends `IncomingMessage`) didn't declare it — so middleware reads it via `(request as any).pathname`. With the field declared, middleware can use `request.pathname` directly.

**Type-only, no behavior change.** Verified: build, lint, format, and the full unit suite (670 pass) are clean.

The `(request as any).pathname` cast itself lives in `withMCPAuth` (#134, still open at time of writing), so it isn't on `main` to remove here — this field makes `request.pathname` available so #134 (and any future middleware) can drop the cast once it lands on top of this.

Closes #137. Surfaced by the gemini-review bot on #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)