### PR TITLE
MCP OAuth Stage 6: audit logging + onMCPTokenIssued hook (#96)

### DIFF
--- a/src/lib/hookManager.ts
+++ b/src/lib/hookManager.ts
@@ -86,7 +86,11 @@ export class HookManager {
 			this.logger?.debug?.(`Calling onMCPTokenIssued hook for client: ${event.client_id} type: ${event.type}`);
 			await this.hooks.onMCPTokenIssued(event, request);
 		} catch (error) {
-			this.logger?.error?.('onMCPTokenIssued hook failed:', (error as Error).message);
+			// `instanceof Error` (not `as Error`): a hook may throw a non-Error
+			// (string, null, undefined). `(null).message` would itself throw —
+			// inside the catch — and escape, breaking the fire-and-forget contract
+			// (a throwing hook must NEVER block token issuance).
+			this.logger?.error?.('onMCPTokenIssued hook failed:', error instanceof Error ? error.message : String(error));
 			// Don't throw - hooks should not block token issuance
 		}
 	}

--- a/src/lib/hookManager.ts
+++ b/src/lib/hookManager.ts
@@ -94,9 +94,18 @@ export class HookManager {
 		// throw inside the catch.
 		void Promise.resolve()
 			.then(() => hook(event, request))
-			.catch((error) =>
-				this.logger?.error?.('onMCPTokenIssued hook failed:', error instanceof Error ? error.message : String(error))
-			);
+			.catch((error) => {
+				// Shield the catch body itself: a throwing logger (logging-subsystem
+				// I/O error) or a malicious `error.toString()` must NOT throw here —
+				// this chain is detached (`void`), so an escaping error would be an
+				// unhandled rejection (process crash on Node ≥15). Best-effort, same
+				// posture as emitMCPAuditEvent.
+				try {
+					this.logger?.error?.('onMCPTokenIssued hook failed:', error instanceof Error ? error.message : String(error));
+				} catch {
+					// Intentionally ignored — logging is best-effort.
+				}
+			});
 	}
 
 	/**

--- a/src/lib/hookManager.ts
+++ b/src/lib/hookManager.ts
@@ -70,6 +70,28 @@ export class HookManager {
 	}
 
 	/**
+	 * Call onMCPTokenIssued hook.
+	 *
+	 * Failure is swallowed — a throwing hook must NOT block token issuance.
+	 * The hook is fire-and-forget: we await it (so the log lands before the
+	 * response) but reject from app code is caught and logged, never re-thrown.
+	 */
+	async callOnMCPTokenIssued(
+		event: { type: 'access' | 'refresh'; client_id: string; sub: string; aud: string; scope?: string; jti: string },
+		request: any
+	): Promise<void> {
+		if (!this.hooks.onMCPTokenIssued) return;
+
+		try {
+			this.logger?.debug?.(`Calling onMCPTokenIssued hook for client: ${event.client_id} type: ${event.type}`);
+			await this.hooks.onMCPTokenIssued(event, request);
+		} catch (error) {
+			this.logger?.error?.('onMCPTokenIssued hook failed:', (error as Error).message);
+			// Don't throw - hooks should not block token issuance
+		}
+	}
+
+	/**
 	 * Call onTokenRefresh hook
 	 */
 	async callOnTokenRefresh(session: any, refreshed: boolean, request?: any): Promise<void> {

--- a/src/lib/hookManager.ts
+++ b/src/lib/hookManager.ts
@@ -48,7 +48,7 @@ export class HookManager {
 			const result = await this.hooks.onLogin(oauthUser, tokenResponse, session, request, provider);
 			return result;
 		} catch (error) {
-			this.logger?.error?.('onLogin hook failed:', (error as Error).message);
+			this.logger?.error?.('onLogin hook failed:', error instanceof Error ? error.message : String(error));
 			// Don't throw - hooks should not break the OAuth flow
 			return;
 		}
@@ -64,35 +64,39 @@ export class HookManager {
 			this.logger?.debug?.('Calling onLogout hook');
 			await this.hooks.onLogout(session, request);
 		} catch (error) {
-			this.logger?.error?.('onLogout hook failed:', (error as Error).message);
+			this.logger?.error?.('onLogout hook failed:', error instanceof Error ? error.message : String(error));
 			// Don't throw - hooks should not break logout
 		}
 	}
 
 	/**
-	 * Call onMCPTokenIssued hook.
+	 * Call onMCPTokenIssued hook (fire-and-forget).
 	 *
-	 * Failure is swallowed — a throwing hook must NOT block token issuance.
-	 * The hook is fire-and-forget: we await it (so the log lands before the
-	 * response) but reject from app code is caught and logged, never re-thrown.
+	 * NOT awaited: the hook runs detached after the token is durably issued, so it
+	 * can never add latency to — or block — token issuance (per @kriszyp's review
+	 * on #141; this also removes the need for a hook-execution timeout, #143). A
+	 * rejection, or a synchronous throw, from app code is caught and logged here,
+	 * never surfaced to the caller.
 	 */
-	async callOnMCPTokenIssued(
+	callOnMCPTokenIssued(
 		event: { type: 'access' | 'refresh'; client_id: string; sub: string; aud: string; scope?: string; jti: string },
 		request: any
-	): Promise<void> {
-		if (!this.hooks.onMCPTokenIssued) return;
+	): void {
+		const hook = this.hooks.onMCPTokenIssued;
+		if (!hook) return;
 
-		try {
-			this.logger?.debug?.(`Calling onMCPTokenIssued hook for client: ${event.client_id} type: ${event.type}`);
-			await this.hooks.onMCPTokenIssued(event, request);
-		} catch (error) {
-			// `instanceof Error` (not `as Error`): a hook may throw a non-Error
-			// (string, null, undefined). `(null).message` would itself throw —
-			// inside the catch — and escape, breaking the fire-and-forget contract
-			// (a throwing hook must NEVER block token issuance).
-			this.logger?.error?.('onMCPTokenIssued hook failed:', error instanceof Error ? error.message : String(error));
-			// Don't throw - hooks should not block token issuance
-		}
+		this.logger?.debug?.(`Calling onMCPTokenIssued hook for client: ${event.client_id} type: ${event.type}`);
+		// Detach with Promise.resolve().then so a SYNCHRONOUS throw in the hook is
+		// funneled into the same catch as a rejected promise (and never escapes as
+		// an uncaught exception on the issuance path). `void` marks the floating
+		// promise intentional. `instanceof Error` (not `as Error`): a hook may throw
+		// a non-Error (string, null, undefined) and `(null).message` would itself
+		// throw inside the catch.
+		void Promise.resolve()
+			.then(() => hook(event, request))
+			.catch((error) =>
+				this.logger?.error?.('onMCPTokenIssued hook failed:', error instanceof Error ? error.message : String(error))
+			);
 	}
 
 	/**
@@ -105,7 +109,7 @@ export class HookManager {
 			this.logger?.debug?.(`Calling onTokenRefresh hook (refreshed: ${refreshed})`);
 			await this.hooks.onTokenRefresh(session, refreshed, request);
 		} catch (error) {
-			this.logger?.error?.('onTokenRefresh hook failed:', (error as Error).message);
+			this.logger?.error?.('onTokenRefresh hook failed:', error instanceof Error ? error.message : String(error));
 			// Don't throw - hooks should not break token refresh
 		}
 	}
@@ -147,7 +151,7 @@ export class HookManager {
 			}
 			return config;
 		} catch (error) {
-			this.logger?.error?.('onResolveProvider hook failed:', (error as Error).message);
+			this.logger?.error?.('onResolveProvider hook failed:', error instanceof Error ? error.message : String(error));
 			throw error; // Re-throw for resource to handle (returns 500)
 		}
 	}

--- a/src/lib/mcp/audit.ts
+++ b/src/lib/mcp/audit.ts
@@ -20,21 +20,29 @@
  *     auth audit trail, not to system.log.
  *
  * Keep ALL string formatting inside the logger call so the optional-call
- * short-circuit (`?.`) avoids JSON.stringify work when info is suppressed
- * (same lazy-logging pattern as dcr.ts).
+ * short-circuit (`?.`) avoids JSON.stringify work when info is undefined
+ * (same lazy-logging pattern as dcr.ts). Note: `?.` only short-circuits when
+ * `info` is absent, not when it's a level-suppressed no-op — fully lazy logging
+ * would need a logger-level check Harper doesn't expose to plugins here.
  *
- * The `rejected` event (oauth.mcp.token.rejected) is NOT implemented here yet
- * — it belongs in withMCPAuth (Stage 5, PR #134, not on main). The helper is
- * written to accept any event type so adding it later is a one-liner.
+ * Three event types: `issued` / `refreshed` (success path, from the token
+ * endpoint — carry the verified claims) and `rejected` (from the withMCPAuth
+ * guard when a presented bearer token fails validation). A rejected token has
+ * NO verified claims, so its payload is a distinct shape (reason + resource).
  */
 
 import { logger as harperLogger } from 'harper';
 
 export type MCPAuditEventType = 'oauth.mcp.token.issued' | 'oauth.mcp.token.refreshed' | 'oauth.mcp.token.rejected';
 
-export interface MCPAuditPayload {
-	/** Discriminator for the audit event type. */
-	event: MCPAuditEventType;
+/**
+ * Audit record for a successfully issued or refreshed token. Carries the
+ * verified claims (the token validated, so these are trustworthy) — but never
+ * the token strings themselves; only the `jti` identifier.
+ */
+export interface MCPTokenIssuedAuditPayload {
+	/** Discriminator: success-path token events. */
+	event: 'oauth.mcp.token.issued' | 'oauth.mcp.token.refreshed';
 	/** Registered MCP client identifier. */
 	client_id: string;
 	/** Subject claim — the Harper user the token was issued to. */
@@ -48,6 +56,26 @@ export interface MCPAuditPayload {
 	/** ISO-8601 UTC timestamp of the event. */
 	timestamp: string;
 }
+
+/**
+ * Audit record for a bearer token rejected at the withMCPAuth guard. The token
+ * FAILED validation (bad signature / expired / wrong audience / malformed
+ * claims), so it has no trustworthy claims: we log only the denial reason and
+ * the resource it was presented to — never an unverified `client_id`/`sub`/`jti`,
+ * which would be attacker-controlled, spoofable input.
+ */
+export interface MCPTokenRejectedAuditPayload {
+	/** Discriminator: a presented token was rejected. */
+	event: 'oauth.mcp.token.rejected';
+	/** Human-readable denial reason (the same text returned in the 401 body). */
+	reason: string;
+	/** Resource URI the token was presented to (best-effort, from MCP config). */
+	aud: string;
+	/** ISO-8601 UTC timestamp of the event. */
+	timestamp: string;
+}
+
+export type MCPAuditPayload = MCPTokenIssuedAuditPayload | MCPTokenRejectedAuditPayload;
 
 /**
  * Emit a structured MCP audit event via Harper's global logger.

--- a/src/lib/mcp/audit.ts
+++ b/src/lib/mcp/audit.ts
@@ -1,0 +1,74 @@
+/**
+ * MCP Audit Channel
+ *
+ * Emits structured audit records for MCP token lifecycle events via Harper's
+ * global logger at `.info`. Mirrors how Harper core audits auth events in
+ * security/auth.ts (authEventLog.info?.(log)). Each record is prefixed
+ * `MCP audit:` and carries an `event` discriminator field, so operators filter
+ * by that prefix / the `event` value — Harper's logger doesn't expose a tag/
+ * named-level facility to plugins here (the `dcr.ts` audit logs are untagged
+ * for the same reason).
+ *
+ * Why .info and not .notify:
+ *   - `notify` sits above `fatal` (level 7) in Harper's hierarchy and is
+ *     reserved for operational broadcast events (service started, fatal state
+ *     changes). Token issuance is routine success-path activity — it should be
+ *     auditable at the standard info level, just like Harper core's
+ *     auth-success events.
+ *   - Using harperLogger (Harper's global structured logger) rather than the
+ *     scoped plugin logger routes these to hdb.log alongside Harper's own
+ *     auth audit trail, not to system.log.
+ *
+ * Keep ALL string formatting inside the logger call so the optional-call
+ * short-circuit (`?.`) avoids JSON.stringify work when info is suppressed
+ * (same lazy-logging pattern as dcr.ts).
+ *
+ * The `rejected` event (oauth.mcp.token.rejected) is NOT implemented here yet
+ * — it belongs in withMCPAuth (Stage 5, PR #134, not on main). The helper is
+ * written to accept any event type so adding it later is a one-liner.
+ */
+
+import { logger as harperLogger } from 'harper';
+
+export type MCPAuditEventType = 'oauth.mcp.token.issued' | 'oauth.mcp.token.refreshed' | 'oauth.mcp.token.rejected';
+
+export interface MCPAuditPayload {
+	/** Discriminator for the audit event type. */
+	event: MCPAuditEventType;
+	/** Registered MCP client identifier. */
+	client_id: string;
+	/** Subject claim — the Harper user the token was issued to. */
+	sub: string;
+	/** Audience claim — the resource URI the token is bound to. */
+	aud: string;
+	/** OAuth scope string (may be undefined for unscoped tokens). */
+	scope?: string;
+	/** JWT ID — uniquely identifies this token. Safe to log (not the token). */
+	jti: string;
+	/** ISO-8601 UTC timestamp of the event. */
+	timestamp: string;
+}
+
+/**
+ * Emit a structured MCP audit event via Harper's global logger.
+ *
+ * Failure to log MUST NOT propagate — this is fire-and-forget. The call site
+ * is responsible for the try/catch if needed, but this function itself does
+ * not throw.
+ *
+ * SECURITY: payload must never include token strings (access_token,
+ * refresh_token, client_secret). Only the jti (token identifier) is included.
+ */
+export function emitMCPAuditEvent(payload: MCPAuditPayload): void {
+	// Fire-and-forget: a logging failure MUST NOT propagate. Callers emit AFTER
+	// token state is durably committed (e.g. a rotated refresh family), so a
+	// thrown logger error here would deny the client its new token and strand
+	// the family on a hash the client never received. Swallow everything.
+	try {
+		// Keep JSON.stringify inside the optional call so it is only evaluated
+		// when the info level is active (optional-call short-circuit).
+		harperLogger?.info?.(`MCP audit: ${JSON.stringify(payload)}`);
+	} catch {
+		// Intentionally ignored — audit logging is best-effort.
+	}
+}

--- a/src/lib/mcp/index.ts
+++ b/src/lib/mcp/index.ts
@@ -7,6 +7,7 @@
  */
 
 import type { RequestTarget } from 'harper';
+import type { HookManager } from '../hookManager.ts';
 import type { Logger, MCPConfig, ProviderRegistry, Request } from '../../types.ts';
 import { handleAuthorize } from './authorize.ts';
 import { handleRegister } from './dcr.ts';
@@ -27,12 +28,16 @@ export { publicKeyToJwk, signAccessToken, verifyAccessToken } from './tokenIssue
  *
  * Returns 404 when MCP is disabled (existence-hiding — clients shouldn't
  * be able to probe whether MCP support is configured).
+ *
+ * `hookManager` is forwarded to `handleToken` so `onMCPTokenIssued` fires
+ * on successful token issuance.
  */
 export async function handleMCPPost(
 	action: string,
 	request: Request,
 	body: any,
 	mcpConfig: MCPConfig | undefined,
+	hookManager?: HookManager,
 	logger?: Logger
 ): Promise<any> {
 	if (!mcpConfig?.enabled) {
@@ -44,7 +49,7 @@ export async function handleMCPPost(
 	}
 
 	if (action === 'token') {
-		return handleToken(request, body, mcpConfig, logger);
+		return handleToken(request, body, mcpConfig, hookManager, logger);
 	}
 
 	return { status: 404, body: { error: 'Not found' } };

--- a/src/lib/mcp/token.ts
+++ b/src/lib/mcp/token.ts
@@ -412,18 +412,31 @@ export async function handleToken(
 	hookManager?: HookManager,
 	logger?: Logger
 ): Promise<TokenResponse> {
-	const grantType = typeof body?.grant_type === 'string' ? body.grant_type : undefined;
-	if (grantType !== 'authorization_code' && grantType !== 'refresh_token') {
-		return errorResponse(400, 'unsupported_grant_type', 'grant_type must be authorization_code or refresh_token');
-	}
+	// Top-level guard: any unexpected throw (a signing failure, a store
+	// timeout, etc.) must become a structured OAuth error (RFC 6749 §5.2), not
+	// propagate to the framework's default 500 handler — which could surface a
+	// stack trace or raw error message. The per-grant handlers already return
+	// their own 4xx errors; this only catches the unexpected.
+	try {
+		const grantType = typeof body?.grant_type === 'string' ? body.grant_type : undefined;
+		if (grantType !== 'authorization_code' && grantType !== 'refresh_token') {
+			return errorResponse(400, 'unsupported_grant_type', 'grant_type must be authorization_code or refresh_token');
+		}
 
-	const auth = await authenticateClient(request, body, logger);
-	if ('error' in auth) {
-		return auth.error;
-	}
+		const auth = await authenticateClient(request, body, logger);
+		if ('error' in auth) {
+			return auth.error;
+		}
 
-	if (grantType === 'authorization_code') {
-		return handleAuthorizationCodeGrant(request, body, auth.client, mcpConfig, hookManager, logger);
+		if (grantType === 'authorization_code') {
+			return await handleAuthorizationCodeGrant(request, body, auth.client, mcpConfig, hookManager, logger);
+		}
+		return await handleRefreshTokenGrant(request, body, auth.client, mcpConfig, hookManager, logger);
+	} catch (error) {
+		logger?.error?.(
+			'MCP token: unexpected error during token issuance:',
+			error instanceof Error ? error.message : String(error)
+		);
+		return errorResponse(500, 'server_error', 'An unexpected error occurred during token issuance');
 	}
-	return handleRefreshTokenGrant(request, body, auth.client, mcpConfig, hookManager, logger);
 }

--- a/src/lib/mcp/token.ts
+++ b/src/lib/mcp/token.ts
@@ -11,7 +11,9 @@
  */
 
 import { createHash, timingSafeEqual } from 'node:crypto';
+import type { HookManager } from '../hookManager.ts';
 import type { Logger, MCPClientRecord, MCPConfig, Request } from '../../types.ts';
+import { emitMCPAuditEvent } from './audit.ts';
 import { MCPAuthCodeStore } from './authCodeStore.ts';
 import { MCPClientStore } from './clientStore.ts';
 import { MCPKeyStore } from './keyStore.ts';
@@ -161,6 +163,7 @@ async function mintTokenPair(
 	request: Request | undefined,
 	mcpConfig: MCPConfig,
 	grant: { user: string; resource: string; scope?: string; clientId: string; issueRefresh: boolean },
+	hookManager?: HookManager,
 	logger?: Logger
 ): Promise<TokenResponse> {
 	const issuer = resolveIssuer(request as any, mcpConfig);
@@ -168,7 +171,7 @@ async function mintTokenPair(
 	const refreshTtl = coerceTtl(mcpConfig.refreshTokenTtl, DEFAULT_REFRESH_TOKEN_TTL);
 
 	const key = await new MCPKeyStore(logger).getSigningKey(mcpConfig);
-	const accessToken = signAccessToken(
+	const { token: accessToken, jti } = signAccessToken(
 		{
 			issuer,
 			subject: grant.user,
@@ -206,6 +209,28 @@ async function mintTokenPair(
 		responseBody.refresh_token = refreshToken;
 	}
 
+	// Emit the audit event + fire the hook only AFTER all token state is durably
+	// persisted (the refresh family above) — otherwise a persistence failure
+	// would report a phantom successful issuance to audit/billing/rate-limit
+	// consumers for an exchange the client never actually received. Both are
+	// fire-and-forget (emitMCPAuditEvent and callOnMCPTokenIssued each swallow
+	// their own errors), so neither can block the token from reaching the client.
+	emitMCPAuditEvent({
+		event: 'oauth.mcp.token.issued',
+		client_id: grant.clientId,
+		sub: grant.user,
+		aud: grant.resource,
+		scope: grant.scope,
+		jti,
+		timestamp: new Date().toISOString(),
+	});
+	if (hookManager) {
+		await hookManager.callOnMCPTokenIssued(
+			{ type: 'access', client_id: grant.clientId, sub: grant.user, aud: grant.resource, scope: grant.scope, jti },
+			request
+		);
+	}
+
 	return { status: 200, body: responseBody, headers: NO_STORE_HEADERS };
 }
 
@@ -214,6 +239,7 @@ async function handleAuthorizationCodeGrant(
 	body: any,
 	client: MCPClientRecord,
 	mcpConfig: MCPConfig,
+	hookManager?: HookManager,
 	logger?: Logger
 ): Promise<TokenResponse> {
 	const code = typeof body?.code === 'string' ? body.code : undefined;
@@ -261,6 +287,7 @@ async function handleAuthorizationCodeGrant(
 			clientId: client.client_id,
 			issueRefresh: allowsRefresh(client),
 		},
+		hookManager,
 		logger
 	);
 }
@@ -270,6 +297,7 @@ async function handleRefreshTokenGrant(
 	body: any,
 	client: MCPClientRecord,
 	mcpConfig: MCPConfig,
+	hookManager?: HookManager,
 	logger?: Logger
 ): Promise<TokenResponse> {
 	if (!allowsRefresh(client)) {
@@ -317,7 +345,7 @@ async function handleRefreshTokenGrant(
 	const issuer = resolveIssuer(request as any, mcpConfig);
 	const accessTtl = coerceTtl(mcpConfig.accessTokenTtl, DEFAULT_ACCESS_TOKEN_TTL);
 	const key = await new MCPKeyStore(logger).getSigningKey(mcpConfig);
-	const accessToken = signAccessToken(
+	const { token: accessToken, jti } = signAccessToken(
 		{
 			issuer,
 			subject: family.user,
@@ -334,6 +362,31 @@ async function handleRefreshTokenGrant(
 	family.current_token_hash = newHash;
 	await familyStore.set(family);
 
+	// Emit audit event + fire hook after the token is signed and rotation is
+	// committed. Failures are fire-and-forget: must not block the response.
+	emitMCPAuditEvent({
+		event: 'oauth.mcp.token.refreshed',
+		client_id: client.client_id,
+		sub: family.user,
+		aud: family.resource,
+		scope: family.scope,
+		jti,
+		timestamp: new Date().toISOString(),
+	});
+	if (hookManager) {
+		await hookManager.callOnMCPTokenIssued(
+			{
+				type: 'refresh',
+				client_id: client.client_id,
+				sub: family.user,
+				aud: family.resource,
+				scope: family.scope,
+				jti,
+			},
+			request
+		);
+	}
+
 	const responseBody: Record<string, unknown> = {
 		access_token: accessToken,
 		token_type: 'Bearer',
@@ -347,11 +400,16 @@ async function handleRefreshTokenGrant(
 /**
  * Handle POST /oauth/mcp/token. Returns `{ status, body }`; the `enabled` gate
  * is applied upstream in handleMCPPost.
+ *
+ * `hookManager` is optional so callers that don't have access to it (e.g.
+ * unit tests that go directly to this function) can omit it without error.
+ * When present, `onMCPTokenIssued` is fired after every successful mint.
  */
 export async function handleToken(
 	request: Request | undefined,
 	body: any,
 	mcpConfig: MCPConfig,
+	hookManager?: HookManager,
 	logger?: Logger
 ): Promise<TokenResponse> {
 	const grantType = typeof body?.grant_type === 'string' ? body.grant_type : undefined;
@@ -365,7 +423,7 @@ export async function handleToken(
 	}
 
 	if (grantType === 'authorization_code') {
-		return handleAuthorizationCodeGrant(request, body, auth.client, mcpConfig, logger);
+		return handleAuthorizationCodeGrant(request, body, auth.client, mcpConfig, hookManager, logger);
 	}
-	return handleRefreshTokenGrant(request, body, auth.client, mcpConfig, logger);
+	return handleRefreshTokenGrant(request, body, auth.client, mcpConfig, hookManager, logger);
 }

--- a/src/lib/mcp/token.ts
+++ b/src/lib/mcp/token.ts
@@ -225,7 +225,7 @@ async function mintTokenPair(
 		timestamp: new Date().toISOString(),
 	});
 	if (hookManager) {
-		await hookManager.callOnMCPTokenIssued(
+		hookManager.callOnMCPTokenIssued(
 			{ type: 'access', client_id: grant.clientId, sub: grant.user, aud: grant.resource, scope: grant.scope, jti },
 			request
 		);
@@ -374,7 +374,7 @@ async function handleRefreshTokenGrant(
 		timestamp: new Date().toISOString(),
 	});
 	if (hookManager) {
-		await hookManager.callOnMCPTokenIssued(
+		hookManager.callOnMCPTokenIssued(
 			{
 				type: 'refresh',
 				client_id: client.client_id,

--- a/src/lib/mcp/token.ts
+++ b/src/lib/mcp/token.ts
@@ -273,7 +273,10 @@ async function handleAuthorizationCodeGrant(
 	try {
 		await codeStore.consume(code);
 	} catch (error) {
-		logger?.error?.('MCP token: failed to consume authorization code:', (error as Error).message);
+		logger?.error?.(
+			'MCP token: failed to consume authorization code:',
+			error instanceof Error ? error.message : String(error)
+		);
 		return errorResponse(500, 'server_error', 'Failed to consume authorization code');
 	}
 
@@ -331,7 +334,7 @@ async function handleRefreshTokenGrant(
 		} catch (error) {
 			logger?.error?.(
 				`MCP token: failed to persist revocation for family ${family.family_id}:`,
-				(error as Error).message
+				error instanceof Error ? error.message : String(error)
 			);
 		}
 		logger?.warn?.(`MCP token: refresh replay detected; revoked family ${family.family_id}`);

--- a/src/lib/mcp/tokenIssuer.ts
+++ b/src/lib/mcp/tokenIssuer.ts
@@ -24,25 +24,40 @@ export interface MintAccessTokenParams {
 	scope?: string;
 	/** Access-token lifetime in seconds. */
 	ttlSeconds: number;
+	/**
+	 * JWT ID (`jti` claim). Callers SHOULD generate this with `randomUUID()`
+	 * before calling so they can capture it for audit/hook events without
+	 * decoding the signed token. When omitted a fresh UUID is generated here.
+	 */
+	jti?: string;
 }
 
 /**
- * Sign an access token. `iat`/`exp` are set from `ttlSeconds`, `jti` is a fresh
- * UUID, and registered claims are populated via jsonwebtoken's options so the
- * payload carries only `client_id` + `scope`.
+ * Sign an access token. `iat`/`exp` are set from `ttlSeconds`; `jti` is taken
+ * from `params.jti` (or generated fresh when omitted). Registered claims are
+ * populated via jsonwebtoken's options so the payload carries only
+ * `client_id` + `scope`.
+ *
+ * Returns an object containing both the signed token string and the `jti`
+ * so callers can use the id for audit records without re-parsing the JWT.
  */
-export function signAccessToken(params: MintAccessTokenParams, key: MCPSigningKeyRecord): string {
+export function signAccessToken(
+	params: MintAccessTokenParams,
+	key: MCPSigningKeyRecord
+): { token: string; jti: string } {
+	const jti = params.jti ?? randomUUID();
 	const payload: Record<string, unknown> = { client_id: params.clientId };
 	if (params.scope) payload.scope = params.scope;
-	return jwt.sign(payload, key.private_key_pem, {
+	const token = jwt.sign(payload, key.private_key_pem, {
 		algorithm: 'RS256',
 		keyid: key.kid,
 		issuer: params.issuer,
 		audience: params.audience,
 		subject: params.subject,
-		jwtid: randomUUID(),
+		jwtid: jti,
 		expiresIn: params.ttlSeconds,
 	});
+	return { token, jti };
 }
 
 export interface VerifyOptions {

--- a/src/lib/mcp/withMCPAuth.ts
+++ b/src/lib/mcp/withMCPAuth.ts
@@ -246,7 +246,10 @@ export function withMCPAuth(handler: HttpListener, options: WithMCPAuthOptions =
 			const keyStore: KeySource = options.keyStore ?? new MCPKeyStore(logger);
 			keys = await keyStore.getAllPublicKeys();
 		} catch (error) {
-			logger?.error?.('withMCPAuth: failed to load MCP signing keys:', (error as Error).message);
+			logger?.error?.(
+				'withMCPAuth: failed to load MCP signing keys:',
+				error instanceof Error ? error.message : String(error)
+			);
 			keys = [];
 		}
 		if (keys.length === 0) {
@@ -263,7 +266,10 @@ export function withMCPAuth(handler: HttpListener, options: WithMCPAuthOptions =
 		try {
 			payload = verifyAccessTokenWithKeySet(token, keys, { audience: resource, issuer });
 		} catch (error) {
-			logger?.debug?.('withMCPAuth: token verification failed:', (error as Error).message);
+			logger?.debug?.(
+				'withMCPAuth: token verification failed:',
+				error instanceof Error ? error.message : String(error)
+			);
 			return deny('access token is invalid, expired, or not issued for this resource');
 		}
 

--- a/src/lib/mcp/withMCPAuth.ts
+++ b/src/lib/mcp/withMCPAuth.ts
@@ -45,6 +45,7 @@ import { OAuthResource } from '../resource.ts';
 import { MCPKeyStore } from './keyStore.ts';
 import { verifyAccessTokenWithKeySet } from './tokenIssuer.ts';
 import { protectedResourceMetadataUrl, resolveIssuer, resolveResource } from './wellKnown.ts';
+import { emitMCPAuditEvent, type MCPTokenRejectedAuditPayload } from './audit.ts';
 
 /** Minimal surface withMCPAuth needs from a key source (lets tests inject one). */
 interface KeySource {
@@ -81,6 +82,12 @@ export interface WithMCPAuthOptions {
 	 * turn a denial into a pass (fail closed by construction).
 	 */
 	onAuthError?: (request: Request, error: string) => any;
+	/**
+	 * Audit sink for `oauth.mcp.token.rejected` events, invoked when a *presented*
+	 * bearer token is rejected (not for missing-token probes or the pre-token
+	 * guards). Defaults to the plugin's `emitMCPAuditEvent`. Injectable for tests.
+	 */
+	emitAudit?: (payload: MCPTokenRejectedAuditPayload) => void;
 }
 
 type HttpListener = (request: Request, next: (req: Request) => any) => any;
@@ -160,7 +167,28 @@ export function withMCPAuth(handler: HttpListener, options: WithMCPAuthOptions =
 		// challenge points at the SAME path-aware PRM URL the well-known handler
 		// serves (RFC 9728 §3.1: path-appended when the resource carries a path),
 		// so a client using the challenge value verbatim hits a real document.
+		const emitAudit = options.emitAudit ?? emitMCPAuditEvent;
+		// Flipped true once a bearer token has actually been presented; from that
+		// point on, every denial is an audited `oauth.mcp.token.rejected` event.
+		// Denials BEFORE it (path-length guard, MCP disabled, no token presented)
+		// are NOT audited — those are unauthenticated probes / the normal discovery
+		// 401, not rejected tokens, and auditing them would flood the log on probes
+		// and DoS floods.
+		let tokenPresented = false;
+
 		const deny = async (reason: string): Promise<any> => {
+			if (tokenPresented) {
+				// Best-effort, secret-free: the reason + the resource the token was
+				// presented to. NEVER unverified claims — the token failed validation,
+				// so any client_id/sub/jti it carries is attacker-controlled. The audit
+				// helper swallows its own errors, so this can't break the 401 path.
+				emitAudit({
+					event: 'oauth.mcp.token.rejected',
+					reason,
+					aud: resolveResource(request as any, getConfig() ?? ({} as MCPConfig)),
+					timestamp: new Date().toISOString(),
+				});
+			}
 			const metadataUrl = protectedResourceMetadataUrl(request as any, getConfig() ?? ({} as MCPConfig));
 			const defaultResponse = {
 				status: 401,
@@ -202,6 +230,8 @@ export function withMCPAuth(handler: HttpListener, options: WithMCPAuthOptions =
 		if (!token) {
 			return deny('missing or malformed Authorization: Bearer header');
 		}
+		// A bearer token was presented — any denial below is a rejected token (audited).
+		tokenPresented = true;
 
 		let keys: MCPSigningKeyRecord[];
 		try {

--- a/src/lib/mcp/withMCPAuth.ts
+++ b/src/lib/mcp/withMCPAuth.ts
@@ -180,14 +180,22 @@ export function withMCPAuth(handler: HttpListener, options: WithMCPAuthOptions =
 			if (tokenPresented) {
 				// Best-effort, secret-free: the reason + the resource the token was
 				// presented to. NEVER unverified claims — the token failed validation,
-				// so any client_id/sub/jti it carries is attacker-controlled. The audit
-				// helper swallows its own errors, so this can't break the 401 path.
-				emitAudit({
-					event: 'oauth.mcp.token.rejected',
-					reason,
-					aud: resolveResource(request as any, getConfig() ?? ({} as MCPConfig)),
-					timestamp: new Date().toISOString(),
-				});
+				// so any client_id/sub/jti it carries is attacker-controlled. Shielded
+				// in try/catch: emitAudit is part of the exported options surface, so a
+				// custom sink that throws must NOT turn this denial into a 500 — deny()
+				// must always produce the 401 (fail closed). The default
+				// emitMCPAuditEvent already swallows its own errors; this guards a
+				// caller-supplied sink too.
+				try {
+					emitAudit({
+						event: 'oauth.mcp.token.rejected',
+						reason,
+						aud: resolveResource(request as any, getConfig() ?? ({} as MCPConfig)),
+						timestamp: new Date().toISOString(),
+					});
+				} catch {
+					// Audit is best-effort; never let it break the fail-closed 401.
+				}
 			}
 			const metadataUrl = protectedResourceMetadataUrl(request as any, getConfig() ?? ({} as MCPConfig));
 			const defaultResponse = {

--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -458,7 +458,14 @@ export class OAuthResource extends Resource {
 
 		// Handle MCP endpoints (/oauth/mcp/<action>)
 		if (providerName === 'mcp') {
-			return handleMCPPost(action, request, data, OAuthResource.mcpConfig, logger);
+			return handleMCPPost(
+				action,
+				request,
+				data,
+				OAuthResource.mcpConfig,
+				OAuthResource.hookManager ?? undefined,
+				logger
+			);
 		}
 
 		// All other POST endpoints are not supported

--- a/src/types.ts
+++ b/src/types.ts
@@ -311,6 +311,28 @@ export interface OAuthHooks {
 	 * @param request - The HTTP request object (may be undefined for background refresh)
 	 */
 	onTokenRefresh?: (session: any, refreshed: boolean, request?: any) => Promise<void>;
+
+	/**
+	 * Called after an MCP access or refresh token is minted, before the response
+	 * is returned. Use for rate-limiting by client_id, usage attribution,
+	 * pushing to a queue, etc.
+	 *
+	 * Failure is caught and logged — a throwing hook NEVER blocks token issuance
+	 * (fire-and-forget contract).
+	 *
+	 * SECURITY: the `event` is sanitized — it carries only the `jti` (token
+	 * identifier, safe to log), never the access/refresh token strings. The
+	 * `request` is NOT sanitized: on the refresh path its body carries the
+	 * refresh_token the client presented, so do not log `request` wholesale.
+	 *
+	 * @param event - Identifies the token issued: type, client_id, sub, aud, scope, jti
+	 * @param request - The HTTP request that triggered issuance (typed as any for
+	 *   Harper version independence). NOT sanitized — see SECURITY above.
+	 */
+	onMCPTokenIssued?: (
+		event: { type: 'access' | 'refresh'; client_id: string; sub: string; aud: string; scope?: string; jti: string },
+		request: any
+	) => Promise<void>;
 }
 
 /**

--- a/test/lib/handlers.test.js
+++ b/test/lib/handlers.test.js
@@ -840,6 +840,35 @@ describe('OAuth Handlers', () => {
 			assert.equal(mockRequest.session.update.mock.calls.length, 0);
 			global.databases = originalDatabases;
 		});
+
+		it('onLogin fires for MCP-initiated auth (bridged authorize/callback flow)', async () => {
+			// Regression guard: the onLogin hook must fire on the MCP branch exactly
+			// as it does on the human-session branch — it runs before the branch
+			// decision so user-provisioning hooks work for MCP users too.
+			const onLoginMock = createMockFn(async () => ({}));
+			const trackingHookManager = {
+				...mockHookManager,
+				callOnLogin: onLoginMock,
+			};
+
+			await handleCallback(
+				mockRequest,
+				mockTarget,
+				mockProvider,
+				mockConfig,
+				trackingHookManager,
+				'test-provider',
+				mockLogger
+			);
+
+			assert.equal(onLoginMock.mock.calls.length, 1, 'callOnLogin fired exactly once on the MCP path');
+			// The hook receives the mapped Harper user, the upstream token response, the session, the request, and the provider name.
+			const [oauthUser, tokenResponse, , , providerName] = onLoginMock.mock.calls[0].arguments;
+			assert.ok(oauthUser.username, 'user object forwarded to onLogin');
+			assert.ok(tokenResponse, 'token response forwarded to onLogin');
+			assert.equal(providerName, 'test-provider');
+			global.databases = originalDatabases;
+		});
 	});
 
 	describe('handleLogout', () => {

--- a/test/lib/hookManager.test.js
+++ b/test/lib/hookManager.test.js
@@ -214,11 +214,16 @@ describe('HookManager', () => {
 		};
 		const SAMPLE_REQUEST = { headers: {} };
 
+		// The hook is fire-and-forget (NOT awaited), so it runs detached on the
+		// microtask queue. Drain it with a macrotask tick before asserting.
+		const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+
 		it('should call onMCPTokenIssued hook with the correct event and request', async () => {
 			const hookMock = createMockFn(async () => {});
 			hookManager.register({ onMCPTokenIssued: hookMock });
 
-			await hookManager.callOnMCPTokenIssued(SAMPLE_EVENT, SAMPLE_REQUEST);
+			hookManager.callOnMCPTokenIssued(SAMPLE_EVENT, SAMPLE_REQUEST);
+			await flushMicrotasks();
 
 			assert.equal(hookMock.mock.calls.length, 1);
 			const [eventArg, requestArg] = hookMock.mock.calls[0].arguments;
@@ -231,9 +236,34 @@ describe('HookManager', () => {
 			assert.equal(requestArg, SAMPLE_REQUEST);
 		});
 
-		it('should not throw when no onMCPTokenIssued hook is registered', async () => {
-			// No hook registered — must complete without error.
-			await hookManager.callOnMCPTokenIssued(SAMPLE_EVENT, SAMPLE_REQUEST);
+		it('does not await the hook — a slow hook never blocks token issuance', async () => {
+			let release;
+			const gate = new Promise((resolve) => {
+				release = resolve;
+			});
+			let hookCompleted = false;
+			hookManager.register({
+				onMCPTokenIssued: async () => {
+					await gate;
+					hookCompleted = true;
+				},
+			});
+
+			// Returns synchronously (void) without waiting on the hook.
+			const ret = hookManager.callOnMCPTokenIssued(SAMPLE_EVENT, SAMPLE_REQUEST);
+			assert.equal(ret, undefined, 'returns void synchronously');
+			assert.equal(hookCompleted, false, 'issuance does not wait for the hook to finish');
+
+			// Once unblocked, the detached hook still runs to completion.
+			release();
+			await flushMicrotasks();
+			assert.equal(hookCompleted, true);
+		});
+
+		it('is a no-op when no onMCPTokenIssued hook is registered', async () => {
+			// No hook registered — returns without scheduling anything or throwing.
+			hookManager.callOnMCPTokenIssued(SAMPLE_EVENT, SAMPLE_REQUEST);
+			await flushMicrotasks();
 		});
 
 		it('swallows a throwing hook and logs the error (fire-and-forget contract)', async () => {
@@ -242,8 +272,9 @@ describe('HookManager', () => {
 			});
 			hookManager.register({ onMCPTokenIssued: throwingHook });
 
-			// Must not reject — failure-tolerant by design.
-			await assert.doesNotReject(() => hookManager.callOnMCPTokenIssued(SAMPLE_EVENT, SAMPLE_REQUEST));
+			hookManager.callOnMCPTokenIssued(SAMPLE_EVENT, SAMPLE_REQUEST);
+			await flushMicrotasks();
+
 			assert.equal(mockLogger.error.mock.calls.length, 1, 'error is logged');
 			assert.ok(
 				mockLogger.error.mock.calls[0].arguments[0].includes('onMCPTokenIssued hook failed'),
@@ -256,7 +287,8 @@ describe('HookManager', () => {
 			hookManager.register({ onMCPTokenIssued: hookMock });
 
 			const refreshEvent = { ...SAMPLE_EVENT, type: /** @type {const} */ ('refresh') };
-			await hookManager.callOnMCPTokenIssued(refreshEvent, SAMPLE_REQUEST);
+			hookManager.callOnMCPTokenIssued(refreshEvent, SAMPLE_REQUEST);
+			await flushMicrotasks();
 
 			assert.equal(hookMock.mock.calls[0].arguments[0].type, 'refresh');
 		});
@@ -266,11 +298,12 @@ describe('HookManager', () => {
 			// the fire-and-forget contract — guards the `instanceof Error` handling.
 			hookManager.register({
 				onMCPTokenIssued: async () => {
-					throw null; // eslint-disable-line no-throw-literal
+					throw null;
 				},
 			});
 
-			await assert.doesNotReject(() => hookManager.callOnMCPTokenIssued(SAMPLE_EVENT, SAMPLE_REQUEST));
+			hookManager.callOnMCPTokenIssued(SAMPLE_EVENT, SAMPLE_REQUEST);
+			await flushMicrotasks();
 			assert.equal(mockLogger.error.mock.calls.length, 1, 'error is still logged');
 		});
 	});

--- a/test/lib/hookManager.test.js
+++ b/test/lib/hookManager.test.js
@@ -260,5 +260,18 @@ describe('HookManager', () => {
 
 			assert.equal(hookMock.mock.calls[0].arguments[0].type, 'refresh');
 		});
+
+		it('swallows a hook that throws a NON-Error value (null) without the catch itself throwing', async () => {
+			// `(null).message` in the catch would itself throw and escape, breaking
+			// the fire-and-forget contract — guards the `instanceof Error` handling.
+			hookManager.register({
+				onMCPTokenIssued: async () => {
+					throw null; // eslint-disable-line no-throw-literal
+				},
+			});
+
+			await assert.doesNotReject(() => hookManager.callOnMCPTokenIssued(SAMPLE_EVENT, SAMPLE_REQUEST));
+			assert.equal(mockLogger.error.mock.calls.length, 1, 'error is still logged');
+		});
 	});
 });

--- a/test/lib/hookManager.test.js
+++ b/test/lib/hookManager.test.js
@@ -202,4 +202,63 @@ describe('HookManager', () => {
 			);
 		});
 	});
+
+	describe('callOnMCPTokenIssued', () => {
+		const SAMPLE_EVENT = {
+			type: /** @type {const} */ ('access'),
+			client_id: 'client-abc',
+			sub: 'alice@example.com',
+			aud: 'https://app.example.com/mcp',
+			scope: 'mcp:read',
+			jti: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+		};
+		const SAMPLE_REQUEST = { headers: {} };
+
+		it('should call onMCPTokenIssued hook with the correct event and request', async () => {
+			const hookMock = createMockFn(async () => {});
+			hookManager.register({ onMCPTokenIssued: hookMock });
+
+			await hookManager.callOnMCPTokenIssued(SAMPLE_EVENT, SAMPLE_REQUEST);
+
+			assert.equal(hookMock.mock.calls.length, 1);
+			const [eventArg, requestArg] = hookMock.mock.calls[0].arguments;
+			assert.equal(eventArg.type, 'access');
+			assert.equal(eventArg.client_id, SAMPLE_EVENT.client_id);
+			assert.equal(eventArg.sub, SAMPLE_EVENT.sub);
+			assert.equal(eventArg.aud, SAMPLE_EVENT.aud);
+			assert.equal(eventArg.scope, SAMPLE_EVENT.scope);
+			assert.equal(eventArg.jti, SAMPLE_EVENT.jti);
+			assert.equal(requestArg, SAMPLE_REQUEST);
+		});
+
+		it('should not throw when no onMCPTokenIssued hook is registered', async () => {
+			// No hook registered — must complete without error.
+			await hookManager.callOnMCPTokenIssued(SAMPLE_EVENT, SAMPLE_REQUEST);
+		});
+
+		it('swallows a throwing hook and logs the error (fire-and-forget contract)', async () => {
+			const throwingHook = createMockFn(async () => {
+				throw new Error('billing service unavailable');
+			});
+			hookManager.register({ onMCPTokenIssued: throwingHook });
+
+			// Must not reject — failure-tolerant by design.
+			await assert.doesNotReject(() => hookManager.callOnMCPTokenIssued(SAMPLE_EVENT, SAMPLE_REQUEST));
+			assert.equal(mockLogger.error.mock.calls.length, 1, 'error is logged');
+			assert.ok(
+				mockLogger.error.mock.calls[0].arguments[0].includes('onMCPTokenIssued hook failed'),
+				'error message mentions the hook name'
+			);
+		});
+
+		it('handles the refresh type correctly', async () => {
+			const hookMock = createMockFn(async () => {});
+			hookManager.register({ onMCPTokenIssued: hookMock });
+
+			const refreshEvent = { ...SAMPLE_EVENT, type: /** @type {const} */ ('refresh') };
+			await hookManager.callOnMCPTokenIssued(refreshEvent, SAMPLE_REQUEST);
+
+			assert.equal(hookMock.mock.calls[0].arguments[0].type, 'refresh');
+		});
+	});
 });

--- a/test/lib/hookManager.test.js
+++ b/test/lib/hookManager.test.js
@@ -306,5 +306,29 @@ describe('HookManager', () => {
 			await flushMicrotasks();
 			assert.equal(mockLogger.error.mock.calls.length, 1, 'error is still logged');
 		});
+
+		it('shields the catch body — a throwing logger does not escape the detached chain', async () => {
+			// The hook throws AND logger.error throws. Without the try/catch shield in
+			// the catch body, the throw would become an unhandled rejection on the
+			// detached (void) chain — which the test runner attributes as a failure
+			// (and crashes Node >=15 in production). Surviving the flush is the proof.
+			const throwingLogger = {
+				debug() {},
+				error() {
+					throw new Error('logging subsystem down');
+				},
+			};
+			const hm = new HookManager(throwingLogger);
+			hm.register({
+				onMCPTokenIssued: async () => {
+					throw new Error('hook boom');
+				},
+			});
+
+			hm.callOnMCPTokenIssued(SAMPLE_EVENT, SAMPLE_REQUEST);
+			await flushMicrotasks();
+			await flushMicrotasks();
+			assert.ok(true, 'no unhandled rejection escaped the detached chain');
+		});
 	});
 });

--- a/test/lib/mcp/audit.test.js
+++ b/test/lib/mcp/audit.test.js
@@ -1,0 +1,117 @@
+/**
+ * Tests for the MCP audit channel (emitMCPAuditEvent).
+ *
+ * Verifies:
+ *  - oauth.mcp.token.issued fires with the correct payload shape
+ *  - oauth.mcp.token.refreshed fires with the correct payload shape
+ *  - No token material (access_token, refresh_token strings) appears in the emitted payload
+ *  - The logger is called with info level (not error/warn/debug)
+ *  - Emission does not throw
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// harper-mock stubs `logger` as a plain object with noop methods; we need to
+// intercept the call. The mock is loaded by the --import flag, so we can
+// import 'harper' and swap out the `info` method to spy on it.
+import { logger as harperMockLogger } from 'harper';
+
+// Import the function under test from the dist (built) output.
+import { emitMCPAuditEvent } from '../../../dist/lib/mcp/audit.js';
+
+const BASE_PAYLOAD = {
+	event: /** @type {const} */ ('oauth.mcp.token.issued'),
+	client_id: 'client-abc',
+	sub: 'alice@example.com',
+	aud: 'https://app.example.com/mcp',
+	scope: 'mcp:read',
+	jti: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+	timestamp: '2024-01-01T00:00:00.000Z',
+};
+
+describe('emitMCPAuditEvent', () => {
+	let infoCalls;
+	let originalInfo;
+
+	beforeEach(() => {
+		infoCalls = [];
+		originalInfo = harperMockLogger.info;
+		harperMockLogger.info = (...args) => infoCalls.push(args);
+	});
+
+	// Restore after each test so other tests in the suite see the original mock.
+	// node:test doesn't provide afterEach for individual describe-level cleanup
+	// from the outside, so we do it inline within each test.
+
+	it('emits oauth.mcp.token.issued with the correct payload shape', () => {
+		emitMCPAuditEvent(BASE_PAYLOAD);
+		harperMockLogger.info = originalInfo;
+
+		assert.equal(infoCalls.length, 1, 'exactly one info log emitted');
+		const logged = infoCalls[0][0];
+		assert.ok(typeof logged === 'string', 'logged argument is a string');
+		const parsed = JSON.parse(logged.replace(/^MCP audit: /, ''));
+		assert.equal(parsed.event, 'oauth.mcp.token.issued');
+		assert.equal(parsed.client_id, BASE_PAYLOAD.client_id);
+		assert.equal(parsed.sub, BASE_PAYLOAD.sub);
+		assert.equal(parsed.aud, BASE_PAYLOAD.aud);
+		assert.equal(parsed.scope, BASE_PAYLOAD.scope);
+		assert.equal(parsed.jti, BASE_PAYLOAD.jti);
+		assert.ok(parsed.timestamp, 'timestamp present');
+	});
+
+	it('emits oauth.mcp.token.refreshed with the correct payload shape', () => {
+		const payload = { ...BASE_PAYLOAD, event: /** @type {const} */ ('oauth.mcp.token.refreshed') };
+		emitMCPAuditEvent(payload);
+		harperMockLogger.info = originalInfo;
+
+		assert.equal(infoCalls.length, 1);
+		const parsed = JSON.parse(infoCalls[0][0].replace(/^MCP audit: /, ''));
+		assert.equal(parsed.event, 'oauth.mcp.token.refreshed');
+		assert.equal(parsed.client_id, payload.client_id);
+		assert.equal(parsed.sub, payload.sub);
+		assert.equal(parsed.aud, payload.aud);
+		assert.equal(parsed.jti, payload.jti);
+	});
+
+	it('never includes token strings in the emitted payload', () => {
+		// Verify no token-shaped keys appear in what was logged.
+		// emitMCPAuditEvent signature doesn't accept token strings — but confirm
+		// no field sneaks through that looks like an actual credential.
+		emitMCPAuditEvent(BASE_PAYLOAD);
+		harperMockLogger.info = originalInfo;
+
+		const logged = infoCalls[0][0];
+		const BANNED_KEYS = ['access_token', 'refresh_token', 'id_token', 'client_secret'];
+		for (const key of BANNED_KEYS) {
+			assert.ok(!logged.includes(`"${key}"`), `"${key}" must not appear in audit log`);
+		}
+	});
+
+	it('emits with a timestamp in ISO-8601 UTC format', () => {
+		const payload = { ...BASE_PAYLOAD, timestamp: new Date().toISOString() };
+		emitMCPAuditEvent(payload);
+		harperMockLogger.info = originalInfo;
+
+		const parsed = JSON.parse(infoCalls[0][0].replace(/^MCP audit: /, ''));
+		assert.ok(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$/.test(parsed.timestamp), 'timestamp is ISO-8601 UTC');
+	});
+
+	it('does not throw when the logger is suppressed (info is undefined)', () => {
+		// Simulate the logger being at a higher level so info is undefined (no-op).
+		harperMockLogger.info = undefined;
+		assert.doesNotThrow(() => emitMCPAuditEvent(BASE_PAYLOAD), 'emitMCPAuditEvent must not throw');
+		harperMockLogger.info = originalInfo;
+	});
+
+	it('emits without scope when scope is undefined', () => {
+		const { scope, ...noScope } = BASE_PAYLOAD;
+		void scope;
+		emitMCPAuditEvent(noScope);
+		harperMockLogger.info = originalInfo;
+
+		const parsed = JSON.parse(infoCalls[0][0].replace(/^MCP audit: /, ''));
+		assert.equal(parsed.scope, undefined);
+	});
+});

--- a/test/lib/mcp/audit.test.js
+++ b/test/lib/mcp/audit.test.js
@@ -114,4 +114,24 @@ describe('emitMCPAuditEvent', () => {
 		const parsed = JSON.parse(infoCalls[0][0].replace(/^MCP audit: /, ''));
 		assert.equal(parsed.scope, undefined);
 	});
+
+	it('emits oauth.mcp.token.rejected with reason + aud and NO unverified claims', () => {
+		emitMCPAuditEvent({
+			event: /** @type {const} */ ('oauth.mcp.token.rejected'),
+			reason: 'access token is invalid, expired, or not issued for this resource',
+			aud: 'https://app.example.com/mcp',
+			timestamp: '2024-01-01T00:00:00.000Z',
+		});
+		harperMockLogger.info = originalInfo;
+
+		assert.equal(infoCalls.length, 1);
+		const parsed = JSON.parse(infoCalls[0][0].replace(/^MCP audit: /, ''));
+		assert.equal(parsed.event, 'oauth.mcp.token.rejected');
+		assert.equal(parsed.reason, 'access token is invalid, expired, or not issued for this resource');
+		assert.equal(parsed.aud, 'https://app.example.com/mcp');
+		// A rejected token has no trustworthy claims — none must be logged.
+		assert.equal(parsed.client_id, undefined, 'no client_id on a rejected event');
+		assert.equal(parsed.sub, undefined, 'no sub on a rejected event');
+		assert.equal(parsed.jti, undefined, 'no jti on a rejected event');
+	});
 });

--- a/test/lib/mcp/token.test.js
+++ b/test/lib/mcp/token.test.js
@@ -607,15 +607,17 @@ describe('handleToken', () => {
 		const token = seedFamily('fam-1');
 		const before = families.get('fam-1').current_token_hash;
 		// Corrupt the signing key so signAccessToken throws — this happens before
-		// the rotation is persisted, so the family must be left intact.
+		// the rotation is persisted, so the family must be left intact. The throw
+		// is caught by handleToken's top-level guard and surfaced as a structured
+		// server_error (RFC 6749 §5.2), not propagated to the framework.
 		keys.set(SIGNING_KEY_ID, { ...keys.get(SIGNING_KEY_ID), private_key_pem: 'not-a-valid-pem' });
-		await assert.rejects(() =>
-			handleToken(
-				{ headers: {} },
-				{ grant_type: 'refresh_token', refresh_token: token, client_id: 'public-1' },
-				mcpConfig
-			)
+		const res = await handleToken(
+			{ headers: {} },
+			{ grant_type: 'refresh_token', refresh_token: token, client_id: 'public-1' },
+			mcpConfig
 		);
+		assert.equal(res.status, 500, 'signing failure → structured server_error, not a propagated throw');
+		assert.equal(res.body.error, 'server_error');
 		assert.equal(families.get('fam-1').current_token_hash, before, 'family not rotated when signing fails');
 	});
 

--- a/test/lib/mcp/tokenAuditHook.test.js
+++ b/test/lib/mcp/tokenAuditHook.test.js
@@ -78,6 +78,12 @@ describe('handleToken — audit events and onMCPTokenIssued hook', () => {
 	after(() => {
 		global.databases = originalDatabases;
 		harperMockLogger.info = originalHarperInfo;
+		// Clear the cached table refs so this file (which mints a signing key)
+		// doesn't leak state into other files under Bun's shared-process runner.
+		resetMCPClientsTableCache();
+		resetMCPAuthCodesTableCache();
+		resetMCPRefreshFamiliesTableCache();
+		resetMCPKeysTableCache();
 	});
 
 	beforeEach(() => {

--- a/test/lib/mcp/tokenAuditHook.test.js
+++ b/test/lib/mcp/tokenAuditHook.test.js
@@ -1,0 +1,471 @@
+/**
+ * Tests for audit-event emission and onMCPTokenIssued hook from handleToken.
+ *
+ * Verifies:
+ *  - oauth.mcp.token.issued emits on authorization_code exchange with correct shape
+ *  - oauth.mcp.token.refreshed emits on refresh-token rotation with correct shape
+ *  - Neither event includes token material (access_token/refresh_token strings)
+ *  - onMCPTokenIssued fires after mint with the right event object (type, client_id, sub, aud, scope, jti)
+ *  - A throwing onMCPTokenIssued hook does NOT block or error the token response
+ *  - onMCPTokenIssued is NOT called when token issuance fails (e.g. invalid grant)
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash, generateKeyPairSync, randomBytes } from 'node:crypto';
+import { logger as harperMockLogger } from 'harper';
+import { handleToken } from '../../../dist/lib/mcp/token.js';
+import { resetMCPAuthCodesTableCache } from '../../../dist/lib/mcp/authCodeStore.js';
+import { resetMCPClientsTableCache } from '../../../dist/lib/mcp/clientStore.js';
+import { resetMCPKeysTableCache, SIGNING_KEY_ID } from '../../../dist/lib/mcp/keyStore.js';
+import { resetMCPRefreshFamiliesTableCache, makeRefreshToken } from '../../../dist/lib/mcp/refreshTokenStore.js';
+import { HookManager } from '../../../dist/lib/hookManager.js';
+import { createMockFn, createMockLogger } from '../../helpers/mockFn.js';
+
+// --- Test fixtures ---
+
+const keypair = generateKeyPairSync('rsa', {
+	modulusLength: 2048,
+	publicKeyEncoding: { type: 'spki', format: 'pem' },
+	privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+const CODE_VERIFIER = randomBytes(32).toString('base64url'); // 43 chars, valid
+const CODE_CHALLENGE = createHash('sha256').update(CODE_VERIFIER).digest('base64url');
+
+const RESOURCE = 'https://app.example.com/mcp';
+const ISSUER = 'https://as.example.com';
+const REDIRECT = 'https://mcp.example.com/cb';
+
+const mcpConfig = {
+	enabled: true,
+	issuer: ISSUER,
+	resource: RESOURCE,
+	accessTokenTtl: 3600,
+	refreshTokenTtl: 86400,
+};
+
+function makeTable(map, pkField) {
+	return {
+		get: async (id) => {
+			const raw = map.get(id);
+			return raw ? new Proxy(raw, { ownKeys: () => [], getOwnPropertyDescriptor: () => undefined }) : null;
+		},
+		put: async (rec) => {
+			map.set(rec[pkField], rec);
+		},
+		delete: async (id) => {
+			map.delete(id);
+		},
+	};
+}
+
+describe('handleToken — audit events and onMCPTokenIssued hook', () => {
+	let originalDatabases;
+	let clients;
+	let codes;
+	let families;
+	let keys;
+
+	// Capture info calls on Harper's mock logger.
+	let infoCalls;
+	let originalHarperInfo;
+
+	before(() => {
+		originalDatabases = global.databases;
+	});
+
+	after(() => {
+		global.databases = originalDatabases;
+		harperMockLogger.info = originalHarperInfo;
+	});
+
+	beforeEach(() => {
+		resetMCPClientsTableCache();
+		resetMCPAuthCodesTableCache();
+		resetMCPRefreshFamiliesTableCache();
+		resetMCPKeysTableCache();
+
+		clients = new Map();
+		codes = new Map();
+		families = new Map();
+		keys = new Map();
+
+		keys.set(SIGNING_KEY_ID, {
+			kid: SIGNING_KEY_ID,
+			alg: 'RS256',
+			public_key_pem: keypair.publicKey,
+			private_key_pem: keypair.privateKey,
+			created_at: 1700000000,
+		});
+		clients.set('public-1', {
+			client_id: 'public-1',
+			token_endpoint_auth_method: 'none',
+			redirect_uris: JSON.stringify([REDIRECT]),
+			client_id_issued_at: 1700000000,
+		});
+
+		global.databases = {
+			oauth: {
+				harper_oauth_mcp_clients: makeTable(clients, 'client_id'),
+				mcp_auth_codes: makeTable(codes, 'code'),
+				mcp_refresh_families: makeTable(families, 'family_id'),
+				harper_oauth_mcp_keys: makeTable(keys, 'kid'),
+			},
+		};
+
+		// Reset Harper mock logger spy.
+		infoCalls = [];
+		originalHarperInfo = harperMockLogger.info;
+		harperMockLogger.info = (...args) => infoCalls.push(args);
+	});
+
+	function restoreLogger() {
+		harperMockLogger.info = originalHarperInfo;
+	}
+
+	function seedCode(code, overrides = {}) {
+		codes.set(code, {
+			code,
+			client_id: 'public-1',
+			user: 'alice@example.com',
+			resource: RESOURCE,
+			code_challenge: CODE_CHALLENGE,
+			code_challenge_method: 'S256',
+			redirect_uri: REDIRECT,
+			scope: 'mcp:read',
+			created_at: 1700000000,
+			...overrides,
+		});
+	}
+
+	function seedFamily(familyId, overrides = {}) {
+		const { token, hash } = makeRefreshToken(familyId);
+		families.set(familyId, {
+			family_id: familyId,
+			current_token_hash: hash,
+			revoked: false,
+			client_id: 'public-1',
+			user: 'alice@example.com',
+			resource: RESOURCE,
+			scope: 'mcp:read',
+			created_at: 1700000000,
+			expires_at: Math.floor(Date.now() / 1000) + 86400,
+			...overrides,
+		});
+		return token;
+	}
+
+	// ---- Audit: oauth.mcp.token.issued ----
+
+	it('emits oauth.mcp.token.issued audit event on authorization_code exchange', async () => {
+		seedCode('code-1');
+		await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+			},
+			mcpConfig
+		);
+		restoreLogger();
+
+		const auditLog = infoCalls.find((args) => args[0]?.includes('oauth.mcp.token.issued'));
+		assert.ok(auditLog, 'audit log for oauth.mcp.token.issued was emitted');
+		const parsed = JSON.parse(auditLog[0].replace(/^MCP audit: /, ''));
+		assert.equal(parsed.event, 'oauth.mcp.token.issued');
+		assert.equal(parsed.client_id, 'public-1');
+		assert.equal(parsed.sub, 'alice@example.com');
+		assert.equal(parsed.aud, RESOURCE);
+		assert.equal(parsed.scope, 'mcp:read');
+		assert.ok(parsed.jti, 'jti present');
+		assert.ok(parsed.timestamp, 'timestamp present');
+	});
+
+	it('audit event for issued token contains no token material', async () => {
+		seedCode('code-1');
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+			},
+			mcpConfig
+		);
+		restoreLogger();
+
+		const auditLog = infoCalls.find((args) => args[0]?.includes('oauth.mcp.token.issued'));
+		assert.ok(auditLog, 'audit log emitted');
+		const logged = auditLog[0];
+
+		// The actual token strings must not appear in the audit record.
+		const BANNED = [res.body.access_token, res.body.refresh_token].filter(Boolean);
+		for (const banned of BANNED) {
+			assert.ok(!logged.includes(banned), 'token string must not appear in audit log');
+		}
+		// Verify no generic credential keys either.
+		for (const key of ['access_token', 'refresh_token', 'client_secret']) {
+			assert.ok(!logged.includes(`"${key}"`), `"${key}" must not appear in audit log`);
+		}
+	});
+
+	// ---- Audit: oauth.mcp.token.refreshed ----
+
+	it('emits oauth.mcp.token.refreshed audit event on refresh-token rotation', async () => {
+		const token = seedFamily('fam-1');
+		await handleToken(
+			{ headers: {} },
+			{ grant_type: 'refresh_token', refresh_token: token, client_id: 'public-1' },
+			mcpConfig
+		);
+		restoreLogger();
+
+		const auditLog = infoCalls.find((args) => args[0]?.includes('oauth.mcp.token.refreshed'));
+		assert.ok(auditLog, 'audit log for oauth.mcp.token.refreshed was emitted');
+		const parsed = JSON.parse(auditLog[0].replace(/^MCP audit: /, ''));
+		assert.equal(parsed.event, 'oauth.mcp.token.refreshed');
+		assert.equal(parsed.client_id, 'public-1');
+		assert.equal(parsed.sub, 'alice@example.com');
+		assert.equal(parsed.aud, RESOURCE);
+		assert.equal(parsed.scope, 'mcp:read');
+		assert.ok(parsed.jti, 'jti present');
+		assert.ok(parsed.timestamp, 'timestamp present');
+	});
+
+	it('audit event for refreshed token contains no token material', async () => {
+		const token = seedFamily('fam-1');
+		const res = await handleToken(
+			{ headers: {} },
+			{ grant_type: 'refresh_token', refresh_token: token, client_id: 'public-1' },
+			mcpConfig
+		);
+		restoreLogger();
+
+		const auditLog = infoCalls.find((args) => args[0]?.includes('oauth.mcp.token.refreshed'));
+		assert.ok(auditLog, 'audit log emitted');
+		const logged = auditLog[0];
+
+		const BANNED = [res.body.access_token, res.body.refresh_token, token].filter(Boolean);
+		for (const banned of BANNED) {
+			assert.ok(!logged.includes(banned), 'token string must not appear in audit log');
+		}
+	});
+
+	it('does NOT emit an audit event when token issuance fails (invalid grant)', async () => {
+		// No code seeded — will fail with invalid_grant.
+		await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'nonexistent',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+			},
+			mcpConfig
+		);
+		restoreLogger();
+
+		const auditLog = infoCalls.find((args) => args[0]?.includes('oauth.mcp.token'));
+		assert.equal(auditLog, undefined, 'no audit log emitted on failure');
+	});
+
+	// ---- onMCPTokenIssued hook ----
+
+	it('fires onMCPTokenIssued with type=access on authorization_code exchange', async () => {
+		seedCode('code-1');
+		const hookMock = createMockFn(async () => {});
+		const hookManager = new HookManager(createMockLogger());
+		hookManager.register({ onMCPTokenIssued: hookMock });
+
+		const request = { headers: {} };
+		await handleToken(
+			request,
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+			},
+			mcpConfig,
+			hookManager
+		);
+		restoreLogger();
+
+		assert.equal(hookMock.mock.calls.length, 1, 'hook called exactly once');
+		const [eventArg, requestArg] = hookMock.mock.calls[0].arguments;
+		assert.equal(eventArg.type, 'access');
+		assert.equal(eventArg.client_id, 'public-1');
+		assert.equal(eventArg.sub, 'alice@example.com');
+		assert.equal(eventArg.aud, RESOURCE);
+		assert.equal(eventArg.scope, 'mcp:read');
+		assert.ok(eventArg.jti, 'jti present in hook event');
+		assert.equal(requestArg, request, 'request object forwarded unchanged');
+	});
+
+	it('fires onMCPTokenIssued with type=refresh on refresh-token rotation', async () => {
+		const token = seedFamily('fam-1');
+		const hookMock = createMockFn(async () => {});
+		const hookManager = new HookManager(createMockLogger());
+		hookManager.register({ onMCPTokenIssued: hookMock });
+
+		await handleToken(
+			{ headers: {} },
+			{ grant_type: 'refresh_token', refresh_token: token, client_id: 'public-1' },
+			mcpConfig,
+			hookManager
+		);
+		restoreLogger();
+
+		assert.equal(hookMock.mock.calls.length, 1);
+		assert.equal(hookMock.mock.calls[0].arguments[0].type, 'refresh');
+	});
+
+	it('onMCPTokenIssued jti matches the jti in the audit log', async () => {
+		seedCode('code-1');
+		const hookMock = createMockFn(async () => {});
+		const hookManager = new HookManager(createMockLogger());
+		hookManager.register({ onMCPTokenIssued: hookMock });
+
+		await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+			},
+			mcpConfig,
+			hookManager
+		);
+		restoreLogger();
+
+		const auditLog = infoCalls.find((args) => args[0]?.includes('oauth.mcp.token.issued'));
+		const parsed = JSON.parse(auditLog[0].replace(/^MCP audit: /, ''));
+		const hookJti = hookMock.mock.calls[0].arguments[0].jti;
+		assert.equal(hookJti, parsed.jti, 'hook jti matches the audit-log jti');
+	});
+
+	it('a throwing onMCPTokenIssued hook does NOT block the token response (fire-and-forget)', async () => {
+		seedCode('code-1');
+		const throwingHook = createMockFn(async () => {
+			throw new Error('billing service unavailable');
+		});
+		const mockLogger = createMockLogger();
+		const hookManager = new HookManager(mockLogger);
+		hookManager.register({ onMCPTokenIssued: throwingHook });
+
+		let res;
+		await assert.doesNotReject(async () => {
+			res = await handleToken(
+				{ headers: {} },
+				{
+					grant_type: 'authorization_code',
+					code: 'code-1',
+					code_verifier: CODE_VERIFIER,
+					redirect_uri: REDIRECT,
+					client_id: 'public-1',
+				},
+				mcpConfig,
+				hookManager
+			);
+		});
+		restoreLogger();
+
+		// Token response is still returned.
+		assert.equal(res.status, 200, 'token response is 200 despite throwing hook');
+		assert.ok(res.body.access_token, 'access_token present despite throwing hook');
+
+		// Error is logged.
+		assert.ok(
+			mockLogger.error.mock.calls.some((call) => call.arguments[0].includes('onMCPTokenIssued hook failed')),
+			'hook failure is logged'
+		);
+	});
+
+	it('does NOT call onMCPTokenIssued when the grant fails (hook skipped on failure)', async () => {
+		const hookMock = createMockFn(async () => {});
+		const hookManager = new HookManager(createMockLogger());
+		hookManager.register({ onMCPTokenIssued: hookMock });
+
+		await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'does-not-exist',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+			},
+			mcpConfig,
+			hookManager
+		);
+		restoreLogger();
+
+		assert.equal(hookMock.mock.calls.length, 0, 'hook must not fire when grant fails');
+	});
+
+	// ---- Ordering / failure-tolerance regressions ----
+
+	it('does NOT emit the issued audit event or fire the hook when refresh-family persistence fails (auth-code path)', async () => {
+		seedCode('code-1');
+		// The refresh-family store rejects — this happens AFTER the JWT is minted,
+		// so it exercises the reordering that prevents a phantom successful
+		// issuance being reported for an exchange the client never received.
+		global.databases.oauth.mcp_refresh_families.put = async () => {
+			throw new Error('simulated persistence failure');
+		};
+		const hookMock = createMockFn(async () => {});
+		const hookManager = new HookManager(createMockLogger());
+		hookManager.register({ onMCPTokenIssued: hookMock });
+
+		await assert.rejects(
+			handleToken(
+				{ headers: {} },
+				{
+					grant_type: 'authorization_code',
+					code: 'code-1',
+					code_verifier: CODE_VERIFIER,
+					redirect_uri: REDIRECT,
+					client_id: 'public-1',
+				},
+				mcpConfig,
+				hookManager
+			),
+			/simulated persistence failure/
+		);
+		restoreLogger();
+
+		const issued = infoCalls.find((args) => args[0]?.includes('oauth.mcp.token.issued'));
+		assert.equal(issued, undefined, 'no phantom issued audit event when persistence fails');
+		assert.equal(hookMock.mock.calls.length, 0, 'hook must not fire when persistence fails');
+	});
+
+	it('returns the rotated token on the refresh path even when the audit logger throws', async () => {
+		const token = seedFamily('fam-1');
+		// emitMCPAuditEvent runs AFTER the refresh family is rotated; a logger
+		// throw there must be swallowed so the client still receives its new token
+		// (otherwise the family is stranded on a hash the client never got).
+		harperMockLogger.info = () => {
+			throw new Error('simulated logger failure');
+		};
+		const res = await handleToken(
+			{ headers: {} },
+			{ grant_type: 'refresh_token', refresh_token: token, client_id: 'public-1' },
+			mcpConfig
+		);
+		restoreLogger();
+
+		assert.equal(res.status, 200, 'token response returned despite the logger throwing');
+		assert.ok(res.body.access_token, 'new access token issued');
+		assert.ok(res.body.refresh_token, 'rotated refresh token issued');
+	});
+});

--- a/test/lib/mcp/tokenAuditHook.test.js
+++ b/test/lib/mcp/tokenAuditHook.test.js
@@ -433,23 +433,25 @@ describe('handleToken — audit events and onMCPTokenIssued hook', () => {
 		const hookManager = new HookManager(createMockLogger());
 		hookManager.register({ onMCPTokenIssued: hookMock });
 
-		await assert.rejects(
-			handleToken(
-				{ headers: {} },
-				{
-					grant_type: 'authorization_code',
-					code: 'code-1',
-					code_verifier: CODE_VERIFIER,
-					redirect_uri: REDIRECT,
-					client_id: 'public-1',
-				},
-				mcpConfig,
-				hookManager
-			),
-			/simulated persistence failure/
+		const res = await handleToken(
+			{ headers: {} },
+			{
+				grant_type: 'authorization_code',
+				code: 'code-1',
+				code_verifier: CODE_VERIFIER,
+				redirect_uri: REDIRECT,
+				client_id: 'public-1',
+			},
+			mcpConfig,
+			hookManager
 		);
 		restoreLogger();
 
+		// handleToken's top-level guard turns the persistence throw into a clean
+		// server_error — NOT a propagated exception — and the side effects (which
+		// run only after persistence) never fire.
+		assert.equal(res.status, 500, 'persistence failure → structured server_error');
+		assert.equal(res.body.error, 'server_error');
 		const issued = infoCalls.find((args) => args[0]?.includes('oauth.mcp.token.issued'));
 		assert.equal(issued, undefined, 'no phantom issued audit event when persistence fails');
 		assert.equal(hookMock.mock.calls.length, 0, 'hook must not fire when persistence fails');

--- a/test/lib/mcp/tokenIssuer.test.js
+++ b/test/lib/mcp/tokenIssuer.test.js
@@ -32,7 +32,7 @@ const baseParams = {
 
 describe('tokenIssuer', () => {
 	it('signs and verifies an access token with the expected claims', () => {
-		const token = signAccessToken(baseParams, key);
+		const { token, jti } = signAccessToken(baseParams, key);
 		const claims = verifyAccessToken(token, key.public_key_pem, {
 			audience: baseParams.audience,
 			issuer: baseParams.issuer,
@@ -43,33 +43,41 @@ describe('tokenIssuer', () => {
 		assert.equal(claims.client_id, baseParams.clientId);
 		assert.equal(claims.scope, baseParams.scope);
 		assert.ok(claims.jti, 'jti present');
+		assert.equal(claims.jti, jti, 'returned jti matches the JWT claim');
 		assert.ok(claims.exp > claims.iat, 'exp after iat');
 		assert.equal(claims.exp - claims.iat, 3600, 'exp derived from ttlSeconds');
 	});
 
 	it('puts the kid and RS256 alg in the JWT header', () => {
-		const token = signAccessToken(baseParams, key);
+		const { token } = signAccessToken(baseParams, key);
 		const header = JSON.parse(Buffer.from(token.split('.')[0], 'base64url').toString('utf8'));
 		assert.equal(header.kid, SIGNING_KEY_ID);
 		assert.equal(header.alg, 'RS256');
 	});
 
 	it('rejects a token verified against the wrong audience (RFC 8707 binding)', () => {
-		const token = signAccessToken(baseParams, key);
+		const { token } = signAccessToken(baseParams, key);
 		assert.throws(() => verifyAccessToken(token, key.public_key_pem, { audience: 'https://evil.example.com/mcp' }));
 	});
 
 	it('rejects a token verified against the wrong issuer', () => {
-		const token = signAccessToken(baseParams, key);
+		const { token } = signAccessToken(baseParams, key);
 		assert.throws(() => verifyAccessToken(token, key.public_key_pem, { issuer: 'https://evil.example.com' }));
 	});
 
 	it('omits scope when none is requested', () => {
 		const { scope, ...noScope } = baseParams;
 		void scope;
-		const token = signAccessToken(noScope, key);
+		const { token } = signAccessToken(noScope, key);
 		const claims = verifyAccessToken(token, key.public_key_pem);
 		assert.equal(claims.scope, undefined);
+	});
+
+	it('uses the caller-supplied jti when provided', () => {
+		const { token, jti } = signAccessToken({ ...baseParams, jti: 'my-custom-jti' }, key);
+		assert.equal(jti, 'my-custom-jti', 'returned jti matches the supplied value');
+		const claims = verifyAccessToken(token, key.public_key_pem);
+		assert.equal(claims.jti, 'my-custom-jti', 'JWT jti claim matches the supplied value');
 	});
 
 	it('serializes an RSA public key to a JWK with kid/use/alg', () => {

--- a/test/lib/mcp/tokenIssuer.test.js
+++ b/test/lib/mcp/tokenIssuer.test.js
@@ -109,7 +109,7 @@ function makeRsaKey(kid) {
 
 describe('verifyAccessTokenWithKeySet', () => {
 	it('selects the key by kid and verifies aud + iss', () => {
-		const token = signAccessToken(baseParams, key);
+		const { token } = signAccessToken(baseParams, key);
 		const claims = verifyAccessTokenWithKeySet(token, [makeRsaKey('unrelated'), key], {
 			audience: baseParams.audience,
 			issuer: baseParams.issuer,
@@ -119,7 +119,7 @@ describe('verifyAccessTokenWithKeySet', () => {
 	});
 
 	it('throws on an empty key set', () => {
-		const token = signAccessToken(baseParams, key);
+		const { token } = signAccessToken(baseParams, key);
 		assert.throws(
 			() => verifyAccessTokenWithKeySet(token, [], { audience: baseParams.audience, issuer: baseParams.issuer }),
 			/no signing keys/
@@ -128,7 +128,7 @@ describe('verifyAccessTokenWithKeySet', () => {
 
 	it('throws on an unknown kid rather than falling back to another key', () => {
 		// Signed with `key` (kid SIGNING_KEY_ID) but that kid is absent from the set.
-		const token = signAccessToken(baseParams, key);
+		const { token } = signAccessToken(baseParams, key);
 		assert.throws(
 			() =>
 				verifyAccessTokenWithKeySet(token, [makeRsaKey('different-kid')], {

--- a/test/lib/mcp/wellKnown.test.js
+++ b/test/lib/mcp/wellKnown.test.js
@@ -12,6 +12,14 @@ import {
 	resolveIssuer,
 	resolveResource,
 } from '../../../dist/lib/mcp/wellKnown.js';
+import { resetMCPKeysTableCache } from '../../../dist/lib/mcp/keyStore.js';
+
+// Bun runs every test file in ONE shared process (Node isolates per file). The
+// JWKS tests below assert an EMPTY key set, which relies on the MCPKeyStore
+// module-level table cache being clear — a prior file that minted a signing key
+// would otherwise leak its cached table here and these tests would see that
+// key. Reset the cache before every test so they're order-independent.
+beforeEach(() => resetMCPKeysTableCache());
 
 function makeRequest(overrides = {}) {
 	return {

--- a/test/lib/mcp/withMCPAuth.test.js
+++ b/test/lib/mcp/withMCPAuth.test.js
@@ -153,6 +153,20 @@ describe('withMCPAuth — rejected-token audit (oauth.mcp.token.rejected)', () =
 		assert.equal(res.status, 401);
 		assert.equal(events.length, 0, 'no audit event for an oversized path');
 	});
+
+	it('a throwing emitAudit sink never breaks the fail-closed 401 (no 500)', async () => {
+		// emitAudit is part of the exported options surface; a custom sink that throws
+		// must not turn the denial into a rejected promise / framework 500.
+		const token = mint({}, makeKey(SIGNING_KEY_ID)); // valid kid, wrong key → bad signature
+		const o = opts({
+			emitAudit: () => {
+				throw new Error('audit sink down');
+			},
+		});
+		const res = await withMCPAuth(spyHandler().handler, o)(req(`Bearer ${token}`), NEXT);
+		assert.equal(res.status, 401, 'a throwing audit sink must not break the 401');
+		assert.equal(res.headers['WWW-Authenticate'], EXPECTED_CHALLENGE);
+	});
 });
 
 describe('withMCPAuth — rejections (all return 401 + Bearer PRM challenge)', () => {

--- a/test/lib/mcp/withMCPAuth.test.js
+++ b/test/lib/mcp/withMCPAuth.test.js
@@ -52,7 +52,7 @@ function mint(overrides = {}, signingKey = key) {
 		ttlSeconds: 3600,
 		...overrides,
 	};
-	return signAccessToken(params, signingKey);
+	return signAccessToken(params, signingKey).token;
 }
 
 const config = { enabled: true, issuer: ISSUER, resource: RESOURCE };

--- a/test/lib/mcp/withMCPAuth.test.js
+++ b/test/lib/mcp/withMCPAuth.test.js
@@ -99,6 +99,62 @@ describe('withMCPAuth — construction', () => {
 	});
 });
 
+describe('withMCPAuth — rejected-token audit (oauth.mcp.token.rejected)', () => {
+	// Inject an emitAudit spy; returns the captured events + the options bag.
+	function auditOpts(extra = {}) {
+		const events = [];
+		return { events, opts: opts({ emitAudit: (p) => events.push(p), ...extra }) };
+	}
+
+	it('emits oauth.mcp.token.rejected when a presented token fails validation', async () => {
+		const token = mint({}, makeKey(SIGNING_KEY_ID)); // valid kid, wrong key → bad signature
+		const { events, opts: o } = auditOpts();
+		const res = await withMCPAuth(spyHandler().handler, o)(req(`Bearer ${token}`), NEXT);
+
+		assert.equal(res.status, 401);
+		assert.equal(events.length, 1, 'exactly one rejected audit event');
+		assert.equal(events[0].event, 'oauth.mcp.token.rejected');
+		assert.equal(events[0].aud, RESOURCE, 'aud is the configured resource, not the token claim');
+		assert.ok(events[0].reason, 'reason present');
+		assert.ok(events[0].timestamp, 'timestamp present');
+		// A rejected token has no trustworthy claims — none may leak into the record.
+		assert.equal(events[0].client_id, undefined);
+		assert.equal(events[0].sub, undefined);
+		assert.equal(events[0].jti, undefined);
+	});
+
+	it('audits a wrong-audience token (RFC 8707 rejection)', async () => {
+		const token = mint({ audience: 'https://evil.example.com/mcp' });
+		const { events, opts: o } = auditOpts();
+		const res = await withMCPAuth(spyHandler().handler, o)(req(`Bearer ${token}`), NEXT);
+		assert.equal(res.status, 401);
+		assert.equal(events.length, 1);
+		assert.equal(events[0].event, 'oauth.mcp.token.rejected');
+	});
+
+	it('does NOT audit a missing-token request (unauthenticated probe, not a rejected token)', async () => {
+		const { events, opts: o } = auditOpts();
+		const res = await withMCPAuth(spyHandler().handler, o)(req(undefined), NEXT);
+		assert.equal(res.status, 401);
+		assert.equal(events.length, 0, 'no audit event for a missing token');
+	});
+
+	it('does NOT audit when MCP is disabled (denial before any token work)', async () => {
+		const { events, opts: o } = auditOpts({ getConfig: () => ({ enabled: false }) });
+		const res = await withMCPAuth(spyHandler().handler, o)(req(`Bearer ${mint()}`), NEXT);
+		assert.equal(res.status, 401);
+		assert.equal(events.length, 0, 'no audit event when the guard short-circuits before token validation');
+	});
+
+	it('does NOT audit the path-length guard (pre-token DoS rejection)', async () => {
+		const { events, opts: o } = auditOpts();
+		const longPath = '/mcp/' + 'a'.repeat(2100);
+		const res = await withMCPAuth(spyHandler().handler, o)(req(`Bearer ${mint()}`, { pathname: longPath }), NEXT);
+		assert.equal(res.status, 401);
+		assert.equal(events.length, 0, 'no audit event for an oversized path');
+	});
+});
+
 describe('withMCPAuth — rejections (all return 401 + Bearer PRM challenge)', () => {
 	it('rejects a request with no Authorization header', async () => {
 		const { handler, calls } = spyHandler();


### PR DESCRIPTION
Stage 6 of the MCP OAuth epic (#86): wires MCP token-lifecycle events into Harper's audit trail and adds a lifecycle hook so apps can react to token issuance (rate-limiting, billing, usage attribution).

Closes #96. Draft until CI's claude/gemini review passes — then Ready for @kriszyp.

## What this adds

- **`onMCPTokenIssued` hook** on `OAuthHooks` + `HookManager.callOnMCPTokenIssued` — mirrors `onLogin` (fire-and-forget; a throwing hook is caught/logged and never blocks issuance). Fires after the JWT is minted and all token state is persisted, before the response.
- **Audit events** `oauth.mcp.token.issued` / `oauth.mcp.token.refreshed`, emitted from the token-issuance path via a new `src/lib/mcp/audit.ts` helper (`emitMCPAuditEvent`). Structured `MCP audit: <JSON>` record through Harper's global logger at `.info`, mirroring core's `authAuditLog` pattern (→ hdb.log, alongside the auth audit trail). **No token material** — payload is `client_id`/`sub`/`aud`/`scope`/`jti`/`timestamp` only.
- **`signAccessToken` now returns `{ token, jti }`** (accepts an optional `jti`) so the audit/hook can reference the token id without re-parsing the JWT.
- **`onLogin` already fires on MCP-initiated auth** (the bridged authorize/callback flow, Stage 3) — verified, with a regression test added.

## Deferred (depends on unmerged #134)

`oauth.mcp.token.rejected` lives in `withMCPAuth` (Stage 5 / #134, not yet on main). The audit helper already accepts that event type, so adding the call site once #134 merges is a one-liner. This PR ships the two issuance events + the hook + the onLogin verification.

## Cross-model review (pre-PR)

Ran Codex + a Harper-domain pass before pushing. Both P2 findings fixed (the bulk of this PR's care):

1. **Auth-code ordering** — the audit event + hook fired *before* the refresh-family was persisted, so a persistence failure would report a phantom successful issuance to audit/billing. Moved the emit/hook to **after** all token state is durably committed.
2. **`emitMCPAuditEvent` non-throwing** — it now `try/catch`es the logger call (its doc promised non-throwing but didn't deliver). On the refresh path the emit runs *after* the family is rotated, so a thrown logger error would otherwise deny the client its new token and strand the family — a data-integrity path, not just observability.

Plus: corrected the audit doc (records are filterable by the `MCP audit:` prefix / `event` field, not a logger tag — Harper doesn't expose tagging to plugins here); a JSDoc note that the hook's `event` is sanitized but `request` is not; and **two regression tests** for the paths above (failing refresh-family persistence → no phantom audit/hook; throwing logger → token still returned).

## Testing

Unit suite: 694 pass, 2 skipped (pre-existing), 0 fail. Build/lint/format clean. (Integration tests run on CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
