### PR TITLE
MCP OAuth Stage 8: user-facing docs (#98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ The plugin can also act as an OAuth 2.1 authorization server for **Model Context
 import { server } from 'harper';
 import { withMCPAuth } from '@harperfast/oauth';
 
-// request.mcp = { sub, client_id, aud, scope } once a valid bearer token is verified.
+// request.mcp (verified { sub, client_id, aud, scope }) is guaranteed present inside the guarded handler.
 server.http(
 	withMCPAuth((request) => ({ status: 200, body: JSON.stringify({ user: request.mcp.sub }) })),
 	{

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Complete documentation is available in the [docs](./docs) directory:
 - **[Lifecycle Hooks](./docs/lifecycle-hooks.md)** - User provisioning and custom logic
 - **[Multi-Tenant SSO](./docs/multi-tenant-sso.md)** - Per-organization OAuth providers for B2B SaaS
 - **[Token Refresh and Sessions](./docs/token-refresh-and-sessions.md)** - How OAuth tokens and Harper sessions interact
+- **[MCP OAuth](./docs/mcp-oauth.md)** - Authorization server for Model Context Protocol clients (experimental)
 - **[API Reference](./docs/api-reference.md)** - Endpoints and programmatic API
 
 ## Development
@@ -192,35 +193,37 @@ When MCP OAuth is enabled (see [issue #86](https://github.com/HarperFast/oauth/i
 
 ## MCP OAuth (experimental)
 
-The plugin can also act as an OAuth authorization server for **Model Context Protocol** clients (Claude Desktop, Cursor, `mcp-remote`), letting them authenticate against the same upstream providers. Enable it with `mcp.enabled: true` (see [`docs/configuration.md`](./docs/configuration.md)).
+The plugin can also act as an OAuth 2.1 authorization server for **Model Context Protocol** clients (Claude Desktop, Cursor, `mcp-remote`), letting them authenticate against the same upstream providers. Two steps: enable it in config, and guard your MCP route with `withMCPAuth`.
 
-**Status: experimental, opt-in.** Available now: RFC 7591 Dynamic Client Registration, discovery metadata (`/.well-known/*`), the authorization endpoint, audience-bound JWT token issuance, and token _verification_ for app-owned MCP routes (`withMCPAuth`, below). The remaining pieces land in 2.0.x — see [issue #86](https://github.com/HarperFast/oauth/issues/86).
+```yaml
+# config.yaml
+'@harperfast/oauth':
+  providers:
+    github:
+      clientId: ${OAUTH_GITHUB_CLIENT_ID}
+      clientSecret: ${OAUTH_GITHUB_CLIENT_SECRET}
+  mcp:
+    enabled: true
+    issuer: https://my-app.example.com # required; pin to your public origin
+```
 
-### Protecting an MCP route — `withMCPAuth`
-
-The plugin doesn't own the MCP endpoint — your app does. `withMCPAuth` wraps your handler so it enforces the spec contract once, centrally: it validates the `Authorization: Bearer` access token (signature against the published JWKS, `exp`/`nbf`, and audience binding to `mcp.resource` per RFC 8707), and on any failure returns `401` with `WWW-Authenticate: Bearer resource_metadata="…"` (RFC 9728) pointing MCP clients at discovery. On success it attaches the verified claims as `request.mcp = { sub, client_id, aud, scope }` and invokes your handler unchanged.
-
-```ts
+```typescript
+// resources.ts
 import { server } from 'harper';
 import { withMCPAuth } from '@harperfast/oauth';
 
-const mcpHandler = (request) => {
-	// request.mcp is guaranteed present here: { sub, client_id, aud, scope }
-	return { status: 200, body: JSON.stringify({ user: request.mcp.sub }) };
-};
-
-// Recommended: register on a urlPath subroute.
-server.http(withMCPAuth(mcpHandler), { urlPath: '/mcp' });
+// request.mcp = { sub, client_id, aud, scope } once a valid bearer token is verified.
+server.http(
+	withMCPAuth((request) => ({ status: 200, body: JSON.stringify({ user: request.mcp.sub }) })),
+	{
+		urlPath: '/mcp',
+	}
+);
 ```
 
-**Registration matters — Harper's core auth will otherwise reject the token.** Core auth consumes `Authorization: Bearer` and rejects any non-Harper token with `WWW-Authenticate: Basic`, which breaks the MCP discovery loop. Register `withMCPAuth` so it owns the response for its route:
+The plugin serves discovery (`/.well-known/*`), Dynamic Client Registration, the authorize/token endpoints, and JWKS; `withMCPAuth` verifies the audience-bound JWT on every call and fails closed. There's an [`onMCPTokenIssued`](./docs/lifecycle-hooks.md#onmcptokenissued) hook to react when a client gains access (client→user mapping, monitoring, rate-limiting) and a built-in audit log.
 
-- **urlPath subroute (recommended):** `server.http(withMCPAuth(handler), { urlPath: '/mcp' })`. Harper routes the request to this chain alone, so core auth never runs for it — the same isolation the `/.well-known/*` endpoints use. No extra options needed.
-- **Default-group fallback:** `server.http(withMCPAuth(handler, { path: '/mcp' }), { before: 'authentication' })`. When the route shares the default middleware chain with auth, pass `path` (so the guard scopes to your route and lets other paths fall through) and register `before: 'authentication'` so it runs ahead of core auth.
-
-`withMCPAuth(handler, options?)` options: `path` (default-group scoping, above), `onAuthError(request, reason)` (custom denial response — a falsy return still fails closed to the default `401`), plus `getConfig` / `logger` / `keyStore` overrides (default to the plugin's live MCP config, logger, and key store). The guard fails closed: while MCP is disabled or no signing key has been published, every request is rejected. Query-string tokens are ignored (header-only, RFC 6750).
-
-If your MCP route lives in a **different component** than the one declaring `@harperfast/oauth`, inject `getConfig` (the consumer's copy of `OAuthResource.mcpConfig` is unpopulated) — signing keys still resolve from the shared `oauth` database. See [`docs/configuration.md`](./docs/configuration.md).
+**Status: experimental, opt-in.** See **[MCP OAuth](./docs/mcp-oauth.md)** for the full flow, the `withMCPAuth` registration models and options, the hook, configuration, the production checklist, and troubleshooting — and [issue #86](https://github.com/HarperFast/oauth/issues/86) for what's still v1.1.
 
 ## Security Considerations
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ The plugin can also act as an OAuth 2.1 authorization server for **Model Context
 ```yaml
 # config.yaml
 '@harperfast/oauth':
+  package: '@harperfast/oauth'
   providers:
     github:
       clientId: ${OAUTH_GITHUB_CLIENT_ID}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@ Complete configuration options for the `@harperfast/oauth` plugin.
 | `redirectUri`           | string            | (auto-gen) | OAuth callback URL where providers redirect back to                                                                                                                                                                                                        |
 | `postLoginRedirect`     | string            | `/`        | Default URL to redirect users after successful OAuth login                                                                                                                                                                                                 |
 | `cacheDynamicProviders` | boolean \| number | `300`      | TTL (seconds) for providers resolved via the `onResolveProvider` hook. Number = seconds; `false` = never cache (call the hook every request); `true` = cache forever. Default 300s; freshness is controlled by this TTL (there is no manual invalidation). |
-| `mcp`                   | object            | (off)      | MCP OAuth flow configuration. See [MCP OAuth](#mcp-oauth-work-in-progress) below                                                                                                                                                                           |
+| `mcp`                   | object            | (off)      | MCP OAuth flow configuration. See [MCP OAuth](#mcp-oauth) below                                                                                                                                                                                            |
 
 ### Provider Configuration
 
@@ -55,9 +55,11 @@ Each provider requires:
 - `userInfoUrl` - User info endpoint URL (required)
 - `jwksUrl` - JWKS endpoint URL (required for ID token verification)
 
-### MCP OAuth (work in progress)
+### MCP OAuth
 
-Opt-in support for the Model Context Protocol authorization flow ([issue #86](https://github.com/HarperFast/oauth/issues/86)). Implemented so far: Dynamic Client Registration at `POST /oauth/mcp/register` (RFC 7591), the discovery documents under `/.well-known/*` (RFCs 8414, 9728) so MCP clients (Claude Desktop, Cursor, `mcp-remote`) can find and register themselves, the authorization endpoint `GET /oauth/mcp/authorize` (OAuth 2.1 + PKCE-S256), the `POST /oauth/mcp/token` exchange (audience-bound RS256 JWTs), and the `withMCPAuth` route guard (below) that verifies those tokens on your MCP endpoint.
+Opt-in support for the Model Context Protocol authorization flow ([issue #86](https://github.com/HarperFast/oauth/issues/86)). The plugin serves Dynamic Client Registration at `POST /oauth/mcp/register` (RFC 7591), the discovery documents under `/.well-known/*` (RFCs 8414, 9728) so MCP clients (Claude Desktop, Cursor, `mcp-remote`) can find and register themselves, the authorization endpoint `GET /oauth/mcp/authorize` (OAuth 2.1 + PKCE-S256), the `POST /oauth/mcp/token` exchange (audience-bound RS256 JWTs), and the `withMCPAuth` route guard that verifies those tokens on your MCP endpoint.
+
+> This section is the configuration reference. For the end-to-end flow, the `withMCPAuth` wrapper (registration models + options), the `onMCPTokenIssued` hook, the production checklist, and troubleshooting, see **[MCP OAuth](./mcp-oauth.md)**. The feature is **experimental and opt-in** (`mcp.enabled`).
 
 ```yaml
 '@harperfast/oauth':
@@ -82,91 +84,37 @@ Opt-in support for the Model Context Protocol authorization flow ([issue #86](ht
         - app.example.com
 ```
 
-| Option                                                  | Type     | Default         | Description                                                                                                                                                                                                                       |
-| ------------------------------------------------------- | -------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mcp.enabled`                                           | boolean  | `false`         | Master switch for the MCP OAuth endpoints                                                                                                                                                                                         |
-| `mcp.issuer`                                            | string   | (none)          | Authorization-server URI advertised in AS metadata. **Required when `mcp.enabled`** — startup fails otherwise, to prevent a Host-header-driven `iss`/`aud`                                                                        |
-| `mcp.resource`                                          | string   | `<issuer>/mcp`  | Canonical resource URI advertised in PRM (RFC 9728) and validated as `aud` on issued tokens (RFC 8707). Optional override; defaults safely from the pinned `issuer`                                                               |
-| `mcp.providers`                                         | string[] | (all providers) | Subset of upstream providers eligible for the MCP auth flow. **v1 requires exactly one** resolved provider — set this when more than one provider is configured globally, otherwise `/oauth/mcp/authorize` returns `server_error` |
-| `mcp.dynamicClientRegistration.enabled`                 | boolean  | `true`          | Enable the `/register` endpoint when `mcp.enabled` is true                                                                                                                                                                        |
-| `mcp.dynamicClientRegistration.initialAccessToken`      | string   | (none)          | If set, registration requires `Authorization: Bearer <token>`. Otherwise open per RFC 7591                                                                                                                                        |
-| `mcp.dynamicClientRegistration.allowedRedirectUriHosts` | string[] | (none)          | Allowlist for redirect_uri hosts. Localhost always allowed per RFC 8252                                                                                                                                                           |
+| Option                                                  | Type     | Default         | Description                                                                                                                                                                                                                             |
+| ------------------------------------------------------- | -------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mcp.enabled`                                           | boolean  | `false`         | Master switch for the MCP OAuth endpoints                                                                                                                                                                                               |
+| `mcp.issuer`                                            | string   | (none)          | Authorization-server URI advertised in AS metadata. **Required when `mcp.enabled`** — startup fails otherwise, to prevent a Host-header-driven `iss`/`aud`                                                                              |
+| `mcp.resource`                                          | string   | `<issuer>/mcp`  | Canonical resource URI advertised in PRM (RFC 9728) and validated as `aud` on issued tokens (RFC 8707). Optional override; defaults safely from the pinned `issuer`                                                                     |
+| `mcp.providers`                                         | string[] | (all providers) | Subset of upstream providers eligible for the MCP auth flow. **v1 requires exactly one** resolved provider — set this when more than one provider is configured globally, otherwise `/oauth/mcp/authorize` returns `server_error`       |
+| `mcp.dynamicClientRegistration.enabled`                 | boolean  | `true`          | Enable the `/register` endpoint when `mcp.enabled` is true                                                                                                                                                                              |
+| `mcp.dynamicClientRegistration.initialAccessToken`      | string   | (none)          | If set, registration requires `Authorization: Bearer <token>`. Otherwise open per RFC 7591                                                                                                                                              |
+| `mcp.dynamicClientRegistration.allowedRedirectUriHosts` | string[] | (none)          | Allowlist for redirect_uri hosts. Localhost always allowed per RFC 8252                                                                                                                                                                 |
+| `mcp.signingKeyPem`                                     | string   | (generated)     | PEM-encoded RS256 private key (PKCS#8) used to sign access tokens. When unset, a keypair is generated on first boot. **Pin the same PEM on every node in a cluster** — otherwise nodes can sign with keys the JWKS hasn't published yet |
+| `mcp.signingAlgorithm`                                  | string   | `RS256`         | JWT signing algorithm. Only `RS256` is supported in v1 (reserved for a future EdDSA option)                                                                                                                                             |
+| `mcp.accessTokenTtl`                                    | number   | `3600`          | Access-token lifetime in seconds (default 1 hour)                                                                                                                                                                                       |
+| `mcp.refreshTokenTtl`                                   | number   | `2592000`       | Refresh-token (family) lifetime in seconds (default 30 days)                                                                                                                                                                            |
 
 Sensitive leaves inside `mcp` support `${ENV_VAR}` expansion (e.g., `initialAccessToken: ${OAUTH_MCP_REGISTRATION_TOKEN}`), the same way provider credentials do.
 
 **Discovery endpoints** (served when `mcp.enabled: true`):
 
-| Path                                      | Spec     | Purpose                                                                              |
-| ----------------------------------------- | -------- | ------------------------------------------------------------------------------------ |
-| `/.well-known/oauth-protected-resource`   | RFC 9728 | Tells MCP clients where to find the authorization server                             |
-| `/.well-known/oauth-authorization-server` | RFC 8414 | Advertises authorize / token / register / JWKS endpoints and supported methods       |
-| `/.well-known/jwks.json`                  | —        | Public keys for verifying issued JWTs (returns an empty key set until signing lands) |
+| Path                                      | Spec     | Purpose                                                                                          |
+| ----------------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `/.well-known/oauth-protected-resource`   | RFC 9728 | Tells MCP clients where to find the authorization server                                         |
+| `/.well-known/oauth-authorization-server` | RFC 8414 | Advertises authorize / token / register / JWKS endpoints and supported methods                   |
+| `/.well-known/jwks.json`                  | —        | Public keys for verifying issued JWTs (returns an empty key set until the first token is minted) |
 
 All three documents include `Access-Control-Allow-Origin: *` so browser-based MCP clients and discovery tools can fetch them cross-origin.
 
 #### Protecting your MCP route — `withMCPAuth`
 
-The plugin issues and verifies tokens, but your app owns the MCP endpoint. Wrap your handler with `withMCPAuth` to enforce the spec contract on it:
+Your app owns the MCP endpoint; wrap your handler with `withMCPAuth` to verify the issued tokens on it — fail-closed bearer-token validation that emits the RFC 9728 `WWW-Authenticate` challenge on rejection and attaches `request.mcp = { sub, client_id, aud, scope }` on success. Registration matters (Harper's core auth otherwise consumes the bearer token), so see **[MCP OAuth → The `withMCPAuth` wrapper](./mcp-oauth.md#the-withmcpauth-wrapper)** for the registration models, the full options reference, and using the wrapper from a separate component.
 
-```ts
-import { server } from 'harper';
-import { withMCPAuth } from '@harperfast/oauth';
-
-const mcpHandler = (request) => {
-	// On success, the verified claims are attached: { sub, client_id, aud, scope }
-	return { status: 200, body: JSON.stringify({ user: request.mcp.sub }) };
-};
-
-// Recommended registration — a urlPath subroute (see "Registration", below):
-server.http(withMCPAuth(mcpHandler), { urlPath: '/mcp' });
-```
-
-What it enforces on every request, failing closed with `401 + WWW-Authenticate: Bearer resource_metadata="<PRM URL>"`. The PRM URL is the RFC 9728 §3.1 location for the configured `mcp.resource` — `<resource-origin>/.well-known/oauth-protected-resource` with the resource's path appended when it has one (e.g. `https://app.example.com/.well-known/oauth-protected-resource/mcp` for resource `https://app.example.com/mcp`), matching exactly what the well-known handler serves:
-
-- Bearer token present in the `Authorization` header (header-only; query-string tokens are ignored, RFC 6750).
-- Valid RS256 signature against the published JWKS, selecting the key by the token's `kid`.
-- `exp`/`nbf` within bounds, and `aud` equal to `mcp.resource` (audience binding, RFC 8707).
-- MCP enabled and a signing key published — while either is missing, all requests are rejected.
-
-On success it sets `request.mcp = { sub, client_id, aud, scope }` and calls your handler, returning its response unchanged.
-
-**Registration.** Harper's core auth is a default-group middleware that consumes `Authorization: Bearer` and rejects any non-Harper token with `WWW-Authenticate: Basic` — which would break MCP discovery. Register `withMCPAuth` so it owns the response for its route:
-
-- **urlPath subroute (recommended):** `server.http(withMCPAuth(handler), { urlPath: '/mcp' })`. Harper's routed dispatch runs only this chain, so core auth never runs for the route — the same isolation the `/.well-known/*` endpoints rely on. No extra options needed.
-- **Default-group fallback:** `server.http(withMCPAuth(handler, { path: '/mcp' }), { before: 'authentication' })`. When the route shares the default chain with auth, pass `path` (the guard then scopes to that path and calls `next()` for everything else) and register `before: 'authentication'` so it runs ahead of core auth. In this mode the wrapped handler must terminate the request rather than call `next`, or core auth runs afterward and re-rejects the token.
-
-**Options** — `withMCPAuth(handler, options?)`:
-
-| Option        | Type                           | Default                | Description                                                                                        |
-| ------------- | ------------------------------ | ---------------------- | -------------------------------------------------------------------------------------------------- |
-| `path`        | string                         | (none)                 | Default-group scoping only — the path this guard owns. Omit for the urlPath-subroute registration. |
-| `onAuthError` | `(request, reason) => any`     | (none)                 | Custom denial response. A falsy return still falls back to the default `401` (fail closed).        |
-| `getConfig`   | `() => MCPConfig \| undefined` | live plugin MCP config | Override the MCP config source (read per request).                                                 |
-| `logger`      | Logger                         | plugin logger          | Override the logger.                                                                               |
-| `keyStore`    | `{ getAllPublicKeys() }`       | plugin `MCPKeyStore`   | Override the signing-key source (used by tests).                                                   |
-
-##### Using `withMCPAuth` from a different component than the plugin
-
-By default `withMCPAuth` reads the live MCP config from the OAuth plugin via `OAuthResource.mcpConfig`. That works when the component that **declares** `@harperfast/oauth` is the same one that exposes the MCP route. If your MCP tools live in a **separate** component (it imports `withMCPAuth` as a function but doesn't declare the plugin in its own `config.yaml`), that consumer resolves its **own** `node_modules` copy of the package, where `OAuthResource.mcpConfig` is a module-local static that is never populated — so it reads as `undefined` and the guard fails closed.
-
-In that setup, **inject `getConfig`** so the wrapper sees the config:
-
-```ts
-server.http(
-	withMCPAuth(mcpHandler, {
-		// Pin issuer/resource to the values the plugin component issues tokens with,
-		// so the iss/aud checks match the minted tokens.
-		getConfig: () => ({
-			enabled: true,
-			issuer: 'https://my-app.example.com',
-			resource: 'https://my-app.example.com/mcp',
-		}),
-	}),
-	{ urlPath: '/mcp' }
-);
-```
-
-Signing keys need no extra wiring: the default `MCPKeyStore` reads `databases.oauth.harper_oauth_mcp_keys`, which is cluster-global, so the consumer verifies against the same JWKS the plugin component mints with. Importing `withMCPAuth` as a function does **not** spin up a second plugin instance.
+**Security:** before exposing MCP OAuth publicly, work through the [production-deployment checklist](./mcp-oauth.md#production-deployment) — pin `issuer`, gate Dynamic Client Registration, restrict redirect-URI hosts, serve over HTTPS, and (in clusters) pin `signingKeyPem`.
 
 ## Environment Variables
 

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -360,7 +360,9 @@ async function onMCPTokenIssued(
 
 ```javascript
 async function handleMCPTokenIssued(event, request) {
-	// Record which MCP client is acting for which user.
+	// Record which MCP client is acting for which user. `tables` is a Harper global
+	// (no import needed); `McpClient` is an example app-owned table — the plugin
+	// doesn't provide it, so define your own.
 	await tables.McpClient.put({ id: event.client_id, user: event.sub, lastSeen: Date.now() });
 }
 ```

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -352,7 +352,7 @@ async function onMCPTokenIssued(
 - `event` - Identifies the token issued: `type` (`access` for the authorization-code grant, `refresh` for a rotation), `client_id`, `sub`, `aud`, `scope` (optional), and `jti` (the token id)
 - `request` - The HTTP request that triggered issuance
 
-**Returns:** void. Fire-and-forget — a throwing hook is caught and logged, never blocking token issuance.
+**Returns:** void. Fire-and-forget — the hook is **not awaited** (it runs detached, so it never delays or blocks token issuance); a throwing hook is caught and logged, never surfaced.
 
 > **Security:** `event` is sanitized — it carries only the `jti` (a token identifier, safe to log), never the access/refresh token strings. The `request` is **not** sanitized: on the refresh path its body carries the `refresh_token` the client presented, so do not log `request` wholesale.
 

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -332,6 +332,39 @@ async function handleTokenRefresh(session, refreshed, request) {
 }
 ```
 
+### onMCPTokenIssued
+
+Called after an MCP access or refresh token is minted, before the response returns. Only fires when [MCP OAuth](./mcp-oauth.md) is enabled. This is the MCP-client analog of [`onLogin`](#onlogin) — react in your own application when an MCP client gains access.
+
+**Purpose:** Associate an MCP `client_id` with a user (`sub`) in your own data model, monitoring and security alerting on which clients obtain tokens, per-client rate-limiting
+
+**Signature:**
+
+```typescript
+async function onMCPTokenIssued(
+	event: { type: 'access' | 'refresh'; client_id: string; sub: string; aud: string; scope?: string; jti: string },
+	request: Request
+): Promise<void>;
+```
+
+**Parameters:**
+
+- `event` - Identifies the token issued: `type` (`access` for the authorization-code grant, `refresh` for a rotation), `client_id`, `sub`, `aud`, `scope` (optional), and `jti` (the token id)
+- `request` - The HTTP request that triggered issuance
+
+**Returns:** void. Fire-and-forget — a throwing hook is caught and logged, never blocking token issuance.
+
+> **Security:** `event` is sanitized — it carries only the `jti` (a token identifier, safe to log), never the access/refresh token strings. The `request` is **not** sanitized: on the refresh path its body carries the `refresh_token` the client presented, so do not log `request` wholesale.
+
+**Example:**
+
+```javascript
+async function handleMCPTokenIssued(event, request) {
+	// Record which MCP client is acting for which user.
+	await tables.McpClient.put({ id: event.client_id, user: event.sub, lastSeen: Date.now() });
+}
+```
+
 ## Hook Registration
 
 Hooks are **lazy-referenced** - they are looked up when OAuth events occur (login, logout, token refresh), not when registered. This means you can call `registerHooks()` at any time, and there's no specific initialization window. The hooks are simply stored and referenced later when needed.

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -334,7 +334,7 @@ async function handleTokenRefresh(session, refreshed, request) {
 
 ### onMCPTokenIssued
 
-Called after an MCP access or refresh token is minted, before the response returns. Only fires when [MCP OAuth](./mcp-oauth.md) is enabled. This is the MCP-client analog of [`onLogin`](#onlogin) — react in your own application when an MCP client gains access.
+Called after an MCP access or refresh token is minted. Because it runs detached and is not awaited (fire-and-forget), it never delays the token response — its side effects may complete after the client has already received the token. Only fires when [MCP OAuth](./mcp-oauth.md) is enabled. This is the MCP-client analog of [`onLogin`](#onlogin) — react in your own application when an MCP client gains access.
 
 **Purpose:** Associate an MCP `client_id` with a user (`sub`) in your own data model, monitoring and security alerting on which clients obtain tokens, per-client rate-limiting
 

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -51,7 +51,8 @@ route handler with `withMCPAuth`.
 import { server } from 'harper';
 import { withMCPAuth } from '@harperfast/oauth';
 
-// Your MCP endpoint. request.mcp is populated only after a valid bearer token.
+// Your MCP endpoint. request.mcp is guaranteed present here — the guard rejects
+// missing/invalid tokens before your handler runs, so no optional-chaining needed.
 function mcpHandler(request) {
 	const { sub, client_id, scope } = request.mcp; // verified token claims
 	// Harper HTTP listeners return { status, body, headers? }; MCP messages are

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -317,7 +317,9 @@ import { registerHooks } from '@harperfast/oauth';
 registerHooks({
 	onMCPTokenIssued: async (event, request) => {
 		// event = { type: 'access' | 'refresh', client_id, sub, aud, scope?, jti }
-		// Record which MCP client is acting for which user.
+		// Record which MCP client is acting for which user. `tables` is a Harper
+		// global (no import needed); `McpClient` here is an example app-owned table —
+		// the plugin doesn't provide it, so define your own.
 		await tables.McpClient.put({ id: event.client_id, user: event.sub, lastSeen: Date.now() });
 	},
 });

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -51,8 +51,9 @@ route handler with `withMCPAuth`.
 import { withMCPAuth } from '@harperfast/oauth';
 
 // Your MCP endpoint. request.mcp is populated only after a valid bearer token.
-function mcpHandler(request, next) {
+function mcpHandler(request) {
 	const { sub, client_id, scope } = request.mcp; // verified token claims
+	// MCP messages are JSON-RPC 2.0 — your handler returns a JSON-RPC response.
 	return { jsonrpc: '2.0', result: { hello: sub } };
 }
 

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -53,8 +53,9 @@ import { withMCPAuth } from '@harperfast/oauth';
 // Your MCP endpoint. request.mcp is populated only after a valid bearer token.
 function mcpHandler(request) {
 	const { sub, client_id, scope } = request.mcp; // verified token claims
-	// MCP messages are JSON-RPC 2.0 — your handler returns a JSON-RPC response.
-	return { jsonrpc: '2.0', result: { hello: sub } };
+	// Harper HTTP listeners return { status, body, headers? }; MCP messages are
+	// JSON-RPC 2.0, so serialize the JSON-RPC response as the body.
+	return { status: 200, body: JSON.stringify({ jsonrpc: '2.0', result: { hello: sub } }) };
 }
 
 // Register on a urlPath subroute so Harper's core auth never sees the request.

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -318,9 +318,11 @@ registerHooks({
 });
 ```
 
-It fires **after** the token is durably issued, **before** the response returns.
-It is fire-and-forget: a throwing hook is caught and logged, never blocking token
-issuance.
+It fires **after** the token is durably issued and runs **detached** — it is not
+awaited, so it never delays or blocks the token response (a slow hook can't add
+latency to issuance). It is fire-and-forget: a throwing hook is caught and logged,
+never surfaced. Because it isn't awaited, its side effects may complete after the
+client already has the token — don't rely on it finishing before the response.
 
 > **Security:** `event` is sanitized — it carries only the `jti` (a token
 > identifier, safe to log), never the access/refresh token strings. The `request`

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -1,0 +1,444 @@
+# MCP OAuth
+
+> **Status: experimental, opt-in.** Enable with `mcp.enabled: true`. The surface
+> described here is stable, but the feature is gated behind the flag and the
+> wire format may still change in a minor release. See [issue #86](https://github.com/HarperFast/oauth/issues/86).
+
+The plugin can act as an OAuth 2.1 **authorization server** for [Model Context
+Protocol](https://modelcontextprotocol.io) clients (Claude Desktop, Cursor,
+`mcp-remote`, the MCP Inspector). It lets those clients authenticate against the
+same upstream providers you already configure for human login, then mints
+audience-bound JWT access tokens your MCP routes can verify with a single wrapper.
+
+It implements the [MCP authorization specification (2025-06-18)](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)
+and the OAuth RFCs it builds on:
+
+| RFC                                                   | Role here                                                      |
+| ----------------------------------------------------- | -------------------------------------------------------------- |
+| [6749](https://datatracker.ietf.org/doc/html/rfc6749) | OAuth 2.0 authorization-code grant                             |
+| [6750](https://datatracker.ietf.org/doc/html/rfc6750) | Bearer token usage (`Authorization: Bearer`)                   |
+| [7591](https://datatracker.ietf.org/doc/html/rfc7591) | Dynamic Client Registration (`/register`)                      |
+| [7636](https://datatracker.ietf.org/doc/html/rfc7636) | PKCE (`S256`, required — `plain` is rejected)                  |
+| [8252](https://datatracker.ietf.org/doc/html/rfc8252) | OAuth for native apps (loopback redirect URIs)                 |
+| [8414](https://datatracker.ietf.org/doc/html/rfc8414) | Authorization Server Metadata (`/.well-known/...`)             |
+| [8707](https://datatracker.ietf.org/doc/html/rfc8707) | Resource Indicators (the `resource` parameter, `aud` binding)  |
+| [9728](https://datatracker.ietf.org/doc/html/rfc9728) | Protected Resource Metadata (the `WWW-Authenticate` challenge) |
+
+---
+
+## Quickstart
+
+Two pieces: turn on the authorization server in `config.yaml`, and guard your MCP
+route handler with `withMCPAuth`.
+
+**1. Enable the authorization server** (`config.yaml`):
+
+```yaml
+'@harperfast/oauth':
+  package: '@harperfast/oauth'
+  providers:
+    github:
+      clientId: ${OAUTH_GITHUB_CLIENT_ID}
+      clientSecret: ${OAUTH_GITHUB_CLIENT_SECRET}
+  mcp:
+    enabled: true
+    issuer: https://my-app.example.com # required; pin to your public origin
+```
+
+**2. Guard your MCP handler** (`resources.ts`):
+
+```typescript
+import { withMCPAuth } from '@harperfast/oauth';
+
+// Your MCP endpoint. request.mcp is populated only after a valid bearer token.
+function mcpHandler(request, next) {
+	const { sub, client_id, scope } = request.mcp; // verified token claims
+	return { jsonrpc: '2.0', result: { hello: sub } };
+}
+
+// Register on a urlPath subroute so Harper's core auth never sees the request.
+server.http(withMCPAuth(mcpHandler), { urlPath: '/mcp' });
+```
+
+That's it. An MCP client pointed at `https://my-app.example.com/mcp` now
+discovers the authorization server, registers itself, walks the user through your
+GitHub login, and presents a bearer token on every subsequent call — which
+`withMCPAuth` verifies before `mcpHandler` runs.
+
+> **Why `urlPath`, not the default route?** Harper's core auth is a default-group
+> middleware that consumes `Authorization: Bearer` and rejects any token that
+> isn't a Harper _operation_ token — answering with `WWW-Authenticate: Basic`,
+> not the `Bearer` challenge MCP clients need. Registering on a `urlPath`
+> subroute gives the route its own dispatch chain that core auth never runs on.
+> See [The `withMCPAuth` wrapper](#the-withmcpauth-wrapper) for the default-group
+> fallback.
+
+---
+
+## The flow
+
+```
+ MCP Client                  Harper (OAuth plugin)              Upstream IdP
+     │                                │                          (GitHub/…)
+     │  1. GET /mcp  (no token)       │                              │
+     │ ─────────────────────────────▶│                              │
+     │  401 + WWW-Authenticate:       │                              │
+     │     Bearer resource_metadata   │                              │
+     │ ◀─────────────────────────────│                              │
+     │                                │                              │
+     │  2. GET /.well-known/oauth-protected-resource   (RFC 9728)    │
+     │ ─────────────────────────────▶│                              │
+     │  3. GET /.well-known/oauth-authorization-server (RFC 8414)    │
+     │ ─────────────────────────────▶│                              │
+     │                                │                              │
+     │  4. POST /oauth/mcp/register   (RFC 7591 DCR)                 │
+     │ ─────────────────────────────▶│   → client_id                │
+     │                                │                              │
+     │  5. GET /oauth/mcp/authorize?code_challenge=…&resource=…      │
+     │ ─────────────────────────────▶│  302 to upstream login       │
+     │                                │ ────────────────────────────▶
+     │                  (user authenticates with the upstream IdP)   │
+     │                                │ ◀────────────────────────────
+     │  302 back to client redirect_uri?code=…                       │
+     │ ◀─────────────────────────────│                              │
+     │                                │                              │
+     │  6. POST /oauth/mcp/token  (code + code_verifier)             │
+     │ ─────────────────────────────▶│  → access_token (RS256 JWT)  │
+     │                                │     + refresh_token          │
+     │                                │                              │
+     │  7. GET /mcp  Authorization: Bearer <access_token>            │
+     │ ─────────────────────────────▶│  withMCPAuth verifies → 200  │
+     │ ◀─────────────────────────────│                              │
+```
+
+1. **Challenge.** A request to your guarded MCP route with no (or an invalid)
+   token gets `401` with `WWW-Authenticate: Bearer resource_metadata="<url>"`,
+   pointing at the Protected Resource Metadata document (RFC 9728).
+2. **Protected Resource Metadata.** The client fetches it to learn which
+   authorization server to use.
+3. **Authorization Server Metadata.** The client fetches the AS metadata (RFC 8414) to learn the `authorize`, `token`, `register`, and `jwks_uri` endpoints
+   and the supported methods.
+4. **Dynamic Client Registration.** The client registers itself (RFC 7591) and
+   receives a `client_id`. Registrations persist, so a cached `client_id`
+   survives Harper restarts.
+5. **Authorization.** The client opens `/oauth/mcp/authorize` with a PKCE
+   challenge and the `resource` it wants a token for. The plugin redirects the
+   user to the upstream IdP; on return it mints a single-use authorization code
+   and redirects back to the client's `redirect_uri`.
+6. **Token exchange.** The client posts the code plus its PKCE `code_verifier` to
+   `/oauth/mcp/token` and receives an RS256-signed access token (and a refresh
+   token) bound to the `resource` as its `aud`.
+7. **Authenticated requests.** The client calls your MCP route with
+   `Authorization: Bearer <access_token>`. `withMCPAuth` verifies the signature,
+   audience, and issuer, attaches the claims as `request.mcp`, and runs your
+   handler.
+
+No upstream IdP token is ever embedded in the issued JWT — the access token is
+minted and signed by this plugin.
+
+---
+
+## Endpoints
+
+All endpoints are served only when `mcp.enabled: true` (otherwise `404`, or the
+discovery handlers fall through).
+
+### Discovery (`/.well-known/*`)
+
+| Path                                          | Spec     | Returns                                                                              |
+| --------------------------------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `GET /.well-known/oauth-protected-resource`   | RFC 9728 | `resource`, `authorization_servers`, `bearer_methods_supported`                      |
+| `GET /.well-known/oauth-authorization-server` | RFC 8414 | `issuer`, the endpoint URLs, and supported response/grant/PKCE/auth methods          |
+| `GET /.well-known/jwks.json`                  | —        | The RS256 public keys for verifying issued tokens (empty until the first token mint) |
+
+All three send `Access-Control-Allow-Origin: *` so browser-based clients and
+discovery tools can fetch them cross-origin. When `mcp.resource` carries a path
+(e.g. `https://host/mcp`), the Protected Resource Metadata document is **also**
+served at the RFC 9728 path-appended location `/mcp/.well-known/oauth-protected-resource`,
+which is the form the `WWW-Authenticate` challenge advertises.
+
+### Authorization server
+
+| Endpoint               | Method | Notes                                                                                                                                     |
+| ---------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `/oauth/mcp/register`  | POST   | RFC 7591 Dynamic Client Registration. Open by default; gate with `initialAccessToken`. Returns `201`.                                     |
+| `/oauth/mcp/authorize` | GET    | OAuth 2.1 + PKCE. Requires `client_id`, `redirect_uri`, `response_type=code`, `code_challenge`, `code_challenge_method=S256`, `resource`. |
+| `/oauth/mcp/token`     | POST   | Grants: `authorization_code`, `refresh_token`. Returns the token pair with `Cache-Control: no-store`.                                     |
+
+> `mcp` is a reserved provider name — the plugin refuses to start if you configure
+> a provider called `mcp`, because it would collide with `/oauth/mcp/*`.
+
+### Issued access tokens
+
+RS256 JWT, signed with key id `rs256-default`, carrying:
+
+| Claim       | Value                                                                 |
+| ----------- | --------------------------------------------------------------------- |
+| `iss`       | `mcp.issuer`                                                          |
+| `sub`       | The Harper user the token was issued to (from your `onLogin` mapping) |
+| `aud`       | `mcp.resource` (RFC 8707 audience binding)                            |
+| `client_id` | The DCR-issued client identifier                                      |
+| `scope`     | Space-separated scope string (omitted when empty)                     |
+| `iat`/`exp` | Issued-at / expiry (`exp` = `iat` + `accessTokenTtl`, default 1 hour) |
+| `jti`       | Unique token id (used in audit events; safe to log)                   |
+
+Refresh tokens rotate on use: presenting an already-used token from a family
+revokes the whole family (replay defense). Refresh families live for
+`refreshTokenTtl` (default 30 days).
+
+---
+
+## The `withMCPAuth` wrapper
+
+`withMCPAuth(handler, options?)` wraps an MCP route handler so every request must
+present a valid access token minted by this plugin before the handler runs. It is
+the bearer-token counterpart to `withOAuthValidation` (which guards
+cookie/session routes).
+
+On any failure it **fails closed** with the spec 401:
+
+```
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer resource_metadata="https://my-app.example.com/mcp/.well-known/oauth-protected-resource"
+Content-Type: application/json
+
+{"error":"invalid_token","error_description":"<reason>"}
+```
+
+When a valid token is presented, the wrapper attaches the verified claims and
+calls your handler:
+
+```typescript
+request.mcp = { sub, client_id, aud, scope };
+```
+
+Tokens are read from the `Authorization: Bearer` header only (RFC 6750 §2.1) —
+query-string and body tokens are ignored.
+
+### Registration
+
+**Primary — `urlPath` subroute (recommended):**
+
+```typescript
+server.http(withMCPAuth(mcpHandler), { urlPath: '/mcp' });
+```
+
+Harper dispatches a `urlPath` subroute on its own chain and returns, so the
+default chain — where core auth lives — never runs for `/mcp`. The bearer
+challenge can't be clobbered. This is the same isolation `/.well-known/*` uses.
+No `path` option and no ordering hint are needed.
+
+**Fallback — default group, ahead of core auth:**
+
+```typescript
+server.http(withMCPAuth(mcpHandler, { path: '/mcp' }), { before: 'authentication' });
+```
+
+When the route shares the default chain with auth (no `urlPath`), pass `path` so
+the wrapper guards only that path and calls `next()` for everything else, and
+register with `{ before: 'authentication' }` so it runs ahead of core auth. In
+this mode the wrapped handler **must terminate the request** (not call `next`),
+or core auth runs afterward and re-rejects the token. This mirrors Harper's own
+`server/static.ts`.
+
+### Options
+
+| Option        | Type                                   | Default                    | Purpose                                                                                                                                       |
+| ------------- | -------------------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `path`        | `string`                               | (unset)                    | Set only for the default-group fallback — the path this guard owns; requests outside it fall through to `next()`.                             |
+| `onAuthError` | `(request, reason: string) => any`     | (unset)                    | Custom denial handler. **Any falsy return falls back to the default 401** — a no-return handler can't accidentally turn a denial into a pass. |
+| `getConfig`   | `() => MCPConfig \| undefined`         | live plugin config         | MCP config source, read per request. Override for tests.                                                                                      |
+| `logger`      | `Logger`                               | plugin logger              | Logger for verification failures. Override for tests.                                                                                         |
+| `keyStore`    | `{ getAllPublicKeys(): Promise<...> }` | the plugin's `MCPKeyStore` | Signing-key source. Override for tests.                                                                                                       |
+
+A request whose path exceeds 2048 characters is rejected before any token work
+(DoS guard). If MCP is disabled, no token is presented, or no signing keys exist
+yet, the wrapper denies — it never serves a guarded route in an unconfigured state.
+
+### Using `withMCPAuth` from a different component than the plugin
+
+By default `withMCPAuth` reads the live MCP config from the plugin via
+`OAuthResource.mcpConfig`. That works when the component that **declares**
+`@harperfast/oauth` is the same one that exposes the MCP route. If your MCP tools
+live in a **separate** component (it imports `withMCPAuth` as a function but
+doesn't declare the plugin in its own `config.yaml`), that consumer resolves its
+**own** `node_modules` copy of the package, where `OAuthResource.mcpConfig` is a
+module-local static that is never populated — so it reads as `undefined` and the
+guard fails closed.
+
+In that setup, **inject `getConfig`** so the wrapper sees the config:
+
+```typescript
+server.http(
+	withMCPAuth(mcpHandler, {
+		// Pin issuer/resource to the values the plugin component issues tokens with,
+		// so the iss/aud checks match the minted tokens.
+		getConfig: () => ({
+			enabled: true,
+			issuer: 'https://my-app.example.com',
+			resource: 'https://my-app.example.com/mcp',
+		}),
+	}),
+	{ urlPath: '/mcp' }
+);
+```
+
+Signing keys need no extra wiring: the default `MCPKeyStore` reads
+`databases.oauth.harper_oauth_mcp_keys`, which is cluster-global, so the consumer
+verifies against the same JWKS the plugin component mints with. Importing
+`withMCPAuth` as a function does **not** spin up a second plugin instance.
+
+---
+
+## The `onMCPTokenIssued` hook
+
+Register `onMCPTokenIssued` to react in your own application each time an access
+or refresh token is minted. It is the MCP-client analog of [`onLogin`](./lifecycle-hooks.md#onlogin):
+where `onLogin` lets you provision a user on human sign-in, this lets you record
+and respond to an MCP client gaining access. Typical uses:
+
+- **Associate the client with a user** — link the `client_id` to `sub` in your
+  own data model so you know which MCP clients are acting for which users.
+- **Monitoring and security** — track active clients, or alert when a new or
+  unexpected `client_id` obtains a token.
+- **Rate-limiting / quota** — count issuance per `client_id`.
+
+(The built-in [audit log](#audit-events) already records that a token was issued —
+reach for this hook when you need to act on it, not just log it.)
+
+```typescript
+import { registerHooks } from '@harperfast/oauth';
+
+registerHooks({
+	onMCPTokenIssued: async (event, request) => {
+		// event = { type: 'access' | 'refresh', client_id, sub, aud, scope?, jti }
+		// Record which MCP client is acting for which user.
+		await tables.McpClient.put({ id: event.client_id, user: event.sub, lastSeen: Date.now() });
+	},
+});
+```
+
+It fires **after** the token is durably issued, **before** the response returns.
+It is fire-and-forget: a throwing hook is caught and logged, never blocking token
+issuance.
+
+> **Security:** `event` is sanitized — it carries only the `jti` (a token
+> identifier, safe to log), never the access/refresh token strings. The `request`
+> is **not** sanitized: on the refresh path its body carries the `refresh_token`
+> the client presented. Do not log `request` wholesale.
+
+See [Lifecycle Hooks](./lifecycle-hooks.md) for `registerHooks` and the other hooks.
+
+---
+
+## Audit events
+
+Token lifecycle events are written to Harper's structured log (`hdb.log`) at
+`info`, each line prefixed `MCP audit:` with a JSON payload:
+
+```
+MCP audit: {"event":"oauth.mcp.token.issued","client_id":"…","sub":"…","aud":"https://my-app.example.com/mcp","scope":"…","jti":"…","timestamp":"2026-06-29T17:00:00.000Z"}
+```
+
+| `event`                     | When                                                  |
+| --------------------------- | ----------------------------------------------------- |
+| `oauth.mcp.token.issued`    | An access token was minted (authorization-code grant) |
+| `oauth.mcp.token.refreshed` | A token pair was rotated (refresh-token grant)        |
+| `oauth.mcp.token.rejected`  | A bearer token was rejected by `withMCPAuth`          |
+
+Payloads carry only the `jti` — never `access_token`, `refresh_token`, or
+`client_secret`. Filter your log aggregator on the `MCP audit:` prefix or the
+`event` value. Dynamic Client Registration attempts are logged separately by the
+`/register` handler.
+
+---
+
+## Production deployment
+
+A checklist before you expose MCP OAuth publicly:
+
+- [ ] **HTTPS.** Serve everything over TLS. OAuth bearer tokens are only as safe
+      as the transport.
+- [ ] **Pin `mcp.issuer`** to your public origin (e.g. `https://my-app.example.com`).
+      It is required when `mcp.enabled` — the plugin refuses to start without it —
+      because otherwise `iss` (and `aud`, which derives from it) would float with
+      the client-controlled `Host` header, an audience-confusion risk. Pinning
+      `resource` alone is not enough; `iss` still floats.
+- [ ] **Gate Dynamic Client Registration.** `/register` is open by default per
+      RFC 7591. Set `mcp.dynamicClientRegistration.initialAccessToken` to require
+      a bearer token, or accept open registration deliberately.
+- [ ] **Restrict redirect URI hosts** with
+      `mcp.dynamicClientRegistration.allowedRedirectUriHosts`. Loopback is always
+      allowed for native clients (RFC 8252).
+- [ ] **Set `mcp.signingKeyPem` in clusters.** The signing key is a single row at
+      a fixed key id. Without a configured PEM, two nodes can each generate a
+      different key on first mint and sign tokens the published JWKS doesn't list
+      until replication converges. Provide the **same** PEM on every node.
+- [ ] **Resolve to exactly one provider.** v1 requires a single eligible upstream
+      provider. If you configure more than one globally, set `mcp.providers` to the
+      one that should serve the MCP flow, or `/oauth/mcp/authorize` returns
+      `server_error`.
+
+See [Configuration → MCP OAuth](./configuration.md#mcp-oauth) for the full option
+table.
+
+---
+
+## Troubleshooting
+
+**Client can't discover the server / "could not find authorization server".**
+Confirm `mcp.enabled: true` and that `GET /.well-known/oauth-protected-resource`
+and `GET /.well-known/oauth-authorization-server` return `200`. If your `resource`
+has a path, the client may be looking at the path-appended PRM location — both are
+served.
+
+**Client gets `WWW-Authenticate: Basic` instead of `Bearer`.** Core Harper auth
+ran ahead of `withMCPAuth`. Register the guarded route on a `urlPath` subroute, or
+use the default-group fallback with `{ before: 'authentication' }`. See
+[Registration](#registration).
+
+**Token verification fails right after enabling MCP.** `GET /.well-known/jwks.json`
+returns an empty key set until the first token is minted — the signing key is
+created lazily. Complete one authorization flow and the key (and JWKS entry)
+appear. In a cluster, an empty or mismatched JWKS after traffic usually means
+`mcp.signingKeyPem` isn't pinned (see [Production deployment](#production-deployment)).
+
+**`/oauth/mcp/authorize` returns `server_error`.** More than one upstream provider
+resolved as eligible. Set `mcp.providers` to exactly one.
+
+**`/oauth/mcp/authorize` returns `invalid_request` for `code_challenge_method`.**
+Only `S256` is accepted — OAuth 2.1 forbids `plain`.
+
+**Registration returns `401`.** `mcp.dynamicClientRegistration.initialAccessToken`
+is set and the client didn't present a matching `Authorization: Bearer <token>`.
+
+**Reading the audit trail.** Grep `hdb.log` for `MCP audit:` (see
+[Audit events](#audit-events)).
+
+---
+
+## Migrating from a hand-rolled MCP authorization server
+
+If your app already implements MCP OAuth by hand, swap your pieces for the
+plugin's:
+
+| You had                                                                   | Replace with                                                         |
+| ------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Custom `/.well-known/*`, `/register`, `/authorize`, `/token`, JWKS routes | `mcp.enabled: true` — the plugin serves all of them                  |
+| Your own bearer-token verification middleware                             | `withMCPAuth(handler)` on the MCP route                              |
+| Side effects on token mint (client tracking, monitoring, audit)           | The `onMCPTokenIssued` hook + the built-in `MCP audit:` log events   |
+| A hand-managed signing key                                                | `mcp.signingKeyPem` (or let the plugin generate one for single-node) |
+
+Point your MCP clients at the same route; they rediscover the endpoints via the
+`WWW-Authenticate` challenge and re-register.
+
+---
+
+## Not yet supported (v1.1+)
+
+These are **not** available and no config or code sample here implies them:
+
+- Per-tool / fine-grained scopes (the `scope` claim is passed through, not enforced per tool)
+- Transitive revocation (revoking the upstream IdP session does not invalidate already-issued MCP tokens)
+- Signing algorithms other than RS256, and multi-key JWKS / key rotation
+- A native, composed MCP server (this plugin is the authorization server, not the MCP transport)

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -48,6 +48,7 @@ route handler with `withMCPAuth`.
 **2. Guard your MCP handler** (`resources.ts`):
 
 ```typescript
+import { server } from 'harper';
 import { withMCPAuth } from '@harperfast/oauth';
 
 // Your MCP endpoint. request.mcp is populated only after a valid bearer token.

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -158,8 +158,9 @@ discovery handlers fall through).
 All three send `Access-Control-Allow-Origin: *` so browser-based clients and
 discovery tools can fetch them cross-origin. When `mcp.resource` carries a path
 (e.g. `https://host/mcp`), the Protected Resource Metadata document is **also**
-served at the RFC 9728 path-appended location `/mcp/.well-known/oauth-protected-resource`,
-which is the form the `WWW-Authenticate` challenge advertises.
+served at the RFC 9728 path-appended location `/.well-known/oauth-protected-resource/mcp`
+(the well-known segment sits between the origin and the resource path), which is the
+form the `WWW-Authenticate` challenge advertises.
 
 ### Authorization server
 
@@ -203,7 +204,7 @@ On any failure it **fails closed** with the spec 401:
 
 ```
 HTTP/1.1 401 Unauthorized
-WWW-Authenticate: Bearer resource_metadata="https://my-app.example.com/mcp/.well-known/oauth-protected-resource"
+WWW-Authenticate: Bearer resource_metadata="https://my-app.example.com/.well-known/oauth-protected-resource/mcp"
 Content-Type: application/json
 
 {"error":"invalid_token","error_description":"<reason>"}


### PR DESCRIPTION
Closes #98 — Stage 8 of the MCP OAuth epic (#86). App-author documentation for MCP OAuth.

Its dependencies — #134 (`withMCPAuth`) and #141 (audit + `onMCPTokenIssued`) — are both merged, so this is unblocked. Docs-only; merges cleanly into current `main` (#141 touched no docs).

## What's added / changed

- **`docs/mcp-oauth.md`** (new) — the single deep guide: end-to-end flow diagram, endpoint reference (discovery / authorize / token / JWKS), the `withMCPAuth` wrapper (both registration models, options, cross-component use via `getConfig`), the `onMCPTokenIssued` hook, audit events (all three types, incl. `oauth.mcp.token.rejected`), a production-deployment checklist, troubleshooting, and a migration guide from a hand-rolled MCP authorization server. Links the [MCP authorization spec (2025-06-18)](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) and RFCs 6749/6750/7591/7636/8252/8414/8707/9728.
- **`README.md`** — MCP OAuth section trimmed to a quickstart (config + `withMCPAuth`) plus a pointer to `docs/mcp-oauth.md`; added the doc to the index.
- **`docs/configuration.md`** — dropped the "(work in progress)" marker; documented `signingKeyPem`, `signingAlgorithm`, `accessTokenTtl`, `refreshTokenTtl`; fixed the JWKS note; trimmed the inline `withMCPAuth` how-to to a pointer + a security note.
- **`docs/lifecycle-hooks.md`** — documented `onMCPTokenIssued` (the MCP-client analog of `onLogin`), reflecting #141's **fire-and-forget / not-awaited** behavior.

## Design: single source of truth

#134 had already landed `withMCPAuth` walkthroughs in **both** `README.md` and `docs/configuration.md`. To avoid three copies that drift, the deep wrapper/flow/hook material now lives **once** in `docs/mcp-oauth.md`; `README.md` and `configuration.md` carry short pointers into it (so those two files are net-trimmed here).

## Notes

- Docs-only; no code changes.
- `prettier --check` clean; all internal anchors resolve.
- No v1.1 features advertised — per-tool scopes and transitive revocation are explicitly listed as not-yet-supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
