### PR TITLE
Release 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@harperfast/oauth",
-			"version": "2.0.0",
+			"version": "2.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"description": "OAuth 2.0 authentication plugin for Harper",
 	"license": "Apache-2.0",
 	"author": {


### PR DESCRIPTION
## Release 2.1.0

Completes **MCP OAuth v1** on the Harper v5 line (`2.0.0` → `2.1.0`, minor — all additive). MCP OAuth remains **experimental and opt-in** (`mcp.enabled`).

### Added (MCP OAuth epic #86)

- **`withMCPAuth` bearer-token guard** (#95/#134) — wrap an app-owned MCP route so every request must present a valid RS256 access token; fails closed with the RFC 9728 `WWW-Authenticate: Bearer resource_metadata` challenge, attaches verified claims as `request.mcp`.
- **Audit logging + `onMCPTokenIssued` hook** (#96/#141) — structured `MCP audit:` events (`oauth.mcp.token.issued` / `refreshed` / `rejected`, secret-free) and a fire-and-forget lifecycle hook for reacting to token issuance (client↔user mapping, metering, monitoring).
- **End-to-end conformance test** (#97/#145) — full discovery → DCR → authorize → token → bearer-auth round-trip against a booted Harper with a stub IdP, plus the spec/security negatives; runs in the existing integration suite (Node 22 + 24).
- **User-facing docs** (#98/#144) — `docs/mcp-oauth.md` (flow, endpoints, wrapper, hook, audit, production checklist, troubleshooting), refreshed README + configuration reference.

Combined with the discovery / DCR / authorize / token endpoints already in 2.0.0, an unmodified MCP client (Claude Desktop, Cursor, `mcp-remote`) can now complete the OAuth flow against a Harper app configured with `@harperfast/oauth` — the #86 v1 acceptance bar.

### Release mechanics

Merging this bumps `package.json` to 2.1.0. Publishing a GitHub Release tagged `v2.1.0` triggers `release.yml`, which publishes to npm `latest` via OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
