### PR TITLE
Emit RFC 9207 iss on MCP authorization responses

### DIFF
--- a/integrationTests/mcp-oauth-e2e.test.ts
+++ b/integrationTests/mcp-oauth-e2e.test.ts
@@ -251,6 +251,12 @@ suite('MCP OAuth Stage 7: full round-trip e2e', (ctx: ContextWithHarper) => {
 			'must support S256 code challenge method'
 		);
 		strictEqual(meta.resource_parameter_supported, true, 'must advertise resource_parameter_supported: true');
+		// RFC 9207: server must declare that it emits iss on authorization responses.
+		strictEqual(
+			meta.authorization_response_iss_parameter_supported,
+			true,
+			'must advertise authorization_response_iss_parameter_supported: true (RFC 9207)'
+		);
 	});
 
 	// ── Steps 4-9: full round-trip ────────────────────────────────────────────
@@ -333,6 +339,8 @@ suite('MCP OAuth Stage 7: full round-trip e2e', (ctx: ContextWithHarper) => {
 		ok(mcpCode, 'final redirect must carry a code');
 		const returnedState = finalUrl.searchParams.get('state');
 		strictEqual(returnedState, clientState, 'state must round-trip unchanged');
+		// RFC 9207: iss must equal the configured issuer on the success authorization response.
+		strictEqual(finalUrl.searchParams.get('iss'), 'https://mcp.test', 'iss must equal the configured issuer');
 
 		// ── Step 7: Token exchange ──────────────────────────────────────────────
 		const tokenRes = await fetch(`${base}/oauth/mcp/token`, {
@@ -446,6 +454,8 @@ suite('MCP OAuth Stage 7: full round-trip e2e', (ctx: ContextWithHarper) => {
 		const params = parseQuery(loc);
 		const error = params.get('error');
 		strictEqual(error, 'invalid_request', `plain PKCE must be rejected with error=invalid_request; got: ${loc}`);
+		// RFC 9207: iss must appear on Phase-2 error redirects too.
+		strictEqual(params.get('iss'), 'https://mcp.test', `iss must be present on error redirect; got: ${loc}`);
 	});
 
 	test('negative: missing resource at /authorize → rejected', async () => {

--- a/src/lib/handlers.ts
+++ b/src/lib/handlers.ts
@@ -125,9 +125,9 @@ export async function handleCallback(
 	config: OAuthProviderConfig,
 	hookManager: HookManager,
 	providerName: string,
-	mcpConfig: MCPConfig | undefined,
-	logger?: Logger
+	opts?: { mcpConfig?: MCPConfig; logger?: Logger }
 ): Promise<any> {
+	const { mcpConfig, logger } = opts ?? {};
 	// Get query parameters from target
 	const code = target.get?.('code');
 	const state = target.get?.('state');

--- a/src/lib/handlers.ts
+++ b/src/lib/handlers.ts
@@ -8,8 +8,9 @@ import { readFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { RequestTarget } from 'harper';
-import type { Request, Logger, IOAuthProvider, MCPAuthorizeState, OAuthProviderConfig } from '../types.ts';
+import type { Request, Logger, IOAuthProvider, MCPAuthorizeState, MCPConfig, OAuthProviderConfig } from '../types.ts';
 import { handleMCPCallback } from './mcp/index.ts';
+import { resolveIssuer } from './mcp/wellKnown.ts';
 import type { HookManager } from './hookManager.ts';
 
 /**
@@ -124,6 +125,7 @@ export async function handleCallback(
 	config: OAuthProviderConfig,
 	hookManager: HookManager,
 	providerName: string,
+	mcpConfig: MCPConfig | undefined,
 	logger?: Logger
 ): Promise<any> {
 	// Get query parameters from target
@@ -136,11 +138,13 @@ export async function handleCallback(
 	// Only used in MCP branches — the human path keeps its existing
 	// buildErrorRedirect shape (error code only, optionally with reason) to
 	// avoid changing observable behavior on the human OAuth flow.
+	// RFC 9207: include `iss` on all authorization responses, including errors.
 	const mcpErrorRedirect = (mcp: MCPAuthorizeState, errorCode: string, description: string) => {
 		const url = new URL(mcp.redirectUri);
 		url.searchParams.set('error', errorCode);
 		url.searchParams.set('error_description', description);
 		if (mcp.clientState) url.searchParams.set('state', mcp.clientState);
+		if (mcpConfig) url.searchParams.set('iss', resolveIssuer(request as any, mcpConfig));
 		return { status: 302, headers: { Location: url.toString() } };
 	};
 
@@ -255,7 +259,7 @@ export async function handleCallback(
 		// JWT exchanged for it in Stage 4) is bound to the correct identity.
 		if (mcpState) {
 			const userIdentifier = hookData?.user ?? user.username;
-			return handleMCPCallback(request, mcpState, userIdentifier, logger);
+			return handleMCPCallback(request, mcpState, userIdentifier, mcpConfig ?? {}, logger);
 		}
 
 		// Store in session if available

--- a/src/lib/handlers.ts
+++ b/src/lib/handlers.ts
@@ -144,7 +144,7 @@ export async function handleCallback(
 		url.searchParams.set('error', errorCode);
 		url.searchParams.set('error_description', description);
 		if (mcp.clientState) url.searchParams.set('state', mcp.clientState);
-		if (mcpConfig) url.searchParams.set('iss', resolveIssuer(request as any, mcpConfig));
+		url.searchParams.set('iss', resolveIssuer(request as any, mcpConfig ?? {}));
 		return { status: 302, headers: { Location: url.toString() } };
 	};
 

--- a/src/lib/mcp/authorize.ts
+++ b/src/lib/mcp/authorize.ts
@@ -29,7 +29,7 @@ import type {
 	Request,
 } from '../../types.ts';
 import { MCPClientStore } from './clientStore.ts';
-import { resolveResource } from './wellKnown.ts';
+import { resolveIssuer, resolveResource } from './wellKnown.ts';
 
 type ErrorJSON = {
 	status: 400 | 500;
@@ -133,12 +133,14 @@ function buildClientErrorRedirect(
 	redirectUri: string,
 	error: string,
 	description: string,
-	clientState: string | undefined
+	clientState: string | undefined,
+	issuer: string
 ): Redirect {
 	const url = new URL(redirectUri);
 	url.searchParams.set('error', error);
 	url.searchParams.set('error_description', description);
 	if (clientState) url.searchParams.set('state', clientState);
+	url.searchParams.set('iss', issuer);
 	return { status: 302, headers: { Location: url.toString() } };
 }
 
@@ -223,9 +225,11 @@ export async function handleAuthorize(
 	}
 
 	const clientState = query.state;
+	const issuer = resolveIssuer(request as any, mcpConfig);
 	// Phase 2: everything else redirects to the verified client redirect_uri.
+	// RFC 9207: `iss` is included on all Phase-2 error redirects.
 	const redirect = (error: string, description: string) =>
-		buildClientErrorRedirect(query.redirect_uri as string, error, description, clientState);
+		buildClientErrorRedirect(query.redirect_uri as string, error, description, clientState, issuer);
 
 	if (query.response_type !== 'code') {
 		return redirect('unsupported_response_type', 'response_type must be "code"');

--- a/src/lib/mcp/callback.ts
+++ b/src/lib/mcp/callback.ts
@@ -18,18 +18,25 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import type { Logger, MCPAuthCodeRecord, MCPAuthorizeState, Request } from '../../types.ts';
+import type { Logger, MCPAuthCodeRecord, MCPAuthorizeState, MCPConfig, Request } from '../../types.ts';
 import { MCPAuthCodeStore } from './authCodeStore.ts';
+import { resolveIssuer } from './wellKnown.ts';
 
 type Redirect = {
 	status: 302;
 	headers: { Location: string };
 };
 
-function buildSuccessRedirect(redirectUri: string, code: string, clientState: string | undefined): Redirect {
+function buildSuccessRedirect(
+	redirectUri: string,
+	code: string,
+	clientState: string | undefined,
+	issuer: string
+): Redirect {
 	const url = new URL(redirectUri);
 	url.searchParams.set('code', code);
 	if (clientState) url.searchParams.set('state', clientState);
+	url.searchParams.set('iss', issuer);
 	return { status: 302, headers: { Location: url.toString() } };
 }
 
@@ -37,12 +44,14 @@ function buildErrorRedirect(
 	redirectUri: string,
 	error: string,
 	description: string,
-	clientState: string | undefined
+	clientState: string | undefined,
+	issuer: string
 ): Redirect {
 	const url = new URL(redirectUri);
 	url.searchParams.set('error', error);
 	url.searchParams.set('error_description', description);
 	if (clientState) url.searchParams.set('state', clientState);
+	url.searchParams.set('iss', issuer);
 	return { status: 302, headers: { Location: url.toString() } };
 }
 
@@ -54,15 +63,16 @@ function buildErrorRedirect(
  * human-session branch would apply is also reflected on the auth code
  * (and downstream JWT in Stage 4).
  *
- * `request` is unused today but accepted for signature parity with the
- * human-session branch — Stage 6 audit hooks will read from it.
+ * `mcpConfig` is used to resolve the issuer (RFC 9207 `iss` on the redirect).
  */
 export async function handleMCPCallback(
-	_request: Request,
+	request: Request,
 	mcpState: MCPAuthorizeState,
 	userIdentifier: string,
+	mcpConfig: MCPConfig,
 	logger?: Logger
 ): Promise<Redirect> {
+	const issuer = resolveIssuer(request as any, mcpConfig);
 	const code = randomBytes(32).toString('base64url');
 	const record: MCPAuthCodeRecord = {
 		code,
@@ -85,10 +95,11 @@ export async function handleMCPCallback(
 			mcpState.redirectUri,
 			'server_error',
 			'Failed to persist authorization code',
-			mcpState.clientState
+			mcpState.clientState,
+			issuer
 		);
 	}
 
 	logger?.info?.(`MCP callback: minted auth code for client=${mcpState.clientId} user=${userIdentifier}`);
-	return buildSuccessRedirect(mcpState.redirectUri, code, mcpState.clientState);
+	return buildSuccessRedirect(mcpState.redirectUri, code, mcpState.clientState, issuer);
 }

--- a/src/lib/mcp/wellKnown.ts
+++ b/src/lib/mcp/wellKnown.ts
@@ -166,8 +166,8 @@ export function buildAuthorizationServerMetadata(
 		id_token_signing_alg_values_supported: ['RS256'],
 		// RFC 8707 §2: server understands the `resource` parameter.
 		resource_parameter_supported: true,
-		// CORS-friendly metadata is the spec norm; we serve cross-origin reads.
-		// (No spec-mandated field for this — included as a hint for proxy configs.)
+		// RFC 9207: server emits `iss` on every authorization response redirect.
+		authorization_response_iss_parameter_supported: true,
 	};
 }
 

--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -403,16 +403,10 @@ export class OAuthResource extends Resource {
 				return handleLogin(request, target, provider, config, providerName, logger);
 
 			case 'callback':
-				return handleCallback(
-					request,
-					target,
-					provider,
-					config,
-					hookManager,
-					providerName,
-					OAuthResource.mcpConfig,
-					logger
-				);
+				return handleCallback(request, target, provider, config, hookManager, providerName, {
+					mcpConfig: OAuthResource.mcpConfig,
+					logger,
+				});
 
 			case 'user':
 				return handleUserInfo(request, false);

--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -403,7 +403,16 @@ export class OAuthResource extends Resource {
 				return handleLogin(request, target, provider, config, providerName, logger);
 
 			case 'callback':
-				return handleCallback(request, target, provider, config, hookManager, providerName, logger);
+				return handleCallback(
+					request,
+					target,
+					provider,
+					config,
+					hookManager,
+					providerName,
+					OAuthResource.mcpConfig,
+					logger
+				);
 
 			case 'user':
 				return handleUserInfo(request, false);

--- a/test/lib/handlers.test.js
+++ b/test/lib/handlers.test.js
@@ -2,7 +2,7 @@
  * Tests for OAuth Handlers
  */
 
-import { describe, it, beforeEach } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { handleLogin, handleCallback, handleLogout, handleUserInfo, handleTestPage } from '../../dist/lib/handlers.js';
 import { createMockFn, createMockLogger } from '../helpers/mockFn.js';
@@ -730,7 +730,11 @@ describe('OAuth Handlers', () => {
 			}));
 		});
 
-		// Restore after each test block via the outer afterEach (no-op if global.databases survives — we use a fresh object each time).
+		// Restore global.databases in afterEach so a failing assertion mid-test
+		// doesn't pollute later tests in this describe block.
+		afterEach(() => {
+			global.databases = originalDatabases;
+		});
 
 		it('on success, mints auth code and redirects to MCP client redirect_uri', async () => {
 			const result = await handleCallback(
@@ -749,7 +753,6 @@ describe('OAuth Handlers', () => {
 			assert.ok(url.searchParams.get('code'));
 			assert.equal(url.searchParams.get('state'), MCP_STATE.clientState);
 			assert.equal(storedAuthCodes.size, 1);
-			global.databases = originalDatabases;
 		});
 
 		it('includes iss on success redirect (RFC 9207, handler-level)', async () => {
@@ -765,7 +768,6 @@ describe('OAuth Handlers', () => {
 			);
 			const url = new URL(result.headers.Location);
 			assert.equal(url.searchParams.get('iss'), MCP_CONFIG.issuer, 'iss must equal the configured issuer on success');
-			global.databases = originalDatabases;
 		});
 
 		it('includes iss on error redirect (RFC 9207, handler-level mcpErrorRedirect)', async () => {
@@ -789,7 +791,6 @@ describe('OAuth Handlers', () => {
 			);
 			const url = new URL(result.headers.Location);
 			assert.equal(url.searchParams.get('iss'), MCP_CONFIG.issuer, 'iss must appear on MCP error redirects');
-			global.databases = originalDatabases;
 		});
 
 		it('binds the auth code to onLogin-mapped user (hookData.user wins over OAuth username)', async () => {
@@ -807,7 +808,6 @@ describe('OAuth Handlers', () => {
 			assert.equal(result.status, 302);
 			const [record] = storedAuthCodes.values();
 			assert.equal(record.user, 'internal-user-id-42');
-			global.databases = originalDatabases;
 		});
 
 		it('routes upstream IdP error to MCP client redirect_uri (not Harper postLoginRedirect)', async () => {
@@ -834,7 +834,6 @@ describe('OAuth Handlers', () => {
 			assert.equal(url.origin + url.pathname, MCP_STATE.redirectUri);
 			assert.equal(url.searchParams.get('error'), 'access_denied');
 			assert.equal(url.searchParams.get('state'), MCP_STATE.clientState);
-			global.databases = originalDatabases;
 		});
 
 		it('routes cross-provider state mismatch to MCP redirect_uri', async () => {
@@ -857,7 +856,6 @@ describe('OAuth Handlers', () => {
 			const url = new URL(result.headers.Location);
 			assert.equal(url.origin + url.pathname, MCP_STATE.redirectUri);
 			assert.equal(url.searchParams.get('error'), 'invalid_request');
-			global.databases = originalDatabases;
 		});
 
 		it('does NOT include upstream IdP token in MCP redirect URL', async () => {
@@ -875,7 +873,6 @@ describe('OAuth Handlers', () => {
 			for (const banned of ['access_token', 'refresh_token', 'id_token', 'token_type', 'access-token-123']) {
 				assert.ok(!location.includes(banned), `${banned} must not appear in MCP redirect URL`);
 			}
-			global.databases = originalDatabases;
 		});
 
 		it('does NOT create a Harper session on the MCP branch (independent lifecycle)', async () => {
@@ -891,7 +888,6 @@ describe('OAuth Handlers', () => {
 			);
 			// session.update must not have been called for the MCP branch
 			assert.equal(mockRequest.session.update.mock.calls.length, 0);
-			global.databases = originalDatabases;
 		});
 
 		it('onLogin fires for MCP-initiated auth (bridged authorize/callback flow)', async () => {
@@ -921,7 +917,6 @@ describe('OAuth Handlers', () => {
 			assert.ok(oauthUser.username, 'user object forwarded to onLogin');
 			assert.ok(tokenResponse, 'token response forwarded to onLogin');
 			assert.equal(providerName, 'test-provider');
-			global.databases = originalDatabases;
 		});
 	});
 

--- a/test/lib/handlers.test.js
+++ b/test/lib/handlers.test.js
@@ -162,8 +162,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -175,16 +174,9 @@ describe('OAuth Handlers', () => {
 		});
 
 		it('should update session with user data', async () => {
-			await handleCallback(
-				mockRequest,
-				mockTarget,
-				mockProvider,
-				mockConfig,
-				mockHookManager,
-				'test-provider',
-				undefined,
-				mockLogger
-			);
+			await handleCallback(mockRequest, mockTarget, mockProvider, mockConfig, mockHookManager, 'test-provider', {
+				logger: mockLogger,
+			});
 
 			const updateCall = mockRequest.session.update.mock.calls[0];
 			assert.equal(updateCall.arguments[0].user, 'user@example.com');
@@ -209,8 +201,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -227,8 +218,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -245,8 +235,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -268,8 +257,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -287,8 +275,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -302,16 +289,9 @@ describe('OAuth Handlers', () => {
 				id_token: 'id-token-jwt',
 			}));
 
-			await handleCallback(
-				mockRequest,
-				mockTarget,
-				mockProvider,
-				mockConfig,
-				mockHookManager,
-				'test-provider',
-				undefined,
-				mockLogger
-			);
+			await handleCallback(mockRequest, mockTarget, mockProvider, mockConfig, mockHookManager, 'test-provider', {
+				logger: mockLogger,
+			});
 
 			assert.equal(mockProvider.verifyIdToken.mock.calls.length, 1);
 			assert.equal(mockProvider.verifyIdToken.mock.calls[0].arguments[0], 'id-token-jwt');
@@ -333,8 +313,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			// Should still succeed, falling back to userinfo endpoint
@@ -354,8 +333,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -378,8 +356,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -399,8 +376,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -419,8 +395,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -446,8 +421,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -477,8 +451,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -503,8 +476,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -525,8 +497,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -556,8 +527,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -578,8 +548,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			assert.equal(result.status, 302);
@@ -603,8 +572,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'target-company', // But callback is for this provider
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			// Should reject with error - redirects to original URL with error params
@@ -633,8 +601,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'acme-corp', // Same provider
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			// Should succeed
@@ -664,8 +631,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'target-company',
-				undefined,
-				mockLogger
+				{ logger: mockLogger }
 			);
 
 			// Attack should be blocked - redirects to original URL with error params
@@ -683,16 +649,9 @@ describe('OAuth Handlers', () => {
 				providerName: 'acme-corp',
 			}));
 
-			await handleCallback(
-				mockRequest,
-				mockTarget,
-				mockProvider,
-				mockConfig,
-				mockHookManager,
-				'acme-corp',
-				undefined,
-				mockLogger
-			);
+			await handleCallback(mockRequest, mockTarget, mockProvider, mockConfig, mockHookManager, 'acme-corp', {
+				logger: mockLogger,
+			});
 
 			const updateCall = mockRequest.session.update.mock.calls[0];
 			// Provider should be the registry key (providerName), not the provider type
@@ -759,8 +718,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				MCP_CONFIG,
-				mockLogger
+				{ mcpConfig: MCP_CONFIG, logger: mockLogger }
 			);
 			assert.equal(result.status, 302);
 			const url = new URL(result.headers.Location);
@@ -778,8 +736,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				MCP_CONFIG,
-				mockLogger
+				{ mcpConfig: MCP_CONFIG, logger: mockLogger }
 			);
 			const url = new URL(result.headers.Location);
 			assert.equal(url.searchParams.get('iss'), MCP_CONFIG.issuer, 'iss must equal the configured issuer on success');
@@ -801,8 +758,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				MCP_CONFIG,
-				mockLogger
+				{ mcpConfig: MCP_CONFIG, logger: mockLogger }
 			);
 			const url = new URL(result.headers.Location);
 			assert.equal(url.searchParams.get('iss'), MCP_CONFIG.issuer, 'iss must appear on MCP error redirects');
@@ -817,8 +773,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				MCP_CONFIG,
-				mockLogger
+				{ mcpConfig: MCP_CONFIG, logger: mockLogger }
 			);
 			assert.equal(result.status, 302);
 			const [record] = storedAuthCodes.values();
@@ -841,8 +796,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				MCP_CONFIG,
-				mockLogger
+				{ mcpConfig: MCP_CONFIG, logger: mockLogger }
 			);
 			assert.equal(result.status, 302);
 			const url = new URL(result.headers.Location);
@@ -864,8 +818,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				MCP_CONFIG,
-				mockLogger
+				{ mcpConfig: MCP_CONFIG, logger: mockLogger }
 			);
 			assert.equal(result.status, 302);
 			const url = new URL(result.headers.Location);
@@ -881,8 +834,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				MCP_CONFIG,
-				mockLogger
+				{ mcpConfig: MCP_CONFIG, logger: mockLogger }
 			);
 			const location = result.headers.Location;
 			for (const banned of ['access_token', 'refresh_token', 'id_token', 'token_type', 'access-token-123']) {
@@ -891,16 +843,10 @@ describe('OAuth Handlers', () => {
 		});
 
 		it('does NOT create a Harper session on the MCP branch (independent lifecycle)', async () => {
-			await handleCallback(
-				mockRequest,
-				mockTarget,
-				mockProvider,
-				mockConfig,
-				mockHookManager,
-				'test-provider',
-				MCP_CONFIG,
-				mockLogger
-			);
+			await handleCallback(mockRequest, mockTarget, mockProvider, mockConfig, mockHookManager, 'test-provider', {
+				mcpConfig: MCP_CONFIG,
+				logger: mockLogger,
+			});
 			// session.update must not have been called for the MCP branch
 			assert.equal(mockRequest.session.update.mock.calls.length, 0);
 		});
@@ -915,16 +861,10 @@ describe('OAuth Handlers', () => {
 				callOnLogin: onLoginMock,
 			};
 
-			await handleCallback(
-				mockRequest,
-				mockTarget,
-				mockProvider,
-				mockConfig,
-				trackingHookManager,
-				'test-provider',
-				MCP_CONFIG,
-				mockLogger
-			);
+			await handleCallback(mockRequest, mockTarget, mockProvider, mockConfig, trackingHookManager, 'test-provider', {
+				mcpConfig: MCP_CONFIG,
+				logger: mockLogger,
+			});
 
 			assert.equal(onLoginMock.mock.calls.length, 1, 'callOnLogin fired exactly once on the MCP path');
 			// The hook receives the mapped Harper user, the upstream token response, the session, the request, and the provider name.

--- a/test/lib/handlers.test.js
+++ b/test/lib/handlers.test.js
@@ -563,6 +563,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -587,6 +588,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'target-company', // But callback is for this provider
+				undefined,
 				mockLogger
 			);
 
@@ -699,6 +701,11 @@ describe('OAuth Handlers', () => {
 			clientState: 'mcp-state-xyz',
 		};
 
+		const MCP_CONFIG = {
+			issuer: 'https://as.example.com',
+			enabled: true,
+		};
+
 		beforeEach(async () => {
 			({ resetMCPAuthCodesTableCache } = await import('../../dist/lib/mcp/authCodeStore.js'));
 			resetMCPAuthCodesTableCache();
@@ -733,6 +740,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				MCP_CONFIG,
 				mockLogger
 			);
 			assert.equal(result.status, 302);
@@ -741,6 +749,46 @@ describe('OAuth Handlers', () => {
 			assert.ok(url.searchParams.get('code'));
 			assert.equal(url.searchParams.get('state'), MCP_STATE.clientState);
 			assert.equal(storedAuthCodes.size, 1);
+			global.databases = originalDatabases;
+		});
+
+		it('includes iss on success redirect (RFC 9207, handler-level)', async () => {
+			const result = await handleCallback(
+				mockRequest,
+				mockTarget,
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				MCP_CONFIG,
+				mockLogger
+			);
+			const url = new URL(result.headers.Location);
+			assert.equal(url.searchParams.get('iss'), MCP_CONFIG.issuer, 'iss must equal the configured issuer on success');
+			global.databases = originalDatabases;
+		});
+
+		it('includes iss on error redirect (RFC 9207, handler-level mcpErrorRedirect)', async () => {
+			mockTarget.get = createMockFn((key) => {
+				const params = {
+					state: 'csrf-token-123',
+					error: 'access_denied',
+					error_description: 'User denied authorization',
+				};
+				return params[key];
+			});
+			const result = await handleCallback(
+				mockRequest,
+				mockTarget,
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				MCP_CONFIG,
+				mockLogger
+			);
+			const url = new URL(result.headers.Location);
+			assert.equal(url.searchParams.get('iss'), MCP_CONFIG.issuer, 'iss must appear on MCP error redirects');
 			global.databases = originalDatabases;
 		});
 
@@ -753,6 +801,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				MCP_CONFIG,
 				mockLogger
 			);
 			assert.equal(result.status, 302);
@@ -777,6 +826,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				MCP_CONFIG,
 				mockLogger
 			);
 			assert.equal(result.status, 302);
@@ -800,6 +850,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				MCP_CONFIG,
 				mockLogger
 			);
 			assert.equal(result.status, 302);
@@ -817,6 +868,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				MCP_CONFIG,
 				mockLogger
 			);
 			const location = result.headers.Location;
@@ -834,6 +886,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				MCP_CONFIG,
 				mockLogger
 			);
 			// session.update must not have been called for the MCP branch
@@ -858,6 +911,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				trackingHookManager,
 				'test-provider',
+				MCP_CONFIG,
 				mockLogger
 			);
 

--- a/test/lib/handlers.test.js
+++ b/test/lib/handlers.test.js
@@ -162,6 +162,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -181,7 +182,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -208,6 +209,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -225,6 +227,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -242,7 +245,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -265,6 +268,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -283,6 +287,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -304,7 +309,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
-				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -328,6 +333,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -348,6 +354,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -371,6 +378,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -391,6 +399,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -410,6 +419,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -436,6 +446,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -466,6 +477,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -491,6 +503,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -512,6 +525,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -542,6 +556,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -618,7 +633,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'acme-corp', // Same provider
-				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -649,7 +664,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'target-company',
-				'test-provider',
+				undefined,
 				mockLogger
 			);
 
@@ -675,7 +690,7 @@ describe('OAuth Handlers', () => {
 				mockConfig,
 				mockHookManager,
 				'acme-corp',
-				'test-provider',
+				undefined,
 				mockLogger
 			);
 

--- a/test/lib/mcp/authorize.test.js
+++ b/test/lib/mcp/authorize.test.js
@@ -340,6 +340,53 @@ describe('handleAuthorize', () => {
 		});
 	});
 
+	describe('phase 2 — RFC 9207 iss on error redirects', () => {
+		it('includes iss matching the configured issuer on a Phase-2 error redirect', async () => {
+			const { entries } = newRegistry();
+			const configWithIssuer = { enabled: true, issuer: 'https://as.example.com' };
+			// Trigger a Phase-2 error (response_type mismatch → redirect, not 400)
+			const target = makeTarget({ ...BASE_QUERY, response_type: 'token' });
+			const response = await handleAuthorize(makeRequest(), target, configWithIssuer, entries);
+			assert.equal(response.status, 302);
+			const url = new URL(response.headers.Location);
+			assert.equal(url.searchParams.get('iss'), 'https://as.example.com', 'iss must equal the configured issuer');
+		});
+
+		it('derives iss from request when issuer is not configured', async () => {
+			const { entries } = newRegistry();
+			// Trigger a Phase-2 error without a configured issuer
+			const target = makeTarget({ ...BASE_QUERY, response_type: 'token' });
+			const response = await handleAuthorize(makeRequest(), target, { enabled: true }, entries);
+			assert.equal(response.status, 302);
+			const url = new URL(response.headers.Location);
+			assert.equal(url.searchParams.get('iss'), 'https://app.example.com', 'iss must derive from request scheme+host');
+		});
+
+		it('includes iss on all Phase-2 error types (resource mismatch, provider error)', async () => {
+			const configWithIssuer = { enabled: true, issuer: 'https://as.example.com' };
+			const { entries } = newRegistry();
+
+			// resource mismatch error
+			const resourceTarget = makeTarget({ ...BASE_QUERY, resource: 'https://other.example.com/mcp' });
+			const resourceResp = await handleAuthorize(makeRequest(), resourceTarget, configWithIssuer, entries);
+			assert.equal(new URL(resourceResp.headers.Location).searchParams.get('iss'), 'https://as.example.com');
+
+			// provider selection error
+			const noProviderTarget = makeTarget(BASE_QUERY);
+			const noProviderResp = await handleAuthorize(makeRequest(), noProviderTarget, configWithIssuer, {});
+			assert.equal(new URL(noProviderResp.headers.Location).searchParams.get('iss'), 'https://as.example.com');
+		});
+
+		it('does NOT include iss on Phase-1 errors (400 JSON responses)', async () => {
+			// Phase-1 errors are 400 JSON, not redirects — iss is only for redirects
+			const { entries } = newRegistry();
+			const target = makeTarget({ ...BASE_QUERY, client_id: 'unknown-client' });
+			const response = await handleAuthorize(makeRequest(), target, { enabled: true }, entries);
+			assert.equal(response.status, 400, 'Phase-1 errors are 400 JSON, not redirects');
+			assert.ok(!('headers' in response), 'no Location header on Phase-1 errors');
+		});
+	});
+
 	describe('happy path', () => {
 		it('redirects to upstream provider with CSRF token carrying MCP state', async () => {
 			const { entries, harnesses } = newRegistry();

--- a/test/lib/mcp/callback.test.js
+++ b/test/lib/mcp/callback.test.js
@@ -2,7 +2,7 @@
  * Tests for the MCP callback branch (handleMCPCallback).
  *
  * Verifies it mints an authorization code, persists the binding fields,
- * redirects to the client's redirect_uri with `code` + echoed `state`,
+ * redirects to the client's redirect_uri with `code` + echoed `state` + RFC 9207 `iss`,
  * and never leaks upstream-provider token material in the response.
  */
 
@@ -22,6 +22,16 @@ const SAMPLE_MCP_STATE = {
 };
 
 const SAMPLE_USER_ID = 'alice@example.com';
+
+const SAMPLE_MCP_CONFIG = {
+	issuer: 'https://as.example.com',
+	enabled: true,
+};
+
+// Minimal request stub — handleMCPCallback delegates issuer resolution to
+// resolveIssuer(request, mcpConfig); with a configured issuer the request
+// fields are not consulted.
+const SAMPLE_REQUEST = { protocol: 'https', host: 'app.example.com', headers: { host: 'app.example.com' } };
 
 describe('handleMCPCallback', () => {
 	let originalDatabases;
@@ -54,7 +64,7 @@ describe('handleMCPCallback', () => {
 	});
 
 	it('mints an auth code and persists the binding fields', async () => {
-		const response = await handleMCPCallback({}, SAMPLE_MCP_STATE, SAMPLE_USER_ID);
+		const response = await handleMCPCallback(SAMPLE_REQUEST, SAMPLE_MCP_STATE, SAMPLE_USER_ID, SAMPLE_MCP_CONFIG);
 		assert.equal(response.status, 302);
 		assert.equal(storedRecords.size, 1);
 		const [record] = storedRecords.values();
@@ -70,25 +80,45 @@ describe('handleMCPCallback', () => {
 	});
 
 	it('redirects to the client redirect_uri with code and echoed state', async () => {
-		const response = await handleMCPCallback({}, SAMPLE_MCP_STATE, SAMPLE_USER_ID);
+		const response = await handleMCPCallback(SAMPLE_REQUEST, SAMPLE_MCP_STATE, SAMPLE_USER_ID, SAMPLE_MCP_CONFIG);
 		const url = new URL(response.headers.Location);
 		assert.equal(url.origin + url.pathname, SAMPLE_MCP_STATE.redirectUri);
 		assert.ok(url.searchParams.get('code'));
 		assert.equal(url.searchParams.get('state'), SAMPLE_MCP_STATE.clientState);
 	});
 
+	it('includes iss on the success redirect (RFC 9207)', async () => {
+		const response = await handleMCPCallback(SAMPLE_REQUEST, SAMPLE_MCP_STATE, SAMPLE_USER_ID, SAMPLE_MCP_CONFIG);
+		const url = new URL(response.headers.Location);
+		assert.equal(url.searchParams.get('iss'), SAMPLE_MCP_CONFIG.issuer, 'iss must equal the configured issuer');
+	});
+
+	it('derives iss from the request when issuer is not configured', async () => {
+		const configWithoutIssuer = { enabled: true };
+		const response = await handleMCPCallback(SAMPLE_REQUEST, SAMPLE_MCP_STATE, SAMPLE_USER_ID, configWithoutIssuer);
+		const url = new URL(response.headers.Location);
+		assert.equal(url.searchParams.get('iss'), 'https://app.example.com', 'iss must derive from request scheme+host');
+	});
+
 	it('omits state when the MCP client did not send one', async () => {
 		const { clientState, ...stateWithoutClientState } = SAMPLE_MCP_STATE;
 		void clientState;
-		const response = await handleMCPCallback({}, stateWithoutClientState, SAMPLE_USER_ID);
+		const response = await handleMCPCallback(
+			SAMPLE_REQUEST,
+			stateWithoutClientState,
+			SAMPLE_USER_ID,
+			SAMPLE_MCP_CONFIG
+		);
 		const url = new URL(response.headers.Location);
 		assert.equal(url.searchParams.has('state'), false);
 		assert.ok(url.searchParams.get('code'));
+		// iss is always present regardless of state
+		assert.ok(url.searchParams.get('iss'));
 	});
 
 	it('generates a fresh code per invocation (no reuse across requests)', async () => {
-		const a = await handleMCPCallback({}, SAMPLE_MCP_STATE, SAMPLE_USER_ID);
-		const b = await handleMCPCallback({}, SAMPLE_MCP_STATE, SAMPLE_USER_ID);
+		const a = await handleMCPCallback(SAMPLE_REQUEST, SAMPLE_MCP_STATE, SAMPLE_USER_ID, SAMPLE_MCP_CONFIG);
+		const b = await handleMCPCallback(SAMPLE_REQUEST, SAMPLE_MCP_STATE, SAMPLE_USER_ID, SAMPLE_MCP_CONFIG);
 		const codeA = new URL(a.headers.Location).searchParams.get('code');
 		const codeB = new URL(b.headers.Location).searchParams.get('code');
 		assert.notEqual(codeA, codeB);
@@ -99,18 +129,20 @@ describe('handleMCPCallback', () => {
 		mockTable.put = async () => {
 			throw new Error('db write failure');
 		};
-		const response = await handleMCPCallback({}, SAMPLE_MCP_STATE, SAMPLE_USER_ID);
+		const response = await handleMCPCallback(SAMPLE_REQUEST, SAMPLE_MCP_STATE, SAMPLE_USER_ID, SAMPLE_MCP_CONFIG);
 		assert.equal(response.status, 302);
 		const url = new URL(response.headers.Location);
 		assert.equal(url.origin + url.pathname, SAMPLE_MCP_STATE.redirectUri);
 		assert.equal(url.searchParams.get('error'), 'server_error');
 		assert.equal(url.searchParams.get('state'), SAMPLE_MCP_STATE.clientState);
+		// RFC 9207: iss must appear on error redirects too
+		assert.equal(url.searchParams.get('iss'), SAMPLE_MCP_CONFIG.issuer);
 	});
 
 	it('never includes upstream provider token in the redirect URL', async () => {
 		// `handleMCPCallback` signature doesn't take a token — that's the guard.
 		// But assert no field on the response references known token-ish names.
-		const response = await handleMCPCallback({}, SAMPLE_MCP_STATE, SAMPLE_USER_ID);
+		const response = await handleMCPCallback(SAMPLE_REQUEST, SAMPLE_MCP_STATE, SAMPLE_USER_ID, SAMPLE_MCP_CONFIG);
 		const location = response.headers.Location;
 		for (const banned of ['access_token', 'refresh_token', 'id_token', 'token_type']) {
 			assert.ok(!location.includes(banned), `${banned} must not appear in MCP redirect URL`);

--- a/test/lib/mcp/wellKnown.test.js
+++ b/test/lib/mcp/wellKnown.test.js
@@ -129,6 +129,11 @@ describe('MCP well-known: AS metadata document (RFC 8414)', () => {
 		const doc = buildAuthorizationServerMetadata(makeRequest(), { enabled: true });
 		assert.equal(doc.resource_parameter_supported, true);
 	});
+
+	it('signals RFC 9207 authorization_response_iss_parameter_supported', () => {
+		const doc = buildAuthorizationServerMetadata(makeRequest(), { enabled: true });
+		assert.equal(doc.authorization_response_iss_parameter_supported, true);
+	});
 });
 
 describe('MCP well-known: JWKS document', () => {


### PR DESCRIPTION
## Summary

Implements RFC 9207 (`iss` on authorization responses) for the MCP OAuth flow:

- Advertises `authorization_response_iss_parameter_supported: true` in the RFC 8414 AS metadata (`wellKnown.ts`).
- Emits `iss` on **all** MCP authorization responses — success and error redirects — from the callback endpoint (`callback.ts`) and the authorize endpoint's Phase-2 error redirects (`authorize.ts`), plus the pre-callback error path (`handlers.ts` `mcpErrorRedirect`). The issuer is resolved via the existing `resolveIssuer` helper, so it matches the JWT `iss` claim and the AS-metadata `issuer`.
- Phase-1 (400 JSON) validation errors and the upstream-IdP success redirect are intentionally left without `iss`.

## Refactor

`handleCallback` now takes an options object `opts?: { mcpConfig?: MCPConfig; logger?: Logger }` instead of trailing positional params — callers no longer pass positional `undefined` filler. The single production caller (`resource.ts`) and the test call sites are updated accordingly. Human-session OAuth flow behavior is unchanged.

## Tests

- Unit: `iss` on success + error redirects (configured and request-derived issuer), the AS-metadata flag, and a guard that Phase-1 errors stay 400 JSON.
- E2E (`mcp-oauth-e2e.test.ts`): asserts the AS-metadata flag and the `iss` round-trip on success + error redirects.

## Review

Codex, Gemini, and Claude reviews all clean — no blockers.

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)
