### PR TITLE
Release 2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@harperfast/oauth",
-			"version": "2.1.0",
+			"version": "2.1.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "OAuth 2.0 authentication plugin for Harper",
 	"license": "Apache-2.0",
 	"author": {


### PR DESCRIPTION
## Release 2.1.1

Patch — RFC 9207 `iss` on MCP OAuth authorization responses (#150, closes #149).

- Emits the `iss` parameter on **all** MCP authorization responses (success + error redirects) and advertises `authorization_response_iss_parameter_supported: true` in the AS metadata, per RFC 9207 / MCP SEP-2468.
- Mitigates OAuth mix-up attacks; the RC (2026-07-28) encourages emitting `iss` now, ahead of a future revision making it a MUST.
- Additive and backward-compatible. MCP OAuth remains experimental / opt-in (`mcp.enabled`).

### Release mechanics

Merging this bumps `package.json` to 2.1.1. Publishing a GitHub Release tagged `v2.1.1` triggers `release.yml`, which publishes to npm `latest` via OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
