### PR TITLE
fix: emit MCP audit events lazily via structured logging (#146)

### DIFF
--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -343,7 +343,10 @@ See [Lifecycle Hooks](./lifecycle-hooks.md) for `registerHooks` and the other ho
 ## Audit events
 
 Token lifecycle events are written to Harper's structured log (`hdb.log`) at
-`info`, each line prefixed `MCP audit:` with a JSON payload:
+`info`. Each event is emitted as a two-argument logger call — a fixed `'MCP audit:'`
+marker string followed by the structured payload object — so the payload is never
+serialised unless the logger actually renders it. Log aggregators see output similar
+to:
 
 ```
 MCP audit: {"event":"oauth.mcp.token.issued","client_id":"…","sub":"…","aud":"https://my-app.example.com/mcp","scope":"…","jti":"…","timestamp":"2026-06-29T17:00:00.000Z"}

--- a/src/lib/mcp/audit.ts
+++ b/src/lib/mcp/audit.ts
@@ -19,11 +19,10 @@
  *     scoped plugin logger routes these to hdb.log alongside Harper's own
  *     auth audit trail, not to system.log.
  *
- * Keep ALL string formatting inside the logger call so the optional-call
- * short-circuit (`?.`) avoids JSON.stringify work when info is undefined
- * (same lazy-logging pattern as dcr.ts). Note: `?.` only short-circuits when
- * `info` is absent, not when it's a level-suppressed no-op — fully lazy logging
- * would need a logger-level check Harper doesn't expose to plugins here.
+ * The payload is passed as a second argument (`harperLogger?.info?.('MCP audit:', payload)`)
+ * so the structured object is never serialised unless the logger renders it.
+ * This matches how Harper core's auth-event logger is called. The `'MCP audit:'`
+ * prefix string stays greppable / filterable in hdb.log.
  *
  * Three event types: `issued` / `refreshed` (success path, from the token
  * endpoint — carry the verified claims) and `rejected` (from the withMCPAuth
@@ -93,9 +92,8 @@ export function emitMCPAuditEvent(payload: MCPAuditPayload): void {
 	// thrown logger error here would deny the client its new token and strand
 	// the family on a hash the client never received. Swallow everything.
 	try {
-		// Keep JSON.stringify inside the optional call so it is only evaluated
-		// when the info level is active (optional-call short-circuit).
-		harperLogger?.info?.(`MCP audit: ${JSON.stringify(payload)}`);
+		// Pass payload as a second arg so serialisation is deferred to the logger.
+		harperLogger?.info?.('MCP audit:', payload);
 	} catch {
 		// Intentionally ignored — audit logging is best-effort.
 	}

--- a/test/lib/mcp/audit.test.js
+++ b/test/lib/mcp/audit.test.js
@@ -49,16 +49,15 @@ describe('emitMCPAuditEvent', () => {
 		harperMockLogger.info = originalInfo;
 
 		assert.equal(infoCalls.length, 1, 'exactly one info log emitted');
-		const logged = infoCalls[0][0];
-		assert.ok(typeof logged === 'string', 'logged argument is a string');
-		const parsed = JSON.parse(logged.replace(/^MCP audit: /, ''));
-		assert.equal(parsed.event, 'oauth.mcp.token.issued');
-		assert.equal(parsed.client_id, BASE_PAYLOAD.client_id);
-		assert.equal(parsed.sub, BASE_PAYLOAD.sub);
-		assert.equal(parsed.aud, BASE_PAYLOAD.aud);
-		assert.equal(parsed.scope, BASE_PAYLOAD.scope);
-		assert.equal(parsed.jti, BASE_PAYLOAD.jti);
-		assert.ok(parsed.timestamp, 'timestamp present');
+		const [marker, payload] = infoCalls[0];
+		assert.equal(marker, 'MCP audit:', 'first arg is the marker string');
+		assert.equal(payload.event, 'oauth.mcp.token.issued');
+		assert.equal(payload.client_id, BASE_PAYLOAD.client_id);
+		assert.equal(payload.sub, BASE_PAYLOAD.sub);
+		assert.equal(payload.aud, BASE_PAYLOAD.aud);
+		assert.equal(payload.scope, BASE_PAYLOAD.scope);
+		assert.equal(payload.jti, BASE_PAYLOAD.jti);
+		assert.ok(payload.timestamp, 'timestamp present');
 	});
 
 	it('emits oauth.mcp.token.refreshed with the correct payload shape', () => {
@@ -67,12 +66,13 @@ describe('emitMCPAuditEvent', () => {
 		harperMockLogger.info = originalInfo;
 
 		assert.equal(infoCalls.length, 1);
-		const parsed = JSON.parse(infoCalls[0][0].replace(/^MCP audit: /, ''));
-		assert.equal(parsed.event, 'oauth.mcp.token.refreshed');
-		assert.equal(parsed.client_id, payload.client_id);
-		assert.equal(parsed.sub, payload.sub);
-		assert.equal(parsed.aud, payload.aud);
-		assert.equal(parsed.jti, payload.jti);
+		const [marker, logged] = infoCalls[0];
+		assert.equal(marker, 'MCP audit:');
+		assert.equal(logged.event, 'oauth.mcp.token.refreshed');
+		assert.equal(logged.client_id, payload.client_id);
+		assert.equal(logged.sub, payload.sub);
+		assert.equal(logged.aud, payload.aud);
+		assert.equal(logged.jti, payload.jti);
 	});
 
 	it('never includes token strings in the emitted payload', () => {
@@ -82,10 +82,10 @@ describe('emitMCPAuditEvent', () => {
 		emitMCPAuditEvent(BASE_PAYLOAD);
 		harperMockLogger.info = originalInfo;
 
-		const logged = infoCalls[0][0];
+		const logged = infoCalls[0][1];
 		const BANNED_KEYS = ['access_token', 'refresh_token', 'id_token', 'client_secret'];
 		for (const key of BANNED_KEYS) {
-			assert.ok(!logged.includes(`"${key}"`), `"${key}" must not appear in audit log`);
+			assert.ok(!(key in logged), `"${key}" must not appear in audit log`);
 		}
 	});
 
@@ -94,8 +94,8 @@ describe('emitMCPAuditEvent', () => {
 		emitMCPAuditEvent(payload);
 		harperMockLogger.info = originalInfo;
 
-		const parsed = JSON.parse(infoCalls[0][0].replace(/^MCP audit: /, ''));
-		assert.ok(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$/.test(parsed.timestamp), 'timestamp is ISO-8601 UTC');
+		const logged = infoCalls[0][1];
+		assert.ok(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$/.test(logged.timestamp), 'timestamp is ISO-8601 UTC');
 	});
 
 	it('does not throw when the logger is suppressed (info is undefined)', () => {
@@ -111,8 +111,8 @@ describe('emitMCPAuditEvent', () => {
 		emitMCPAuditEvent(noScope);
 		harperMockLogger.info = originalInfo;
 
-		const parsed = JSON.parse(infoCalls[0][0].replace(/^MCP audit: /, ''));
-		assert.equal(parsed.scope, undefined);
+		const logged = infoCalls[0][1];
+		assert.equal(logged.scope, undefined);
 	});
 
 	it('emits oauth.mcp.token.rejected with reason + aud and NO unverified claims', () => {
@@ -125,13 +125,14 @@ describe('emitMCPAuditEvent', () => {
 		harperMockLogger.info = originalInfo;
 
 		assert.equal(infoCalls.length, 1);
-		const parsed = JSON.parse(infoCalls[0][0].replace(/^MCP audit: /, ''));
-		assert.equal(parsed.event, 'oauth.mcp.token.rejected');
-		assert.equal(parsed.reason, 'access token is invalid, expired, or not issued for this resource');
-		assert.equal(parsed.aud, 'https://app.example.com/mcp');
+		const [marker, logged] = infoCalls[0];
+		assert.equal(marker, 'MCP audit:');
+		assert.equal(logged.event, 'oauth.mcp.token.rejected');
+		assert.equal(logged.reason, 'access token is invalid, expired, or not issued for this resource');
+		assert.equal(logged.aud, 'https://app.example.com/mcp');
 		// A rejected token has no trustworthy claims — none must be logged.
-		assert.equal(parsed.client_id, undefined, 'no client_id on a rejected event');
-		assert.equal(parsed.sub, undefined, 'no sub on a rejected event');
-		assert.equal(parsed.jti, undefined, 'no jti on a rejected event');
+		assert.equal(logged.client_id, undefined, 'no client_id on a rejected event');
+		assert.equal(logged.sub, undefined, 'no sub on a rejected event');
+		assert.equal(logged.jti, undefined, 'no jti on a rejected event');
 	});
 });

--- a/test/lib/mcp/tokenAuditHook.test.js
+++ b/test/lib/mcp/tokenAuditHook.test.js
@@ -179,16 +179,16 @@ describe('handleToken — audit events and onMCPTokenIssued hook', () => {
 		);
 		restoreLogger();
 
-		const auditLog = infoCalls.find((args) => args[0]?.includes('oauth.mcp.token.issued'));
+		const auditLog = infoCalls.find((args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.issued'));
 		assert.ok(auditLog, 'audit log for oauth.mcp.token.issued was emitted');
-		const parsed = JSON.parse(auditLog[0].replace(/^MCP audit: /, ''));
-		assert.equal(parsed.event, 'oauth.mcp.token.issued');
-		assert.equal(parsed.client_id, 'public-1');
-		assert.equal(parsed.sub, 'alice@example.com');
-		assert.equal(parsed.aud, RESOURCE);
-		assert.equal(parsed.scope, 'mcp:read');
-		assert.ok(parsed.jti, 'jti present');
-		assert.ok(parsed.timestamp, 'timestamp present');
+		const logged = auditLog[1];
+		assert.equal(logged.event, 'oauth.mcp.token.issued');
+		assert.equal(logged.client_id, 'public-1');
+		assert.equal(logged.sub, 'alice@example.com');
+		assert.equal(logged.aud, RESOURCE);
+		assert.equal(logged.scope, 'mcp:read');
+		assert.ok(logged.jti, 'jti present');
+		assert.ok(logged.timestamp, 'timestamp present');
 	});
 
 	it('audit event for issued token contains no token material', async () => {
@@ -206,18 +206,20 @@ describe('handleToken — audit events and onMCPTokenIssued hook', () => {
 		);
 		restoreLogger();
 
-		const auditLog = infoCalls.find((args) => args[0]?.includes('oauth.mcp.token.issued'));
+		const auditLog = infoCalls.find((args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.issued'));
 		assert.ok(auditLog, 'audit log emitted');
-		const logged = auditLog[0];
+		const logged = auditLog[1];
 
 		// The actual token strings must not appear in the audit record.
-		const BANNED = [res.body.access_token, res.body.refresh_token].filter(Boolean);
-		for (const banned of BANNED) {
-			assert.ok(!logged.includes(banned), 'token string must not appear in audit log');
+		const BANNED_KEYS = ['access_token', 'refresh_token', 'client_secret'];
+		for (const key of BANNED_KEYS) {
+			assert.ok(!(key in logged), `"${key}" must not appear in audit log`);
 		}
-		// Verify no generic credential keys either.
-		for (const key of ['access_token', 'refresh_token', 'client_secret']) {
-			assert.ok(!logged.includes(`"${key}"`), `"${key}" must not appear in audit log`);
+		// Verify actual token values are not present either (check in JSON form as belt-and-suspenders).
+		const serialised = JSON.stringify(logged);
+		const BANNED_VALUES = [res.body.access_token, res.body.refresh_token].filter(Boolean);
+		for (const banned of BANNED_VALUES) {
+			assert.ok(!serialised.includes(banned), 'token string must not appear in audit log');
 		}
 	});
 
@@ -232,16 +234,16 @@ describe('handleToken — audit events and onMCPTokenIssued hook', () => {
 		);
 		restoreLogger();
 
-		const auditLog = infoCalls.find((args) => args[0]?.includes('oauth.mcp.token.refreshed'));
+		const auditLog = infoCalls.find((args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.refreshed'));
 		assert.ok(auditLog, 'audit log for oauth.mcp.token.refreshed was emitted');
-		const parsed = JSON.parse(auditLog[0].replace(/^MCP audit: /, ''));
-		assert.equal(parsed.event, 'oauth.mcp.token.refreshed');
-		assert.equal(parsed.client_id, 'public-1');
-		assert.equal(parsed.sub, 'alice@example.com');
-		assert.equal(parsed.aud, RESOURCE);
-		assert.equal(parsed.scope, 'mcp:read');
-		assert.ok(parsed.jti, 'jti present');
-		assert.ok(parsed.timestamp, 'timestamp present');
+		const logged = auditLog[1];
+		assert.equal(logged.event, 'oauth.mcp.token.refreshed');
+		assert.equal(logged.client_id, 'public-1');
+		assert.equal(logged.sub, 'alice@example.com');
+		assert.equal(logged.aud, RESOURCE);
+		assert.equal(logged.scope, 'mcp:read');
+		assert.ok(logged.jti, 'jti present');
+		assert.ok(logged.timestamp, 'timestamp present');
 	});
 
 	it('audit event for refreshed token contains no token material', async () => {
@@ -253,13 +255,14 @@ describe('handleToken — audit events and onMCPTokenIssued hook', () => {
 		);
 		restoreLogger();
 
-		const auditLog = infoCalls.find((args) => args[0]?.includes('oauth.mcp.token.refreshed'));
+		const auditLog = infoCalls.find((args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.refreshed'));
 		assert.ok(auditLog, 'audit log emitted');
-		const logged = auditLog[0];
+		const logged = auditLog[1];
 
+		const serialised = JSON.stringify(logged);
 		const BANNED = [res.body.access_token, res.body.refresh_token, token].filter(Boolean);
 		for (const banned of BANNED) {
-			assert.ok(!logged.includes(banned), 'token string must not appear in audit log');
+			assert.ok(!serialised.includes(banned), 'token string must not appear in audit log');
 		}
 	});
 
@@ -278,7 +281,7 @@ describe('handleToken — audit events and onMCPTokenIssued hook', () => {
 		);
 		restoreLogger();
 
-		const auditLog = infoCalls.find((args) => args[0]?.includes('oauth.mcp.token'));
+		const auditLog = infoCalls.find((args) => args[0] === 'MCP audit:');
 		assert.equal(auditLog, undefined, 'no audit log emitted on failure');
 	});
 
@@ -354,10 +357,10 @@ describe('handleToken — audit events and onMCPTokenIssued hook', () => {
 		);
 		restoreLogger();
 
-		const auditLog = infoCalls.find((args) => args[0]?.includes('oauth.mcp.token.issued'));
-		const parsed = JSON.parse(auditLog[0].replace(/^MCP audit: /, ''));
+		const auditLog = infoCalls.find((args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.issued'));
+		assert.ok(auditLog, 'audit log emitted');
 		const hookJti = hookMock.mock.calls[0].arguments[0].jti;
-		assert.equal(hookJti, parsed.jti, 'hook jti matches the audit-log jti');
+		assert.equal(hookJti, auditLog[1].jti, 'hook jti matches the audit-log jti');
 	});
 
 	it('a throwing onMCPTokenIssued hook does NOT block the token response (fire-and-forget)', async () => {
@@ -452,7 +455,7 @@ describe('handleToken — audit events and onMCPTokenIssued hook', () => {
 		// run only after persistence) never fire.
 		assert.equal(res.status, 500, 'persistence failure → structured server_error');
 		assert.equal(res.body.error, 'server_error');
-		const issued = infoCalls.find((args) => args[0]?.includes('oauth.mcp.token.issued'));
+		const issued = infoCalls.find((args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.issued'));
 		assert.equal(issued, undefined, 'no phantom issued audit event when persistence fails');
 		assert.equal(hookMock.mock.calls.length, 0, 'hook must not fire when persistence fails');
 	});

--- a/test/lib/mcp/tokenAuditHook.test.js
+++ b/test/lib/mcp/tokenAuditHook.test.js
@@ -179,7 +179,9 @@ describe('handleToken — audit events and onMCPTokenIssued hook', () => {
 		);
 		restoreLogger();
 
-		const auditLog = infoCalls.find((args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.issued'));
+		const auditLog = infoCalls.find(
+			(args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.issued')
+		);
 		assert.ok(auditLog, 'audit log for oauth.mcp.token.issued was emitted');
 		const logged = auditLog[1];
 		assert.equal(logged.event, 'oauth.mcp.token.issued');
@@ -206,7 +208,9 @@ describe('handleToken — audit events and onMCPTokenIssued hook', () => {
 		);
 		restoreLogger();
 
-		const auditLog = infoCalls.find((args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.issued'));
+		const auditLog = infoCalls.find(
+			(args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.issued')
+		);
 		assert.ok(auditLog, 'audit log emitted');
 		const logged = auditLog[1];
 
@@ -234,7 +238,9 @@ describe('handleToken — audit events and onMCPTokenIssued hook', () => {
 		);
 		restoreLogger();
 
-		const auditLog = infoCalls.find((args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.refreshed'));
+		const auditLog = infoCalls.find(
+			(args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.refreshed')
+		);
 		assert.ok(auditLog, 'audit log for oauth.mcp.token.refreshed was emitted');
 		const logged = auditLog[1];
 		assert.equal(logged.event, 'oauth.mcp.token.refreshed');
@@ -255,7 +261,9 @@ describe('handleToken — audit events and onMCPTokenIssued hook', () => {
 		);
 		restoreLogger();
 
-		const auditLog = infoCalls.find((args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.refreshed'));
+		const auditLog = infoCalls.find(
+			(args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.refreshed')
+		);
 		assert.ok(auditLog, 'audit log emitted');
 		const logged = auditLog[1];
 
@@ -357,7 +365,9 @@ describe('handleToken — audit events and onMCPTokenIssued hook', () => {
 		);
 		restoreLogger();
 
-		const auditLog = infoCalls.find((args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.issued'));
+		const auditLog = infoCalls.find(
+			(args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.issued')
+		);
 		assert.ok(auditLog, 'audit log emitted');
 		const hookJti = hookMock.mock.calls[0].arguments[0].jti;
 		assert.equal(hookJti, auditLog[1].jti, 'hook jti matches the audit-log jti');
@@ -455,7 +465,9 @@ describe('handleToken — audit events and onMCPTokenIssued hook', () => {
 		// run only after persistence) never fire.
 		assert.equal(res.status, 500, 'persistence failure → structured server_error');
 		assert.equal(res.body.error, 'server_error');
-		const issued = infoCalls.find((args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.issued'));
+		const issued = infoCalls.find(
+			(args) => args[0] === 'MCP audit:' && args[1]?.event?.includes('oauth.mcp.token.issued')
+		);
 		assert.equal(issued, undefined, 'no phantom issued audit event when persistence fails');
 		assert.equal(hookMock.mock.calls.length, 0, 'hook must not fire when persistence fails');
 	});


### PR DESCRIPTION
## Summary

Emit MCP audit events lazily via structured logging (`#146`).

`emitMCPAuditEvent` pre-stringified the payload into the log message: `harperLogger?.info?.(\`MCP audit: ${JSON.stringify(payload)}\`)`. The optional-call short-circuit only skips work when `info` is *absent* — when `info` exists but is level-suppressed, `JSON.stringify` still ran on every event, then the result was dropped internally.

Now the payload is passed as a second argument so serialization is deferred to the logger (it only serializes if it actually emits), aligning with Harper core's audit pattern (`security/auth.ts` `authEventLog.info?.(log)`):

```
harperLogger?.info?.('MCP audit:', payload);
```

- The `'MCP audit:'` marker string is preserved, so existing grep/filter patterns on `hdb.log` keep working; the payload's `event` discriminator is unchanged.
- **Operator-facing format change**: the payload is now rendered by the logger as a structured argument rather than inlined JSON in the message string. `docs/mcp-oauth.md` (audit section) updated to describe the new shape.

## Tests

Updated `audit.test.js` / `tokenAuditHook.test.js` to inspect the structured object at `args[1]` instead of parsing JSON from the message string; existing redaction / secret-free assertions preserved.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)
