### PR TITLE
Release 2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@harperfast/oauth",
-			"version": "2.1.1",
+			"version": "2.1.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"description": "OAuth 2.0 authentication plugin for Harper",
 	"license": "Apache-2.0",
 	"author": {


### PR DESCRIPTION
## Release 2.1.2

Patch — hardening batch from the post-2.1.1 sweep. All fixes, no features.

- **Validate `mcp.issuer` is a full http(s) origin at config load** (#139 / #152). Fail-fast on schemeless or path/query/fragment/credential-bearing values that previously produced malformed endpoint URLs downstream. Format validation only runs when `mcp.enabled` is true.
  - ⚠️ Startup-behavior note: a deployment with `mcp.enabled: true` and a malformed `mcp.issuer` that previously *started* (with broken discovery/endpoint URLs) now refuses to start with a clear error naming the bad value.
- **Secret redaction hardening** (#140 / #153). `SENSITIVE_KEY_PATTERN` now catches snake_case/kebab secret keys (`signing_key_pem`, `initial_access_token`, `private_key`, …); redaction extracted to a shared `lib/redact.ts`; the `pluginDefaults` debug log is now redacted too; non-plain objects (Date/Map/class instances) pass through unmangled.
- **Non-Error catch safety** (#142, #147 / #154). All 16 remaining `(error as Error).message` catch sites now use `error instanceof Error ? error.message : String(error)`, so a thrown string/null can no longer crash the catch itself; the wrapped ID-token verification error now chains the original via `cause`.

### Release mechanics

Merging this bumps `package.json` to 2.1.2. Publishing a GitHub Release tagged `v2.1.2` triggers `release.yml`, which publishes to npm `latest` via OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
