### PR TITLE
feat(mcp): client-assertion primitives — strict EdDSA verify + jti replay store

### DIFF
--- a/schema/oauth.graphql
+++ b/schema/oauth.graphql
@@ -84,6 +84,17 @@ type mcp_refresh_families @table(database: "oauth", expiration: 2592000) {
 	expires_at: Float # Unix seconds; refresh rejected once exceeded
 }
 
+## MCP client-assertion replay guard (RFC 7523 jti; #159/#160)
+## One row per seen (client_id, jti); id = sha256(client_id, jti). Rows only
+## need to outlive the maximum assertion window (60s exp + clock tolerance),
+## so a 120s TTL evicts them. See assertionJtiStore.ts for the keying and
+## accepted-race notes (get-then-put, no atomic compare-and-set).
+type mcp_assertion_jtis @table(database: "oauth", expiration: 120) {
+	id: ID @primaryKey
+	client_id: String
+	created_at: Float
+}
+
 ## OAuth User Session table (optional, for future use)
 ## Could store OAuth-specific user data
 # type oauth_sessions @table(database: "oauth") {

--- a/schema/oauth.graphql
+++ b/schema/oauth.graphql
@@ -92,7 +92,7 @@ type mcp_refresh_families @table(database: "oauth", expiration: 2592000) {
 type mcp_assertion_jtis @table(database: "oauth", expiration: 120) {
 	id: ID @primaryKey
 	client_id: String
-	created_at: Float
+	created_at: Float @createdTime # Harper-assigned (epoch ms); not hand-written
 }
 
 ## OAuth User Session table (optional, for future use)

--- a/schema/oauth.graphql
+++ b/schema/oauth.graphql
@@ -85,10 +85,12 @@ type mcp_refresh_families @table(database: "oauth", expiration: 2592000) {
 }
 
 ## MCP client-assertion replay guard (RFC 7523 jti; #159/#160)
-## One row per seen (client_id, jti); id = sha256(client_id, jti). Rows only
-## need to outlive the maximum assertion window (60s exp + clock tolerance),
-## so a 120s TTL evicts them. See assertionJtiStore.ts for the keying and
-## accepted-race notes (get-then-put, no atomic compare-and-set).
+## One row per seen (client_id, jti); id = sha256(len:client_id:jti), length-
+## prefixed so crafted inputs can't collide. Rows only need to outlive the
+## maximum assertion window (60s exp + clock tolerance), so a 120s TTL evicts
+## them. Enforcement is Table.create() insert-if-absent; see the
+## assertionJtiStore.ts header for the residual-race notes (existence check
+## is pre-staging snapshot only — harper#1745).
 type mcp_assertion_jtis @table(database: "oauth", expiration: 120) {
 	id: ID @primaryKey
 	client_id: String

--- a/src/lib/mcp/assertionJtiStore.ts
+++ b/src/lib/mcp/assertionJtiStore.ts
@@ -7,9 +7,11 @@
  * `expiration: 120`, comfortably past the maximum assertion window (60s `exp`
  * + clock tolerance), so rows self-evict; runtime never needs to prune.
  *
- * Keys are `sha256(client_id \n jti)` — replay scope is per client (RFC 7523
- * defines `jti` uniqueness per issuer), and hashing normalizes an arbitrary
- * client-chosen string to a fixed-length key.
+ * Keys are `sha256(len:client_id:jti)` — the client_id is length-prefixed so
+ * the component boundary is unambiguous (plain delimiter concatenation lets
+ * crafted inputs collide). Replay scope is per client (RFC 7523 defines `jti`
+ * uniqueness per issuer), and hashing normalizes an arbitrary client-chosen
+ * string to a fixed-length key.
  *
  * Accepted race (same precedent as MCPAuthCodeStore.consume): the check is
  * get-then-put with no atomic compare-and-set, and Harper replication is
@@ -79,8 +81,11 @@ export class MCPAssertionJtiStore {
 		const table = getJtisTable();
 		const id = jtiKey(clientId, jti);
 
+		// ANY record under this key means the jti was seen — requiring a
+		// well-formed row (e.g. `existing.id`) would turn a malformed record
+		// into a fail-open bypass of the one guard that must fail closed.
 		const existing = await table.get(id);
-		if (existing && existing.id) {
+		if (existing) {
 			this.logger?.warn?.(`MCP assertion replay detected for client ${clientId}`);
 			return false;
 		}

--- a/src/lib/mcp/assertionJtiStore.ts
+++ b/src/lib/mcp/assertionJtiStore.ts
@@ -1,0 +1,99 @@
+/**
+ * MCP Client-Assertion Replay Guard (RFC 7523 §3 `jti`)
+ *
+ * Records seen client-assertion `jti` values in the `mcp_assertion_jtis`
+ * Harper table so a captured assertion cannot be redeemed twice (#159 security
+ * req 1 — a timestamp-only window is insufficient). The table carries
+ * `expiration: 120`, comfortably past the maximum assertion window (60s `exp`
+ * + clock tolerance), so rows self-evict; runtime never needs to prune.
+ *
+ * Keys are `sha256(client_id \n jti)` — replay scope is per client (RFC 7523
+ * defines `jti` uniqueness per issuer), and hashing normalizes an arbitrary
+ * client-chosen string to a fixed-length key.
+ *
+ * Accepted race (same precedent as MCPAuthCodeStore.consume): the check is
+ * get-then-put with no atomic compare-and-set, and Harper replication is
+ * async — two concurrent presentations of the same assertion can both pass on
+ * different nodes inside the replication window. Bounded by the ≤60s `exp`
+ * and accepted under Harper's single-trust-domain model; do NOT replace this
+ * table with a per-process cache, which would not be shared at all.
+ *
+ * Unlike the other MCP stores, read errors here are NOT swallowed: treating
+ * "could not check" as "not seen" would fail open on the one guard whose whole
+ * job is rejecting repeats. Callers should map a throw to a 500, not issue.
+ */
+
+import { createHash } from 'node:crypto';
+import type { Logger, MCPAssertionJtiRecord, Table } from '../../types.ts';
+
+declare const databases: any;
+
+let jtisTable: Table | undefined;
+
+function getJtisTable(): Table {
+	if (!jtisTable) {
+		if (!databases?.oauth?.mcp_assertion_jtis) {
+			throw new Error(
+				'OAuth MCP assertion jti table (oauth.mcp_assertion_jtis) not found. ' +
+					'Please ensure the OAuth plugin is properly installed with its schema.'
+			);
+		}
+		jtisTable = databases.oauth.mcp_assertion_jtis;
+	}
+	return jtisTable as Table;
+}
+
+/**
+ * Reset the cached table reference (for testing only)
+ * @internal
+ */
+export function resetMCPAssertionJtisTableCache(): void {
+	jtisTable = undefined;
+}
+
+/**
+ * Fixed-length, charset-safe primary key for a (client, jti) sighting. The
+ * client_id is length-prefixed so the component boundary is unambiguous —
+ * plain concatenation with a delimiter would let ("a", "b\nc") and
+ * ("a\nb", "c") collide.
+ */
+export function jtiKey(clientId: string, jti: string): string {
+	return createHash('sha256').update(`${clientId.length}:${clientId}:${jti}`).digest('hex');
+}
+
+export class MCPAssertionJtiStore {
+	private logger?: Logger;
+
+	constructor(logger?: Logger) {
+		this.logger = logger;
+	}
+
+	/**
+	 * Record a (client_id, jti) sighting. Returns true when this is the first
+	 * sighting (proceed with issuance), false when the jti was already seen
+	 * (replay — reject). Storage errors on either the read or the write
+	 * propagate to the caller: this guard must fail closed, never
+	 * "couldn't check, assume fresh".
+	 */
+	async checkAndRecord(clientId: string, jti: string): Promise<boolean> {
+		const table = getJtisTable();
+		const id = jtiKey(clientId, jti);
+
+		const existing = await table.get(id);
+		if (existing && existing.id) {
+			this.logger?.warn?.(`MCP assertion replay detected for client ${clientId}`);
+			return false;
+		}
+
+		const record: MCPAssertionJtiRecord = {
+			id,
+			client_id: clientId,
+			created_at: Math.floor(Date.now() / 1000),
+		};
+		// Explicit field access (no spread) per the tracked-object gotcha, kept
+		// even for this locally-built record so the stores stay uniform.
+		await table.put({ id: record.id, client_id: record.client_id, created_at: record.created_at });
+		this.logger?.debug?.(`Recorded MCP assertion jti for client ${clientId}`);
+		return true;
+	}
+}

--- a/src/lib/mcp/assertionJtiStore.ts
+++ b/src/lib/mcp/assertionJtiStore.ts
@@ -26,7 +26,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import type { Logger, MCPAssertionJtiRecord, Table } from '../../types.ts';
+import type { Logger, Table } from '../../types.ts';
 
 declare const databases: any;
 
@@ -90,14 +90,9 @@ export class MCPAssertionJtiStore {
 			return false;
 		}
 
-		const record: MCPAssertionJtiRecord = {
-			id,
-			client_id: clientId,
-			created_at: Math.floor(Date.now() / 1000),
-		};
-		// Explicit field access (no spread) per the tracked-object gotcha, kept
-		// even for this locally-built record so the stores stay uniform.
-		await table.put({ id: record.id, client_id: record.client_id, created_at: record.created_at });
+		// Only id + client_id are app-owned; `created_at` is stamped by Harper
+		// via @createdTime (see schema) — we don't hand-write record timestamps.
+		await table.put({ id, client_id: clientId });
 		this.logger?.debug?.(`Recorded MCP assertion jti for client ${clientId}`);
 		return true;
 	}

--- a/src/lib/mcp/assertionJtiStore.ts
+++ b/src/lib/mcp/assertionJtiStore.ts
@@ -13,16 +13,26 @@
  * uniqueness per issuer), and hashing normalizes an arbitrary client-chosen
  * string to a fixed-length key.
  *
- * Accepted race (same precedent as MCPAuthCodeStore.consume): the check is
- * get-then-put with no atomic compare-and-set, and Harper replication is
- * async — two concurrent presentations of the same assertion can both pass on
- * different nodes inside the replication window. Bounded by the ≤60s `exp`
- * and accepted under Harper's single-trust-domain model; do NOT replace this
- * table with a per-process cache, which would not be shared at all.
+ * Enforcement uses `Table.create()` — Harper's insert-if-absent, which throws
+ * a 409 ClientError ("Record already exists") — rather than an awaited
+ * get-then-put a concurrent request could interleave.
  *
- * Unlike the other MCP stores, read errors here are NOT swallowed: treating
- * "could not check" as "not seen" would fail open on the one guard whose whole
- * job is rejecting repeats. Callers should map a throw to a 500, not issue.
+ * Residual race (documented, accepted): Harper currently enforces create()'s
+ * existence check against the pre-staging snapshot only, so concurrent
+ * in-flight creates can degrade to last-write-wins with both callers
+ * reporting success (HarperFast/harper#1745). Exposure is bounded to
+ * presentations in flight simultaneously — within the staging→commit interval
+ * on one node, or replication lag across nodes — NOT open reuse across the
+ * assertion's ~60s validity window; each duplicate mints one short-TTL token.
+ * If harper#1745 lands per-node enforcement, the 409 also surfaces on
+ * commit-time conflict and this guard becomes fully atomic per node with no
+ * code change here (the catch below already handles it). Do NOT replace this
+ * table with a per-process cache, which would not be shared across workers
+ * or nodes.
+ *
+ * Unlike the other MCP stores, storage errors here are NOT swallowed:
+ * treating "could not check" as "not seen" would fail open on the one guard
+ * whose whole job is rejecting repeats. Callers should map a throw to a 500.
  */
 
 import { createHash } from 'node:crypto';
@@ -73,26 +83,24 @@ export class MCPAssertionJtiStore {
 	/**
 	 * Record a (client_id, jti) sighting. Returns true when this is the first
 	 * sighting (proceed with issuance), false when the jti was already seen
-	 * (replay — reject). Storage errors on either the read or the write
-	 * propagate to the caller: this guard must fail closed, never
-	 * "couldn't check, assume fresh".
+	 * (replay — reject). Non-409 storage errors propagate to the caller: this
+	 * guard must fail closed, never "couldn't check, assume fresh".
 	 */
 	async checkAndRecord(clientId: string, jti: string): Promise<boolean> {
 		const table = getJtisTable();
 		const id = jtiKey(clientId, jti);
-
-		// ANY record under this key means the jti was seen — requiring a
-		// well-formed row (e.g. `existing.id`) would turn a malformed record
-		// into a fail-open bypass of the one guard that must fail closed.
-		const existing = await table.get(id);
-		if (existing) {
-			this.logger?.warn?.(`MCP assertion replay detected for client ${clientId}`);
-			return false;
+		try {
+			// Insert-if-absent; ANY existing record under this key is a replay.
+			// Only id + client_id are app-owned; `created_at` is stamped by
+			// Harper via @createdTime (see schema).
+			await table.create({ id, client_id: clientId });
+		} catch (error) {
+			if ((error as { statusCode?: number })?.statusCode === 409) {
+				this.logger?.warn?.(`MCP assertion replay detected for client ${clientId}`);
+				return false;
+			}
+			throw error;
 		}
-
-		// Only id + client_id are app-owned; `created_at` is stamped by Harper
-		// via @createdTime (see schema) — we don't hand-write record timestamps.
-		await table.put({ id, client_id: clientId });
 		this.logger?.debug?.(`Recorded MCP assertion jti for client ${clientId}`);
 		return true;
 	}

--- a/src/lib/mcp/clientAssertion.ts
+++ b/src/lib/mcp/clientAssertion.ts
@@ -1,0 +1,267 @@
+/**
+ * RFC 7523 §3 Client-Assertion Verification (private_key_jwt)
+ *
+ * Verifies the `client_assertion` JWT a headless agent presents to the token
+ * endpoint for the client_credentials grant (#159/#160). EdDSA/Ed25519 only
+ * (RFC 8037), verified with `node:crypto` — no new dependency; the plugin's
+ * `jsonwebtoken` cannot verify EdDSA. Everything fails closed: any parse,
+ * header, key, signature, or claim problem yields `{ valid: false, reason }`,
+ * never a throw, so the grant handler can map it straight to an OAuth
+ * `invalid_client` error and an audit reason.
+ *
+ * Verification contract (see the #159 design review):
+ * - header `alg` is exactly `EdDSA`; `typ`, when present, is `JWT`; any `crit`
+ *   is rejected (we implement no extensions).
+ * - key selected from the client's registered JWK Set: `kid` present → must
+ *   match exactly one registered key; `kid` absent → the set must hold exactly
+ *   one key. Keys must be public OKP/Ed25519 (a private `d` is rejected).
+ * - `iss` = `sub` = the authenticating client_id (all three, exactly).
+ * - `aud` equals the resolved token-endpoint URL — a string, or a
+ *   single-element array (RFC 7519 allows an array; more than one audience is
+ *   rejected as ambiguous).
+ * - `exp` required, in the future, and no more than `maxExpiresInSeconds`
+ *   (default 60) out; `iat` required and not in the future; `nbf`, when
+ *   present, must have passed. All checks allow `clockToleranceSeconds`
+ *   (default 5) of skew.
+ * - `jti` required (non-empty string, ≤ 256 chars). Replay is NOT enforced
+ *   here — callers must run the returned `jti` through MCPAssertionJtiStore.
+ */
+
+import { createPublicKey, verify as verifySignature, type KeyObject } from 'node:crypto';
+
+/** RFC 7523 §2.2 value for `client_assertion_type`. */
+export const CLIENT_ASSERTION_TYPE_JWT_BEARER = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
+
+const DEFAULT_MAX_EXPIRES_IN_SECONDS = 60;
+const DEFAULT_CLOCK_TOLERANCE_SECONDS = 5;
+/** Bound what a client can force into the replay table. */
+const MAX_JTI_LENGTH = 256;
+/** Ed25519 signatures are always exactly 64 bytes (RFC 8032). */
+const ED25519_SIGNATURE_LENGTH = 64;
+
+/**
+ * Strict base64url alphabet (RFC 4648 §5, unpadded). `Buffer.from(s,
+ * 'base64url')` silently skips invalid characters, which would let two
+ * distinct token strings decode to the same payload — validate first.
+ */
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+/** Claims of a successfully verified assertion. */
+export interface ClientAssertionClaims {
+	iss: string;
+	sub: string;
+	/** The single verified audience (unwrapped if presented as an array). */
+	aud: string;
+	exp: number;
+	iat: number;
+	jti: string;
+}
+
+export type ClientAssertionResult = { valid: true; claims: ClientAssertionClaims } | { valid: false; reason: string };
+
+export interface VerifyClientAssertionParams {
+	/** The `client_assertion` value — a compact-serialized JWT. */
+	assertion: string;
+	/** The client_id being authenticated; must equal `iss` and `sub`. */
+	clientId: string;
+	/** Resolved token-endpoint URL; must equal `aud` exactly. */
+	tokenEndpoint: string;
+	/** The client's registered public JWK Set keys (OKP/Ed25519). */
+	jwks: Record<string, unknown>[];
+	/** Maximum allowed `exp - now`. Default 60 (issue req 1). */
+	maxExpiresInSeconds?: number;
+	/** Clock-skew allowance for `exp`/`iat`/`nbf`. Default 5. */
+	clockToleranceSeconds?: number;
+}
+
+function fail(reason: string): ClientAssertionResult {
+	return { valid: false, reason };
+}
+
+function decodeSegment(segment: string): Record<string, unknown> | null {
+	if (!BASE64URL_PATTERN.test(segment)) return null;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(Buffer.from(segment, 'base64url').toString('utf8'));
+	} catch {
+		return null;
+	}
+	return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+		? (parsed as Record<string, unknown>)
+		: null;
+}
+
+/**
+ * Load a registered JWK as an Ed25519 public KeyObject. Returns null (reject)
+ * unless the JWK is exactly a public OKP/Ed25519 key — in particular a key
+ * carrying private material (`d`) must never have been registered, and must
+ * never verify, so it is rejected here as defense-in-depth against a
+ * registration-validation gap.
+ */
+function loadEd25519PublicKey(jwk: Record<string, unknown>): KeyObject | null {
+	if (jwk.kty !== 'OKP' || jwk.crv !== 'Ed25519') return null;
+	if (typeof jwk.x !== 'string' || jwk.x.length === 0) return null;
+	if ('d' in jwk) return null;
+	try {
+		return createPublicKey({ key: { kty: 'OKP', crv: 'Ed25519', x: jwk.x }, format: 'jwk' });
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Select the verification key per the JWKS `kid` rules (mirrors
+ * tokenIssuer.verifyAccessTokenWithKeySet): a presented `kid` must match
+ * exactly one registered key — never fall back to "try every key"; no `kid`
+ * requires an unambiguous single-key set.
+ */
+function selectKey(
+	jwks: Record<string, unknown>[],
+	kid: unknown
+): { jwk: Record<string, unknown> } | { error: string } {
+	if (!Array.isArray(jwks) || jwks.length === 0) {
+		return { error: 'client has no registered JWKs' };
+	}
+	if (kid !== undefined) {
+		if (typeof kid !== 'string' || kid.length === 0) return { error: 'assertion kid must be a non-empty string' };
+		const matches = jwks.filter((k) => k.kid === kid);
+		if (matches.length !== 1) return { error: 'assertion kid does not match exactly one registered key' };
+		return { jwk: matches[0] };
+	}
+	if (jwks.length !== 1) {
+		return { error: 'assertion kid is required when multiple keys are registered' };
+	}
+	return { jwk: jwks[0] };
+}
+
+/**
+ * Verify a client assertion end-to-end (structure → header → key → signature
+ * → claims). Signature is checked before claims so a claims-shaped error can
+ * never be probed without possession of the private key.
+ */
+export function verifyClientAssertion(params: VerifyClientAssertionParams): ClientAssertionResult {
+	const { assertion, clientId, tokenEndpoint, jwks } = params;
+	const maxExpiresIn = params.maxExpiresInSeconds ?? DEFAULT_MAX_EXPIRES_IN_SECONDS;
+	const clockTolerance = params.clockToleranceSeconds ?? DEFAULT_CLOCK_TOLERANCE_SECONDS;
+
+	if (typeof assertion !== 'string' || assertion.length === 0) {
+		return fail('client_assertion is required');
+	}
+	if (typeof clientId !== 'string' || clientId.length === 0) {
+		return fail('client_id is required');
+	}
+
+	const segments = assertion.split('.');
+	if (segments.length !== 3) {
+		return fail('client_assertion is not a compact JWT');
+	}
+	const [headerSegment, payloadSegment, signatureSegment] = segments;
+
+	const header = decodeSegment(headerSegment);
+	if (!header) {
+		return fail('client_assertion header is malformed');
+	}
+	// Exact-alg pinning: blocks `none` and any RS/HS/ES downgrade before key work.
+	if (header.alg !== 'EdDSA') {
+		return fail('client_assertion alg must be EdDSA');
+	}
+	// RFC 7515 §4.1.9: `typ` is optional; when present it must be JWT
+	// (case-insensitive per its definition).
+	if (header.typ !== undefined && (typeof header.typ !== 'string' || header.typ.toUpperCase() !== 'JWT')) {
+		return fail('client_assertion typ must be JWT');
+	}
+	// RFC 7515 §4.1.11: `crit` demands the listed extensions be understood; we
+	// implement none, so any `crit` fails closed.
+	if (header.crit !== undefined) {
+		return fail('client_assertion crit extensions are not supported');
+	}
+
+	const selected = selectKey(jwks, header.kid);
+	if ('error' in selected) {
+		return fail(selected.error);
+	}
+	const publicKey = loadEd25519PublicKey(selected.jwk);
+	if (!publicKey) {
+		return fail('registered JWK is not a public Ed25519 key');
+	}
+
+	if (!BASE64URL_PATTERN.test(signatureSegment)) {
+		return fail('client_assertion signature is malformed');
+	}
+	const signature = Buffer.from(signatureSegment, 'base64url');
+	if (signature.length !== ED25519_SIGNATURE_LENGTH) {
+		return fail('client_assertion signature is malformed');
+	}
+	// Ed25519 verification takes no digest algorithm (pass null); the signing
+	// input is the raw ASCII of "header.payload" (RFC 7515 §5.1).
+	let signatureOk: boolean;
+	try {
+		signatureOk = verifySignature(null, Buffer.from(`${headerSegment}.${payloadSegment}`), publicKey, signature);
+	} catch {
+		signatureOk = false;
+	}
+	if (!signatureOk) {
+		return fail('client_assertion signature verification failed');
+	}
+
+	const payload = decodeSegment(payloadSegment);
+	if (!payload) {
+		return fail('client_assertion payload is malformed');
+	}
+
+	// RFC 7523 §3: iss = sub = client_id, all bound to the authenticating client.
+	if (payload.iss !== clientId) {
+		return fail('client_assertion iss does not match client_id');
+	}
+	if (payload.sub !== clientId) {
+		return fail('client_assertion sub does not match client_id');
+	}
+
+	// `aud` must be the token endpoint, exactly — a string or a single-element
+	// array. Multiple audiences are rejected as ambiguous (design review: no
+	// prefix/wildcard/multi-audience comparisons).
+	const aud = Array.isArray(payload.aud) && payload.aud.length === 1 ? payload.aud[0] : payload.aud;
+	if (typeof aud !== 'string' || aud !== tokenEndpoint) {
+		return fail('client_assertion aud does not match the token endpoint');
+	}
+
+	const now = Math.floor(Date.now() / 1000);
+
+	const exp = payload.exp;
+	if (typeof exp !== 'number' || !Number.isFinite(exp)) {
+		return fail('client_assertion exp is required');
+	}
+	if (exp <= now - clockTolerance) {
+		return fail('client_assertion has expired');
+	}
+	if (exp > now + maxExpiresIn + clockTolerance) {
+		return fail(`client_assertion exp exceeds the maximum window of ${maxExpiresIn}s`);
+	}
+
+	const iat = payload.iat;
+	if (typeof iat !== 'number' || !Number.isFinite(iat)) {
+		return fail('client_assertion iat is required');
+	}
+	if (iat > now + clockTolerance) {
+		return fail('client_assertion iat is in the future');
+	}
+
+	if (payload.nbf !== undefined) {
+		if (typeof payload.nbf !== 'number' || !Number.isFinite(payload.nbf)) {
+			return fail('client_assertion nbf is invalid');
+		}
+		if (payload.nbf > now + clockTolerance) {
+			return fail('client_assertion is not yet valid');
+		}
+	}
+
+	const jti = payload.jti;
+	if (typeof jti !== 'string' || jti.length === 0 || jti.length > MAX_JTI_LENGTH) {
+		return fail('client_assertion jti is required');
+	}
+
+	return {
+		valid: true,
+		claims: { iss: clientId, sub: clientId, aud, exp, iat, jti },
+	};
+}

--- a/src/lib/mcp/clientAssertion.ts
+++ b/src/lib/mcp/clientAssertion.ts
@@ -302,8 +302,11 @@ export function verifyClientAssertion(params: VerifyClientAssertionParams): Clie
 	}
 
 	const jti = payload.jti;
-	if (typeof jti !== 'string' || jti.length === 0 || jti.length > MAX_JTI_LENGTH) {
+	if (typeof jti !== 'string' || jti.length === 0) {
 		return fail('client_assertion jti is required');
+	}
+	if (jti.length > MAX_JTI_LENGTH) {
+		return fail('client_assertion jti exceeds the maximum length');
 	}
 
 	return {

--- a/src/lib/mcp/clientAssertion.ts
+++ b/src/lib/mcp/clientAssertion.ts
@@ -250,6 +250,9 @@ export function verifyClientAssertion(params: VerifyClientAssertionParams): Clie
 	if (exp <= now - clockTolerance) {
 		return fail('client_assertion has expired');
 	}
+	// Primary window bound: `exp` is capped relative to NOW, so any single
+	// assertion is usable for at most ~maxExpiresIn seconds of wall-clock
+	// regardless of what `iat` claims — a far-future `exp` is rejected here.
 	if (exp > now + maxExpiresIn + clockTolerance) {
 		return fail(`client_assertion exp exceeds the maximum window of ${maxExpiresIn}s`);
 	}
@@ -260,6 +263,14 @@ export function verifyClientAssertion(params: VerifyClientAssertionParams): Clie
 	}
 	if (iat > now + clockTolerance) {
 		return fail('client_assertion iat is in the future');
+	}
+	// Strictness bound (defense-in-depth): reject an assertion whose self-declared
+	// lifetime (exp - iat) exceeds the policy window even when `exp` sits inside
+	// the now-relative bound above. Such a token isn't exploitable on its own (the
+	// now-relative cap already limits usable life), but it doesn't honor the
+	// ≤maxExpiresIn assertion contract, so a strict verifier refuses it.
+	if (exp - iat > maxExpiresIn + clockTolerance) {
+		return fail(`client_assertion lifetime (exp - iat) exceeds the maximum window of ${maxExpiresIn}s`);
 	}
 
 	if (payload.nbf !== undefined) {

--- a/src/lib/mcp/clientAssertion.ts
+++ b/src/lib/mcp/clientAssertion.ts
@@ -84,6 +84,23 @@ function fail(reason: string): ClientAssertionResult {
 	return { valid: false, reason };
 }
 
+/**
+ * Normalize a window option (seconds) to a safe finite number, falling back to
+ * the conservative default on anything non-finite. These options are the
+ * enforcement boundary for the RFC 7523 §3 validity-window checks, and the
+ * comparisons below fail OPEN on `NaN`/`Infinity` (e.g. `exp > now + NaN` is
+ * always false, so a far-future `exp` would be accepted). #162 will wire these
+ * from `mcp` config, where `${ENV}`/quoted-YAML can deliver a string or
+ * garbage — so coerce here, mirroring token.ts's `coerceTtl`. `allowZero`
+ * distinguishes the tolerance (0 is a valid "no skew") from the max window
+ * (0 would be a nonsensical always-reject, treated as misconfig → default).
+ */
+function coerceWindowSeconds(value: unknown, fallback: number, allowZero: boolean): number {
+	const n = typeof value === 'number' ? value : Number(value);
+	if (!Number.isFinite(n) || n < 0 || (n === 0 && !allowZero)) return fallback;
+	return n;
+}
+
 function decodeSegment(segment: string): Record<string, unknown> | null {
 	if (!BASE64URL_PATTERN.test(segment)) return null;
 	let parsed: unknown;
@@ -154,8 +171,10 @@ function selectKey(
  */
 export function verifyClientAssertion(params: VerifyClientAssertionParams): ClientAssertionResult {
 	const { assertion, clientId, tokenEndpoint, jwks } = params;
-	const maxExpiresIn = params.maxExpiresInSeconds ?? DEFAULT_MAX_EXPIRES_IN_SECONDS;
-	const clockTolerance = params.clockToleranceSeconds ?? DEFAULT_CLOCK_TOLERANCE_SECONDS;
+	// Coerce the window options up front — a NaN/Infinity here would make the
+	// time-window comparisons fail open (see coerceWindowSeconds).
+	const maxExpiresIn = coerceWindowSeconds(params.maxExpiresInSeconds, DEFAULT_MAX_EXPIRES_IN_SECONDS, false);
+	const clockTolerance = coerceWindowSeconds(params.clockToleranceSeconds, DEFAULT_CLOCK_TOLERANCE_SECONDS, true);
 
 	if (typeof assertion !== 'string' || assertion.length === 0) {
 		return fail('client_assertion is required');

--- a/src/lib/mcp/clientAssertion.ts
+++ b/src/lib/mcp/clientAssertion.ts
@@ -36,6 +36,12 @@ const DEFAULT_MAX_EXPIRES_IN_SECONDS = 60;
 const DEFAULT_CLOCK_TOLERANCE_SECONDS = 5;
 /** Bound what a client can force into the replay table. */
 const MAX_JTI_LENGTH = 256;
+/**
+ * Cap on the whole compact JWT before any split/decode work — a legitimate
+ * Ed25519 assertion with our claim set is well under 1KB, so 8KB is generous.
+ * Same defense-in-depth family as the repo's 2048-char request-path cap.
+ */
+const MAX_ASSERTION_LENGTH = 8192;
 /** Ed25519 signatures are always exactly 64 bytes (RFC 8032). */
 const ED25519_SIGNATURE_LENGTH = 64;
 
@@ -122,16 +128,23 @@ function selectKey(
 	if (!Array.isArray(jwks) || jwks.length === 0) {
 		return { error: 'client has no registered JWKs' };
 	}
+	// Registration (#161) should never store non-object entries, but this
+	// module promises "never throws" — so a null/primitive element must fail
+	// the lookup, not TypeError inside it.
 	if (kid !== undefined) {
 		if (typeof kid !== 'string' || kid.length === 0) return { error: 'assertion kid must be a non-empty string' };
-		const matches = jwks.filter((k) => k.kid === kid);
+		const matches = jwks.filter((k) => k !== null && typeof k === 'object' && k.kid === kid);
 		if (matches.length !== 1) return { error: 'assertion kid does not match exactly one registered key' };
 		return { jwk: matches[0] };
 	}
 	if (jwks.length !== 1) {
 		return { error: 'assertion kid is required when multiple keys are registered' };
 	}
-	return { jwk: jwks[0] };
+	const singleKey = jwks[0];
+	if (singleKey === null || typeof singleKey !== 'object') {
+		return { error: 'registered JWK is malformed' };
+	}
+	return { jwk: singleKey };
 }
 
 /**
@@ -146,6 +159,9 @@ export function verifyClientAssertion(params: VerifyClientAssertionParams): Clie
 
 	if (typeof assertion !== 'string' || assertion.length === 0) {
 		return fail('client_assertion is required');
+	}
+	if (assertion.length > MAX_ASSERTION_LENGTH) {
+		return fail('client_assertion exceeds the maximum allowed length');
 	}
 	if (typeof clientId !== 'string' || clientId.length === 0) {
 		return fail('client_id is required');

--- a/src/types.ts
+++ b/src/types.ts
@@ -516,6 +516,14 @@ export interface ProviderRegistry {
 export interface Table {
 	get(id: string): Promise<any>;
 	put(record: any): Promise<any>;
+	/**
+	 * Insert-if-absent: creates the record, throwing a 409 `ClientError`
+	 * ("Record already exists") when a record with the same primary key
+	 * exists. NOTE: Harper currently enforces the existence check against the
+	 * pre-staging snapshot only — concurrent creates can degrade to
+	 * last-write-wins (HarperFast/harper#1745).
+	 */
+	create(record: any): Promise<any>;
 	delete(id: string): Promise<void>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -239,7 +239,8 @@ export interface MCPRefreshFamilyRecord {
 export interface MCPAssertionJtiRecord {
 	id: string;
 	client_id: string;
-	created_at: number;
+	/** Harper-assigned (epoch ms) via @createdTime; never written by the app. */
+	created_at?: number;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -229,6 +229,20 @@ export interface MCPRefreshFamilyRecord {
 }
 
 /**
+ * MCP client-assertion replay-guard record (table `mcp_assertion_jtis`,
+ * `expiration: 120`).
+ *
+ * `id` is sha256(client_id, jti) — see assertionJtiStore.ts for the keying
+ * and accepted-race notes. Rows only need to outlive the maximum assertion
+ * window; the table TTL evicts them.
+ */
+export interface MCPAssertionJtiRecord {
+	id: string;
+	client_id: string;
+	created_at: number;
+}
+
+/**
  * OAuth Lifecycle Hooks
  * Callbacks invoked at key points in the OAuth flow
  */

--- a/test/lib/mcp/assertionJtiStore.test.js
+++ b/test/lib/mcp/assertionJtiStore.test.js
@@ -1,5 +1,13 @@
 /**
  * Tests for MCPAssertionJtiStore (client-assertion replay guard)
+ *
+ * The guard uses Table.create() — insert-if-absent, 409 on an existing
+ * record — so the mock implements that contract. NOTE: the mock's create is
+ * synchronous-atomic, which matches Harper's SEQUENTIAL semantics; real
+ * Harper currently enforces the existence check pre-staging only, so
+ * concurrent in-flight creates can all report success (harper#1745). The
+ * concurrency test below pins only the properties that hold under both
+ * semantics: at least one winner, and rejection once a create has settled.
  */
 
 import { describe, it, before, after, beforeEach } from 'node:test';
@@ -10,15 +18,10 @@ import {
 	resetMCPAssertionJtisTableCache,
 } from '../../../dist/lib/mcp/assertionJtiStore.js';
 
-function asTrackedObject(plain) {
-	return new Proxy(plain, {
-		ownKeys() {
-			return [];
-		},
-		getOwnPropertyDescriptor() {
-			return undefined;
-		},
-	});
+function conflictError() {
+	const error = new Error('Record already exists');
+	error.statusCode = 409;
+	return error;
 }
 
 describe('MCPAssertionJtiStore', () => {
@@ -40,11 +43,8 @@ describe('MCPAssertionJtiStore', () => {
 		store = new MCPAssertionJtiStore();
 		storedRecords = new Map();
 		mockTable = {
-			get: async (id) => {
-				const raw = storedRecords.get(id);
-				return raw ? asTrackedObject(raw) : null;
-			},
-			put: async (record) => {
+			create: async (record) => {
+				if (storedRecords.has(record.id)) throw conflictError();
 				storedRecords.set(record.id, record);
 			},
 		};
@@ -55,24 +55,24 @@ describe('MCPAssertionJtiStore', () => {
 		};
 	});
 
-	it('returns true on first sighting and persists the hashed key', async () => {
+	it('returns true on first sighting and persists under the hashed key', async () => {
 		const ok = await store.checkAndRecord('client-1', 'jti-abc');
 		assert.equal(ok, true);
 		assert.equal(storedRecords.size, 1);
 		const stored = storedRecords.get(jtiKey('client-1', 'jti-abc'));
-		assert.ok(stored, 'record stored under sha256(client_id, jti)');
+		assert.ok(stored, 'record stored under sha256(len:client_id:jti)');
 		assert.equal(stored.client_id, 'client-1');
 		// created_at is Harper-assigned via @createdTime — the app must NOT hand-write it.
 		assert.equal(stored.created_at, undefined);
 	});
 
-	it('returns false on a replayed jti (tracked-object Proxy read path)', async () => {
+	it('returns false on a replayed jti (create 409 → replay)', async () => {
 		assert.equal(await store.checkAndRecord('client-1', 'jti-abc'), true);
 		assert.equal(await store.checkAndRecord('client-1', 'jti-abc'), false);
 		assert.equal(storedRecords.size, 1, 'replay does not write a second record');
 	});
 
-	it('treats ANY truthy stored record as a replay, even a malformed one without id', async () => {
+	it('treats ANY pre-existing record as a replay, even a malformed one', async () => {
 		storedRecords.set(jtiKey('client-1', 'jti-abc'), {});
 		assert.equal(await store.checkAndRecord('client-1', 'jti-abc'), false);
 	});
@@ -89,18 +89,35 @@ describe('MCPAssertionJtiStore', () => {
 		assert.match(jtiKey('a', 'b'), /^[0-9a-f]{64}$/);
 	});
 
-	it('propagates read errors (fail closed — never "could not check, assume fresh")', async () => {
-		mockTable.get = async () => {
-			throw new Error('db read failure');
-		};
-		await assert.rejects(() => store.checkAndRecord('client-1', 'jti-abc'), /db read failure/);
-	});
-
-	it('propagates write errors so the grant refuses issuance', async () => {
-		mockTable.put = async () => {
+	it('propagates non-409 storage errors (fail closed — never "could not check, assume fresh")', async () => {
+		mockTable.create = async () => {
 			throw new Error('db write failure');
 		};
 		await assert.rejects(() => store.checkAndRecord('client-1', 'jti-abc'), /db write failure/);
+	});
+
+	it('propagates a non-409 ClientError rather than treating it as a replay', async () => {
+		mockTable.create = async () => {
+			const error = new Error('table overloaded');
+			error.statusCode = 503;
+			throw error;
+		};
+		await assert.rejects(() => store.checkAndRecord('client-1', 'jti-abc'), /table overloaded/);
+	});
+
+	it('concurrent presentations: at least one wins, and replay is rejected once settled', async () => {
+		// Pins the SAFE properties that hold under both current-Harper
+		// (pre-staging check only; in-flight duplicates may all succeed —
+		// harper#1745) and per-node-atomic semantics (exactly one winner).
+		// The mock serializes, so it yields exactly one winner; on real Harper
+		// the winner count may exceed 1 for in-flight overlap, which is the
+		// documented residual risk in the module header.
+		const results = await Promise.all(Array.from({ length: 8 }, () => store.checkAndRecord('client-1', 'burst-jti')));
+		const winners = results.filter(Boolean).length;
+		assert.ok(winners >= 1, 'at least one presentation must win');
+		assert.equal(storedRecords.size, 1, 'exactly one record persisted');
+		// After any create has settled, every later presentation is a replay.
+		assert.equal(await store.checkAndRecord('client-1', 'burst-jti'), false);
 	});
 
 	it('throws a descriptive error when the table is missing', async () => {

--- a/test/lib/mcp/assertionJtiStore.test.js
+++ b/test/lib/mcp/assertionJtiStore.test.js
@@ -1,0 +1,105 @@
+/**
+ * Tests for MCPAssertionJtiStore (client-assertion replay guard)
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	MCPAssertionJtiStore,
+	jtiKey,
+	resetMCPAssertionJtisTableCache,
+} from '../../../dist/lib/mcp/assertionJtiStore.js';
+
+function asTrackedObject(plain) {
+	return new Proxy(plain, {
+		ownKeys() {
+			return [];
+		},
+		getOwnPropertyDescriptor() {
+			return undefined;
+		},
+	});
+}
+
+describe('MCPAssertionJtiStore', () => {
+	let store;
+	let originalDatabases;
+	let storedRecords;
+	let mockTable;
+
+	before(() => {
+		originalDatabases = global.databases;
+	});
+
+	after(() => {
+		global.databases = originalDatabases;
+	});
+
+	beforeEach(() => {
+		resetMCPAssertionJtisTableCache();
+		store = new MCPAssertionJtiStore();
+		storedRecords = new Map();
+		mockTable = {
+			get: async (id) => {
+				const raw = storedRecords.get(id);
+				return raw ? asTrackedObject(raw) : null;
+			},
+			put: async (record) => {
+				storedRecords.set(record.id, record);
+			},
+		};
+		global.databases = {
+			oauth: {
+				mcp_assertion_jtis: mockTable,
+			},
+		};
+	});
+
+	it('returns true on first sighting and persists the hashed key', async () => {
+		const ok = await store.checkAndRecord('client-1', 'jti-abc');
+		assert.equal(ok, true);
+		assert.equal(storedRecords.size, 1);
+		const stored = storedRecords.get(jtiKey('client-1', 'jti-abc'));
+		assert.ok(stored, 'record stored under sha256(client_id, jti)');
+		assert.equal(stored.client_id, 'client-1');
+		assert.equal(typeof stored.created_at, 'number');
+	});
+
+	it('returns false on a replayed jti (tracked-object Proxy read path)', async () => {
+		assert.equal(await store.checkAndRecord('client-1', 'jti-abc'), true);
+		assert.equal(await store.checkAndRecord('client-1', 'jti-abc'), false);
+		assert.equal(storedRecords.size, 1, 'replay does not write a second record');
+	});
+
+	it('scopes replay per client: the same jti from another client is fresh', async () => {
+		assert.equal(await store.checkAndRecord('client-1', 'shared-jti'), true);
+		assert.equal(await store.checkAndRecord('client-2', 'shared-jti'), true);
+		assert.equal(storedRecords.size, 2);
+	});
+
+	it('keys cannot collide via delimiter stuffing', () => {
+		// ("a", "b\nc") must not collide with ("a\nb", "c").
+		assert.notEqual(jtiKey('a', 'b\nc'), jtiKey('a\nb', 'c'));
+		assert.match(jtiKey('a', 'b'), /^[0-9a-f]{64}$/);
+	});
+
+	it('propagates read errors (fail closed — never "could not check, assume fresh")', async () => {
+		mockTable.get = async () => {
+			throw new Error('db read failure');
+		};
+		await assert.rejects(() => store.checkAndRecord('client-1', 'jti-abc'), /db read failure/);
+	});
+
+	it('propagates write errors so the grant refuses issuance', async () => {
+		mockTable.put = async () => {
+			throw new Error('db write failure');
+		};
+		await assert.rejects(() => store.checkAndRecord('client-1', 'jti-abc'), /db write failure/);
+	});
+
+	it('throws a descriptive error when the table is missing', async () => {
+		global.databases = { oauth: {} };
+		resetMCPAssertionJtisTableCache();
+		await assert.rejects(() => store.checkAndRecord('client-1', 'jti-abc'), /mcp_assertion_jtis/);
+	});
+});

--- a/test/lib/mcp/assertionJtiStore.test.js
+++ b/test/lib/mcp/assertionJtiStore.test.js
@@ -71,6 +71,11 @@ describe('MCPAssertionJtiStore', () => {
 		assert.equal(storedRecords.size, 1, 'replay does not write a second record');
 	});
 
+	it('treats ANY truthy stored record as a replay, even a malformed one without id', async () => {
+		storedRecords.set(jtiKey('client-1', 'jti-abc'), {});
+		assert.equal(await store.checkAndRecord('client-1', 'jti-abc'), false);
+	});
+
 	it('scopes replay per client: the same jti from another client is fresh', async () => {
 		assert.equal(await store.checkAndRecord('client-1', 'shared-jti'), true);
 		assert.equal(await store.checkAndRecord('client-2', 'shared-jti'), true);

--- a/test/lib/mcp/assertionJtiStore.test.js
+++ b/test/lib/mcp/assertionJtiStore.test.js
@@ -62,7 +62,8 @@ describe('MCPAssertionJtiStore', () => {
 		const stored = storedRecords.get(jtiKey('client-1', 'jti-abc'));
 		assert.ok(stored, 'record stored under sha256(client_id, jti)');
 		assert.equal(stored.client_id, 'client-1');
-		assert.equal(typeof stored.created_at, 'number');
+		// created_at is Harper-assigned via @createdTime — the app must NOT hand-write it.
+		assert.equal(stored.created_at, undefined);
 	});
 
 	it('returns false on a replayed jti (tracked-object Proxy read path)', async () => {

--- a/test/lib/mcp/clientAssertion.test.js
+++ b/test/lib/mcp/clientAssertion.test.js
@@ -296,6 +296,12 @@ describe('verifyClientAssertion', () => {
 			rejectPayload(defaultPayload({ exp: nowSeconds() + 300 }), /exceeds the maximum window/);
 		});
 
+		it('rejects an over-long self-declared lifetime (old iat, near-now exp)', () => {
+			// exp is inside the now-relative window, but exp - iat advertises a
+			// far-longer lifetime than the policy allows — strict verifier refuses it.
+			rejectPayload(defaultPayload({ iat: nowSeconds() - 3600, exp: nowSeconds() + 30 }), /lifetime .* exceeds/);
+		});
+
 		it('honors a custom maxExpiresInSeconds', () => {
 			rejectPayload(defaultPayload({ exp: nowSeconds() + 25 }), /exceeds the maximum window/, {
 				maxExpiresInSeconds: 10,

--- a/test/lib/mcp/clientAssertion.test.js
+++ b/test/lib/mcp/clientAssertion.test.js
@@ -113,6 +113,15 @@ describe('verifyClientAssertion', () => {
 			}
 		});
 
+		it('rejects an assertion over the 8KB length cap before any decode work', () => {
+			const { privateKey, jwk } = makeKeyPair();
+			const good = makeAssertion({ privateKey });
+			const oversized = good + 'A'.repeat(8192);
+			const result = verify(oversized, [jwk]);
+			assert.equal(result.valid, false);
+			assert.match(result.reason, /maximum allowed length/);
+		});
+
 		it('rejects base64url segments containing invalid characters', () => {
 			const { privateKey, jwk } = makeKeyPair();
 			const good = makeAssertion({ privateKey });
@@ -196,6 +205,21 @@ describe('verifyClientAssertion', () => {
 			const result = verify(makeAssertion({ privateKey }), [withPrivate]);
 			assert.equal(result.valid, false);
 			assert.match(result.reason, /not a public Ed25519 key/);
+		});
+
+		it('rejects null/primitive JWK Set entries without throwing (never-throws contract)', () => {
+			const { privateKey, jwk } = makeKeyPair();
+			// Single-entry sets on the no-kid path.
+			for (const entry of [null, 42, 'key']) {
+				const result = verify(makeAssertion({ privateKey }), [entry]);
+				assert.equal(result.valid, false, `expected rejection for single entry ${JSON.stringify(entry)}`);
+			}
+			// Mixed sets on the kid path: the null entry must not throw during selection.
+			const result = verify(makeAssertion({ header: { alg: 'EdDSA', kid: 'key-a' }, privateKey }), [
+				null,
+				{ ...jwk, kid: 'key-a' },
+			]);
+			assert.equal(result.valid, true);
 		});
 
 		it('rejects non-OKP and non-Ed25519 JWKs', () => {

--- a/test/lib/mcp/clientAssertion.test.js
+++ b/test/lib/mcp/clientAssertion.test.js
@@ -358,11 +358,14 @@ describe('verifyClientAssertion', () => {
 			rejectPayload(defaultPayload({ nbf: 'later' }), /nbf is invalid/);
 		});
 
-		it('rejects a missing, empty, non-string, or oversized jti', () => {
+		it('rejects a missing, empty, or non-string jti as required', () => {
 			rejectPayload(defaultPayload({ jti: undefined }), /jti is required/);
 			rejectPayload(defaultPayload({ jti: '' }), /jti is required/);
 			rejectPayload(defaultPayload({ jti: 42 }), /jti is required/);
-			rejectPayload(defaultPayload({ jti: 'x'.repeat(257) }), /jti is required/);
+		});
+
+		it('rejects an oversized jti with a length-specific message (not "required")', () => {
+			rejectPayload(defaultPayload({ jti: 'x'.repeat(257) }), /jti exceeds the maximum length/);
 		});
 	});
 });

--- a/test/lib/mcp/clientAssertion.test.js
+++ b/test/lib/mcp/clientAssertion.test.js
@@ -309,6 +309,45 @@ describe('verifyClientAssertion', () => {
 			});
 		});
 
+		it('does not fail open when window options are NaN/Infinity/negative (falls back to defaults)', () => {
+			const { privateKey, jwk } = makeKeyPair();
+			const farFuture = () => defaultPayload({ exp: nowSeconds() + 3600 });
+			const expired = () => defaultPayload({ exp: nowSeconds() - 3600, iat: nowSeconds() - 3630 });
+			// A poisoned maxExpiresInSeconds must not let a far-future exp through.
+			for (const bad of [NaN, Infinity, -Infinity, -5, 0]) {
+				const result = verify(makeAssertion({ privateKey, payload: farFuture() }), [jwk], {
+					maxExpiresInSeconds: bad,
+				});
+				assert.equal(result.valid, false, `far-future exp accepted with maxExpiresInSeconds=${bad}`);
+				assert.match(result.reason, /exceeds the maximum window/);
+			}
+			// A poisoned clockToleranceSeconds must not let an expired assertion through.
+			for (const bad of [NaN, Infinity, -1]) {
+				const result = verify(makeAssertion({ privateKey, payload: expired() }), [jwk], {
+					clockToleranceSeconds: bad,
+				});
+				assert.equal(result.valid, false, `expired assertion accepted with clockToleranceSeconds=${bad}`);
+				assert.match(result.reason, /has expired/);
+			}
+		});
+
+		it('accepts config-shaped numeric strings for the window options', () => {
+			const { privateKey, jwk } = makeKeyPair();
+			// exp within a string "10" window but tolerance "0" — mirrors YAML/${ENV} config.
+			const result = verify(makeAssertion({ privateKey, payload: defaultPayload({ exp: nowSeconds() + 5 }) }), [jwk], {
+				maxExpiresInSeconds: '10',
+				clockToleranceSeconds: '0',
+			});
+			assert.equal(result.valid, true);
+			// And the string window is still enforced as a bound.
+			const tooFar = verify(makeAssertion({ privateKey, payload: defaultPayload({ exp: nowSeconds() + 25 }) }), [jwk], {
+				maxExpiresInSeconds: '10',
+				clockToleranceSeconds: '0',
+			});
+			assert.equal(tooFar.valid, false);
+			assert.match(tooFar.reason, /exceeds the maximum window/);
+		});
+
 		it('rejects missing or future iat', () => {
 			rejectPayload(defaultPayload({ iat: undefined }), /iat is required/);
 			rejectPayload(defaultPayload({ iat: nowSeconds() + 120 }), /iat is in the future/);

--- a/test/lib/mcp/clientAssertion.test.js
+++ b/test/lib/mcp/clientAssertion.test.js
@@ -1,0 +1,299 @@
+/**
+ * Tests for verifyClientAssertion (RFC 7523 §3 private_key_jwt, EdDSA-only).
+ *
+ * Assertions are built by hand (base64url + node:crypto sign) rather than via
+ * a JWT library so the tests can produce every malformed shape the verifier
+ * must reject.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { generateKeyPairSync, sign as signRaw } from 'node:crypto';
+import { verifyClientAssertion, CLIENT_ASSERTION_TYPE_JWT_BEARER } from '../../../dist/lib/mcp/clientAssertion.js';
+
+const CLIENT_ID = 'agent-client-1';
+const TOKEN_ENDPOINT = 'https://mcp.example.com/oauth/mcp/token';
+
+function makeKeyPair() {
+	const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+	return { privateKey, jwk: publicKey.export({ format: 'jwk' }) };
+}
+
+function b64url(value) {
+	return Buffer.from(typeof value === 'string' ? value : JSON.stringify(value)).toString('base64url');
+}
+
+function nowSeconds() {
+	return Math.floor(Date.now() / 1000);
+}
+
+function defaultPayload(overrides = {}) {
+	const now = nowSeconds();
+	return {
+		iss: CLIENT_ID,
+		sub: CLIENT_ID,
+		aud: TOKEN_ENDPOINT,
+		exp: now + 30,
+		iat: now,
+		jti: `jti-${Math.random().toString(36).slice(2)}`,
+		...overrides,
+	};
+}
+
+/** Build and sign an assertion, allowing every part to be overridden. */
+function makeAssertion({ header = { alg: 'EdDSA' }, payload = defaultPayload(), privateKey, rawSignature } = {}) {
+	const h = b64url(header);
+	const p = b64url(payload);
+	const sig = rawSignature ?? signRaw(null, Buffer.from(`${h}.${p}`), privateKey).toString('base64url');
+	return `${h}.${p}.${sig}`;
+}
+
+function verify(assertion, jwks, extra = {}) {
+	return verifyClientAssertion({
+		assertion,
+		clientId: CLIENT_ID,
+		tokenEndpoint: TOKEN_ENDPOINT,
+		jwks,
+		...extra,
+	});
+}
+
+describe('verifyClientAssertion', () => {
+	describe('success paths', () => {
+		it('verifies a well-formed EdDSA assertion and returns its claims', () => {
+			const { privateKey, jwk } = makeKeyPair();
+			const payload = defaultPayload();
+			const result = verify(makeAssertion({ privateKey, payload }), [jwk]);
+			assert.equal(result.valid, true);
+			assert.equal(result.claims.iss, CLIENT_ID);
+			assert.equal(result.claims.sub, CLIENT_ID);
+			assert.equal(result.claims.aud, TOKEN_ENDPOINT);
+			assert.equal(result.claims.jti, payload.jti);
+			assert.equal(result.claims.exp, payload.exp);
+			assert.equal(result.claims.iat, payload.iat);
+		});
+
+		it('accepts aud as a single-element array (RFC 7519), unwrapping it', () => {
+			const { privateKey, jwk } = makeKeyPair();
+			const payload = defaultPayload({ aud: [TOKEN_ENDPOINT] });
+			const result = verify(makeAssertion({ privateKey, payload }), [jwk]);
+			assert.equal(result.valid, true);
+			assert.equal(result.claims.aud, TOKEN_ENDPOINT);
+		});
+
+		it('accepts typ: JWT case-insensitively and a passed nbf', () => {
+			const { privateKey, jwk } = makeKeyPair();
+			const payload = defaultPayload({ nbf: nowSeconds() - 10 });
+			const result = verify(makeAssertion({ header: { alg: 'EdDSA', typ: 'jwt' }, privateKey, payload }), [jwk]);
+			assert.equal(result.valid, true);
+		});
+
+		it('selects the right key by kid among multiple registered keys', () => {
+			const other = makeKeyPair();
+			const { privateKey, jwk } = makeKeyPair();
+			const keys = [
+				{ ...other.jwk, kid: 'key-a' },
+				{ ...jwk, kid: 'key-b' },
+			];
+			const result = verify(makeAssertion({ header: { alg: 'EdDSA', kid: 'key-b' }, privateKey }), keys);
+			assert.equal(result.valid, true);
+		});
+
+		it('exports the RFC 7523 client_assertion_type URN', () => {
+			assert.equal(CLIENT_ASSERTION_TYPE_JWT_BEARER, 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
+		});
+	});
+
+	describe('structure and header', () => {
+		it('rejects empty, non-JWT, and two-segment inputs', () => {
+			const { jwk } = makeKeyPair();
+			for (const bad of ['', 'not-a-jwt', 'aaaa.bbbb', 'a.b.c.d']) {
+				const result = verify(bad, [jwk]);
+				assert.equal(result.valid, false, `expected rejection for ${JSON.stringify(bad)}`);
+			}
+		});
+
+		it('rejects base64url segments containing invalid characters', () => {
+			const { privateKey, jwk } = makeKeyPair();
+			const good = makeAssertion({ privateKey });
+			const [h, p, s] = good.split('.');
+			const result = verify(`${h}.${p}+.${s}`, [jwk]);
+			assert.equal(result.valid, false);
+		});
+
+		it('rejects alg: none even with an empty signature', () => {
+			const { jwk } = makeKeyPair();
+			const assertion = `${b64url({ alg: 'none' })}.${b64url(defaultPayload())}.`;
+			const result = verify(assertion, [jwk]);
+			assert.equal(result.valid, false);
+			assert.match(result.reason, /alg must be EdDSA/);
+		});
+
+		it('rejects any non-EdDSA alg before doing key work (no RS/HS confusion)', () => {
+			const { privateKey, jwk } = makeKeyPair();
+			for (const alg of ['RS256', 'HS256', 'ES256', 'EDDSA', 'eddsa']) {
+				const result = verify(makeAssertion({ header: { alg }, privateKey }), [jwk]);
+				assert.equal(result.valid, false, `expected rejection for alg ${alg}`);
+				assert.match(result.reason, /alg must be EdDSA/);
+			}
+		});
+
+		it('rejects a typ other than JWT', () => {
+			const { privateKey, jwk } = makeKeyPair();
+			const result = verify(makeAssertion({ header: { alg: 'EdDSA', typ: 'JOSE' }, privateKey }), [jwk]);
+			assert.equal(result.valid, false);
+			assert.match(result.reason, /typ must be JWT/);
+		});
+
+		it('rejects assertions carrying crit extensions', () => {
+			const { privateKey, jwk } = makeKeyPair();
+			const result = verify(makeAssertion({ header: { alg: 'EdDSA', crit: ['exp'] }, privateKey }), [jwk]);
+			assert.equal(result.valid, false);
+			assert.match(result.reason, /crit/);
+		});
+	});
+
+	describe('key selection and key material', () => {
+		it('rejects when the client has no registered keys', () => {
+			const { privateKey } = makeKeyPair();
+			for (const jwks of [[], undefined, null]) {
+				const result = verify(makeAssertion({ privateKey }), jwks);
+				assert.equal(result.valid, false);
+			}
+		});
+
+		it('requires kid when multiple keys are registered', () => {
+			const a = makeKeyPair();
+			const b = makeKeyPair();
+			const result = verify(makeAssertion({ privateKey: a.privateKey }), [a.jwk, b.jwk]);
+			assert.equal(result.valid, false);
+			assert.match(result.reason, /kid is required/);
+		});
+
+		it('rejects an unknown kid instead of falling back to other keys', () => {
+			const { privateKey, jwk } = makeKeyPair();
+			const result = verify(makeAssertion({ header: { alg: 'EdDSA', kid: 'nope' }, privateKey }), [
+				{ ...jwk, kid: 'key-a' },
+			]);
+			assert.equal(result.valid, false);
+			assert.match(result.reason, /does not match exactly one/);
+		});
+
+		it('rejects a kid that matches more than one registered key', () => {
+			const a = makeKeyPair();
+			const b = makeKeyPair();
+			const keys = [
+				{ ...a.jwk, kid: 'dup' },
+				{ ...b.jwk, kid: 'dup' },
+			];
+			const result = verify(makeAssertion({ header: { alg: 'EdDSA', kid: 'dup' }, privateKey: a.privateKey }), keys);
+			assert.equal(result.valid, false);
+		});
+
+		it('rejects a registered JWK carrying private material (d)', () => {
+			const { privateKey, jwk } = makeKeyPair();
+			const withPrivate = { ...jwk, d: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' };
+			const result = verify(makeAssertion({ privateKey }), [withPrivate]);
+			assert.equal(result.valid, false);
+			assert.match(result.reason, /not a public Ed25519 key/);
+		});
+
+		it('rejects non-OKP and non-Ed25519 JWKs', () => {
+			const { privateKey } = makeKeyPair();
+			for (const jwk of [
+				{ kty: 'RSA', n: 'abc', e: 'AQAB' },
+				{ kty: 'OKP', crv: 'X25519', x: 'abc' },
+				{ kty: 'OKP', crv: 'Ed25519' }, // missing x
+				{ kty: 'OKP', crv: 'Ed25519', x: 'not!valid!base64url!!!' },
+			]) {
+				const result = verify(makeAssertion({ privateKey }), [jwk]);
+				assert.equal(result.valid, false, `expected rejection for ${JSON.stringify(jwk)}`);
+			}
+		});
+	});
+
+	describe('signature', () => {
+		it('rejects a signature from a different key', () => {
+			const attacker = makeKeyPair();
+			const { jwk } = makeKeyPair();
+			const result = verify(makeAssertion({ privateKey: attacker.privateKey }), [jwk]);
+			assert.equal(result.valid, false);
+			assert.match(result.reason, /signature verification failed/);
+		});
+
+		it('rejects a tampered payload', () => {
+			const { privateKey, jwk } = makeKeyPair();
+			const good = makeAssertion({ privateKey });
+			const [h, , s] = good.split('.');
+			const tampered = `${h}.${b64url(defaultPayload({ sub: 'someone-else' }))}.${s}`;
+			const result = verify(tampered, [jwk]);
+			assert.equal(result.valid, false);
+			assert.match(result.reason, /signature verification failed/);
+		});
+
+		it('rejects a signature that is not 64 bytes', () => {
+			const { privateKey, jwk } = makeKeyPair();
+			const result = verify(makeAssertion({ privateKey, rawSignature: b64url('short') }), [jwk]);
+			assert.equal(result.valid, false);
+			assert.match(result.reason, /signature is malformed/);
+		});
+	});
+
+	describe('claims', () => {
+		function rejectPayload(payload, reasonPattern, extra = {}) {
+			const { privateKey, jwk } = makeKeyPair();
+			const result = verify(makeAssertion({ privateKey, payload }), [jwk], extra);
+			assert.equal(result.valid, false, `expected rejection for ${JSON.stringify(payload)}`);
+			assert.match(result.reason, reasonPattern);
+		}
+
+		it('rejects iss/sub not matching client_id (RFC 7523: iss = sub = client_id)', () => {
+			rejectPayload(defaultPayload({ iss: 'other' }), /iss does not match/);
+			rejectPayload(defaultPayload({ sub: 'other' }), /sub does not match/);
+			rejectPayload(defaultPayload({ iss: undefined }), /iss does not match/);
+		});
+
+		it('rejects aud mismatches, multi-audience arrays, and non-strings', () => {
+			rejectPayload(defaultPayload({ aud: 'https://evil.example.com/token' }), /aud does not match/);
+			rejectPayload(defaultPayload({ aud: [TOKEN_ENDPOINT, 'https://other.example.com'] }), /aud does not match/);
+			rejectPayload(defaultPayload({ aud: [] }), /aud does not match/);
+			rejectPayload(defaultPayload({ aud: undefined }), /aud does not match/);
+			// Prefix of the real endpoint must not pass (no prefix matching).
+			rejectPayload(defaultPayload({ aud: 'https://mcp.example.com/oauth/mcp' }), /aud does not match/);
+		});
+
+		it('rejects missing or expired exp', () => {
+			rejectPayload(defaultPayload({ exp: undefined }), /exp is required/);
+			rejectPayload(defaultPayload({ exp: 'soon' }), /exp is required/);
+			rejectPayload(defaultPayload({ exp: nowSeconds() - 30 }), /has expired/);
+		});
+
+		it('rejects exp beyond the maximum window (default 60s)', () => {
+			rejectPayload(defaultPayload({ exp: nowSeconds() + 300 }), /exceeds the maximum window/);
+		});
+
+		it('honors a custom maxExpiresInSeconds', () => {
+			rejectPayload(defaultPayload({ exp: nowSeconds() + 25 }), /exceeds the maximum window/, {
+				maxExpiresInSeconds: 10,
+				clockToleranceSeconds: 0,
+			});
+		});
+
+		it('rejects missing or future iat', () => {
+			rejectPayload(defaultPayload({ iat: undefined }), /iat is required/);
+			rejectPayload(defaultPayload({ iat: nowSeconds() + 120 }), /iat is in the future/);
+		});
+
+		it('rejects a future nbf', () => {
+			rejectPayload(defaultPayload({ nbf: nowSeconds() + 120 }), /not yet valid/);
+			rejectPayload(defaultPayload({ nbf: 'later' }), /nbf is invalid/);
+		});
+
+		it('rejects a missing, empty, non-string, or oversized jti', () => {
+			rejectPayload(defaultPayload({ jti: undefined }), /jti is required/);
+			rejectPayload(defaultPayload({ jti: '' }), /jti is required/);
+			rejectPayload(defaultPayload({ jti: 42 }), /jti is required/);
+			rejectPayload(defaultPayload({ jti: 'x'.repeat(257) }), /jti is required/);
+		});
+	});
+});


### PR DESCRIPTION
Part 1 of 4 for #159 — closes #160. Pure primitives with no wiring: zero behavior change until the grant (#162) consumes them. Contract per the [design review](https://github.com/HarperFast/oauth/issues/159#issuecomment-4920154341).

## What's here

**`src/lib/mcp/clientAssertion.ts`** — RFC 7523 §3 client-assertion verification (`private_key_jwt`), EdDSA/Ed25519 only (RFC 8037), implemented with `node:crypto` alone — no new dependency (`jsonwebtoken` cannot verify EdDSA). Fails closed with a typed `{ valid: false, reason }` on every path; never throws.

- Exact `alg: EdDSA` pinning before any key work (blocks `none` and RS/HS confusion); `typ` optional-but-`JWT` when present; any `crit` rejected (no extensions implemented).
- JWKS key selection mirrors `verifyAccessTokenWithKeySet`: presented `kid` must match exactly one registered key (no fallback scanning); absent `kid` requires a single-key set.
- Key loading accepts only public OKP/Ed25519 JWKs — a key carrying private `d` is rejected as defense-in-depth against a registration-validation gap.
- Strict base64url validation per segment (`Buffer.from(…, 'base64url')` silently skips invalid characters, letting distinct strings decode identically) and a 64-byte Ed25519 signature length check.
- Claims: `iss` = `sub` = client_id; `aud` exactly the token endpoint (string or single-element array; multi-audience rejected); `exp` required and ≤ 60s out; `iat` required, not future; `nbf` honored when present; `jti` required and length-bounded (caps what a client can force into the replay table). 5s clock tolerance, both knobs overridable.
- Signature is verified before claims are inspected, so claim-shaped errors can't be probed without the private key.

**`src/lib/mcp/assertionJtiStore.ts`** + `mcp_assertion_jtis` table (`expiration: 120`) — the replay guard (#159 security req 1).

- Keys are `sha256` of a **length-prefixed** (client_id, jti) pair — replay scope is per client (RFC 7523 defines `jti` uniqueness per issuer), and the length prefix prevents delimiter-stuffing collisions (a test caught the naive `clientId + '\n' + jti` concat colliding on crafted inputs).
- Unlike the other MCP stores, read errors propagate: "couldn't check" must never become "not seen" on the one store whose job is rejecting repeats.
- The get-then-put race (no atomic compare-and-set; async replication) is documented in the module header — same accepted precedent as `MCPAuthCodeStore.consume`, bounded by the ≤60s assertion `exp`.

## Tests

35 new tests (841 total, all green): verify success paths (incl. `aud`-as-array, `typ` case-insensitivity, multi-key `kid` selection), structural rejections (segment counts, invalid base64url, `alg: none`, RS/HS/case downgrades, `crit`), key-material rejections (private `d`, RSA/X25519/malformed JWKs, empty set, ambiguous/unknown/duplicate `kid`), signature rejections (wrong key, tampered payload, short signature), the full claims matrix (iss/sub/aud incl. prefix-of-endpoint, exp/iat/nbf windows, jti bounds), and the store (first-sighting/replay through the tracked-object Proxy read path, per-client scoping, delimiter-stuffing keys, fail-closed error propagation).

Lint clean (the 4 warnings are pre-existing in `hookManager.test.js`); prettier clean.

## Review status

CI review bots (Gemini, Claude) found no blockers; all four inline suggestions were adjudicated as real and fixed in `bf00888` (8KB assertion cap, replay guard hardened to treat any truthy record as a replay, `selectKey` null/primitive JWK-entry guards, stale module-header comment).

Two Codex cross-model passes:
- Pass 1 (P2): a possible >60s window via old `iat` + far-future `exp`. Adjudicated — the attack is **already blocked** (`exp` is bounded relative to *now*), but it exposed a real strictness gap: the verifier didn't enforce that the *self-declared* lifetime (`exp - iat`) conforms to the policy window. Closed in `024ab58` as defense-in-depth.
- Pass 2 (security/perf/standards): the window options (`maxExpiresInSeconds`/`clockToleranceSeconds`) were trusted as finite — a `NaN`/`Infinity` would fail the time-window checks open. Not reachable today (callers default to 60/5), but #162 wires these from `mcp` config. Coerced up front like `coerceTtl` in `1828274`.

No open cross-model findings remain.

## Where to look

- The claim-validation ordering in `verifyClientAssertion` (signature before claims) and the `aud`/`exp` window rules — this is the security contract of #159, so a second pair of eyes on the RFC 7523 §3 reading is the highest-value review.

## Replay-guard residual risk (explicit sign-off item, per review)

The jti guard uses `Table.create()` (insert-if-absent, 409 on existing) — **not** an awaited get-then-put, after @kriszyp's review prompted a deep dive. What a merge signs off on:

- **Sequential replay: rejected** — any presentation after a create has committed gets the 409.
- **Same-node concurrent in-flight duplicates: may all succeed today.** Harper enforces `create()`'s existence check pre-staging only; the losing create currently degrades to last-write-wins with both callers reporting success (HarperFast/harper#1745, filed from this review — includes the by-design analysis and a per-node enforcement path via the existing retry/`sourceApply` seam). Exposure window: the staging→commit interval, not the assertion's ~60s validity.
- **Cross-node: bounded by replication lag** — by design (coordination-free LWW convergence); irreducible without consensus Harper deliberately doesn't do.
- Each duplicate acceptance mints one short-TTL (≤5 min) token for a client that **does** hold the private key — this narrows abuse to token-count inflation from a captured-in-flight assertion, not impersonation.
- If harper#1745 lands per-node 409 enforcement, this guard becomes fully atomic per node with **zero code change** (the catch already handles it).
- A concurrency test pins the properties stable under both semantics (≥1 winner; replay rejected once settled).

## Docs

No docs change in this PR: these primitives have no user-facing surface until the grant wires them up in #162, which will carry the documentation for the whole flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Fable 5
