### PR TITLE
Release 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@harperfast/oauth` are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Entries prior to 2.2.0 were backfilled from the [GitHub release notes](https://github.com/HarperFast/oauth/releases).
 
+## [2.2.1] - 2026-07-11
+
+Docs-only patch — refreshes the README (and therefore the npm package page), which predated 2.2.0's MCP features.
+
+### Changed
+
+- README: documented headless-agent (`client_credentials`) authentication and CIMD in the MCP section, added the CIMD default-on security caveat, corrected the Database Schema section to the actual table set (`schema/oauth.graphql`), retired the closed #86 pointer in favor of #156, and linked this changelog.
+
 ## [2.2.0] - 2026-07-11
 
 Minor release — headless-agent (machine-to-machine) MCP authentication, plus signing-key rotation.
@@ -94,6 +102,7 @@ First **GA** of the Harper v5 line.
 
 Initial published release, as `@harperdb/oauth` — multi-provider human OAuth for Harper: provider configuration, session management, live config reload, and minimal lifecycle hooks (e.g. adding/modifying user records on authentication).
 
+[2.2.1]: https://github.com/HarperFast/oauth/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/HarperFast/oauth/compare/v2.1.2...v2.2.0
 [2.1.2]: https://github.com/HarperFast/oauth/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/HarperFast/oauth/compare/v2.1.0...v2.1.1

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Complete documentation is available in the [docs](./docs) directory:
 - **[Token Refresh and Sessions](./docs/token-refresh-and-sessions.md)** - How OAuth tokens and Harper sessions interact
 - **[MCP OAuth](./docs/mcp-oauth.md)** - Authorization server for Model Context Protocol clients (experimental)
 - **[API Reference](./docs/api-reference.md)** - Endpoints and programmatic API
+- **[Changelog](./CHANGELOG.md)** - Release history
 
 ## Development
 
@@ -174,22 +175,14 @@ npm run format:write
 
 ## Database Schema
 
-The plugin creates a `csrf_tokens` table for CSRF protection:
+The plugin manages its own tables in the `oauth` database — see [`schema/oauth.graphql`](./schema/oauth.graphql) for the definitions:
 
-```graphql
-type CSRFToken @table {
-	token: string @key
-	sessionId: string
-	provider: string
-	originalUrl: string
-	createdAt: number
-	expiresAt: number @index
-}
-```
-
-Tokens automatically expire after 10 minutes.
-
-When MCP OAuth is enabled (see [issue #86](https://github.com/HarperFast/oauth/issues/86)), the plugin also creates a `harper_oauth_mcp_clients` table for RFC 7591 Dynamic Client Registration. Registrations persist indefinitely so `client_id`s cached by MCP clients (Claude Desktop, Cursor, `mcp-remote`) survive Harper restarts.
+- `csrf_tokens` — CSRF protection for the human OAuth flow (10-minute expiration)
+- `harper_oauth_mcp_clients` — RFC 7591 Dynamic Client Registration; no expiration, so `client_id`s cached by MCP clients (Claude Desktop, Cursor, `mcp-remote`) survive Harper restarts
+- `harper_oauth_mcp_keys` — MCP JWT signing keys, stored in the database so replicated nodes share one rotation-aware key set
+- `mcp_auth_codes` — single-use PKCE authorization codes (5-minute expiration)
+- `mcp_refresh_families` — OAuth 2.1 single-use refresh-token rotation state
+- `mcp_assertion_jtis` — RFC 7523 client-assertion replay guard (120-second expiration)
 
 ## MCP OAuth (experimental)
 
@@ -224,7 +217,9 @@ server.http(
 
 The plugin serves discovery (`/.well-known/*`), Dynamic Client Registration, the authorize/token endpoints, and JWKS; `withMCPAuth` verifies the audience-bound JWT on every call and fails closed. There's an [`onMCPTokenIssued`](./docs/lifecycle-hooks.md#onmcptokenissued) hook to react when a client gains access (client→user mapping, monitoring, rate-limiting) and a built-in audit log.
 
-**Status: experimental, opt-in.** See **[MCP OAuth](./docs/mcp-oauth.md)** for the full flow, the `withMCPAuth` registration models and options, the hook, configuration, the production checklist, and troubleshooting — and [issue #86](https://github.com/HarperFast/oauth/issues/86) for what's still v1.1.
+**Headless agents (machine-to-machine).** An agent with no browser and no human authenticates as itself: `grant_type=client_credentials` with an RFC 7523 `private_key_jwt` client assertion (EdDSA), rate-limited per verified client. Client identity resolves CIMD-first — a URL-shaped `client_id` is fetched as a [Client ID Metadata Document](./docs/mcp-oauth.md#client-id-metadata-documents-cimd) through an SSRF-guarded, rate-limited fetch. See [Headless agents](./docs/mcp-oauth.md#headless-agents-client_credentials).
+
+**Status: experimental, opt-in.** See **[MCP OAuth](./docs/mcp-oauth.md)** for the full flow, the `withMCPAuth` registration models and options, the hook, configuration, the production checklist, and troubleshooting — and [what's not yet supported](./docs/mcp-oauth.md#not-yet-supported-v11) ([#156](https://github.com/HarperFast/oauth/issues/156)) for v1.1 forward-work.
 
 ## Security Considerations
 
@@ -234,6 +229,7 @@ The plugin serves discovery (`/.well-known/*`), Dynamic Client Registration, the
 - **Secure sessions** - Use Harper's secure session configuration
 - **Token storage** - Tokens stored in session (configure secure cookies)
 - **MCP client registration (when `mcp.enabled` is true)** - The `/oauth/mcp/register` endpoint defaults to **open registration** per RFC 7591. Set `mcp.dynamicClientRegistration.initialAccessToken` to require a bearer token on registration, or `mcp.dynamicClientRegistration.allowedRedirectUriHosts` to restrict which hosts may register `redirect_uri`s. See [`docs/configuration.md`](./docs/configuration.md).
+- **CIMD resolution (when `mcp.enabled` is true)** - URL-shaped `client_id`s are resolved as Client ID Metadata Documents **by default**. Disable with `mcp.clientIdMetadataDocuments.enabled: false`, or restrict which hosts are fetched with `mcp.clientIdMetadataDocuments.allowedHosts`.
 
 ## Debug Mode
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@harperfast/oauth",
-			"version": "2.2.0",
+			"version": "2.2.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"description": "OAuth 2.0 authentication plugin for Harper",
 	"license": "Apache-2.0",
 	"author": {


### PR DESCRIPTION
Version bump `2.2.0` → `2.2.1`. Docs-only patch — the README (which is also the npm package page) predated 2.2.0's MCP features and had drifted from the code in a few places.

README fixes:

- **MCP section**: added the headless-agent (machine-to-machine) story — `client_credentials` + RFC 7523 `private_key_jwt`, CIMD-first client resolution — with links to the docs anchors.
- **Security Considerations**: added the CIMD default-on caveat (URL-shaped `client_id`s resolved by default; `mcp.clientIdMetadataDocuments.enabled: false` / `allowedHosts` to control).
- **Database Schema**: the section showed a `CSRFToken` shape that doesn't match the real `csrf_tokens` table and listed 2 of 6 tables — replaced with the actual table set and a pointer to `schema/oauth.graphql`.
- Retired the closed #86 "what's still v1.1" pointer → doc anchor + #156.
- Linked the new `CHANGELOG.md` from the Documentation list; changelog got its 2.2.1 entry.

No source changes. Verified at the bump: format clean, lint clean, full suite passing (2 pre-existing skips).

## Draft release notes

Docs-only patch — refreshes the README (and therefore the npm package page), which predated 2.2.0's MCP features: documents headless-agent (`client_credentials`) authentication and CIMD in the MCP section, adds the CIMD default-on security caveat, corrects the Database Schema section to the actual table set, retires the closed #86 pointer in favor of #156, and links the changelog.

## After this merges

`gh release create v2.2.1 --target <merge-sha>` with the notes above — `release.yml` publishes `@harperfast/oauth@2.2.1` to `latest`, refreshing the npm page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SerGP6Am3xz2CKyPgbRc73
