### PR TITLE
Release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `@harperfast/oauth` are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Entries prior to 2.2.0 were backfilled from the [GitHub release notes](https://github.com/HarperFast/oauth/releases).
 
-## [Unreleased]
+## [2.3.0] - 2026-07-14
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "2.2.1",
+	"version": "2.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@harperfast/oauth",
-			"version": "2.2.1",
+			"version": "2.3.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "2.2.1",
+	"version": "2.3.0",
 	"description": "OAuth 2.0 authentication plugin for Harper",
 	"license": "Apache-2.0",
 	"author": {


### PR DESCRIPTION
Version bump to **2.3.0** and CHANGELOG roll for the `onLogin` outcome-gating minor (#174, merged in #175).

On publish, release.yml sends this to npm `latest`.

Generated by an LLM (Claude Fable 5) pairing with @heskew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)