### PR TITLE
Release 1.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
         run: npm test
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        # --tag v1: the 1.x maintenance line must never take npm's `latest`
+        # dist-tag — 2.x (main) owns latest. Consumers install via
+        # `@harperfast/oauth@1` / `@harperfast/oauth@v1`.
+        run: npm publish --provenance --access public --tag v1
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,9 @@ jobs:
         run: npm test
 
       - name: Publish to npm
-        # --tag v1: the 1.x maintenance line must never take npm's `latest`
-        # dist-tag — 2.x (main) owns latest. Consumers install via
-        # `@harperfast/oauth@1` / `@harperfast/oauth@v1`.
+        # --tag v1: this is a maintenance branch — its releases must never
+        # take npm's `latest` dist-tag (latest always tracks main). Consumers
+        # install via `@harperfast/oauth@1`.
         run: npm publish --provenance --access public --tag v1
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to the `@harperfast/oauth` **1.x maintenance line** are documented here, following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). History prior to 1.6.0 lives in the [GitHub release notes](https://github.com/HarperFast/oauth/releases); the 2.x line has its own changelog on `main`.
 
-## [Unreleased]
+## [1.6.0] - 2026-07-14
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@harperfast/oauth",
-			"version": "1.5.0",
+			"version": "1.6.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"description": "OAuth 2.0 authentication plugin for Harper",
 	"license": "Apache-2.0",
 	"author": {


### PR DESCRIPTION
Version bump to **1.6.0** and CHANGELOG roll for the `onLogin` outcome-gating backport (#174, merged in #176).

Includes the dist-tag guard discussed on #176: `release.yml` now publishes with `--tag v1` — this is a maintenance branch, so its releases must never take npm's `latest` dist-tag (`latest` always tracks `main`). Consumers on Harper 4 install via `@harperfast/oauth@1`.

When creating the GitHub release for this, use `--latest=false` (or untick "Set as the latest release") so the repo's Latest badge stays on the current major.

Generated by an LLM (Claude Fable 5) pairing with @heskew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)