### PR TITLE
fix(release): dist-tag v1 is an invalid npm tag name — use v1-lts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,10 @@ jobs:
         run: npm test
 
       - name: Publish to npm
-        # --tag v1: this is a maintenance branch — its releases must never
+        # --tag v1-lts: this is a maintenance branch — its releases must never
         # take npm's `latest` dist-tag (latest always tracks main). Consumers
-        # install via `@harperfast/oauth@1`.
-        run: npm publish --provenance --access public --tag v1
+        # install via `@harperfast/oauth@1`. (`v1` itself is rejected by npm:
+        # tag names must not be valid semver ranges.)
+        run: npm publish --provenance --access public --tag v1-lts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_KEY }}


### PR DESCRIPTION
The v1.6.0 publish run failed at `npm publish --tag v1`: npm rejects dist-tag names that parse as valid semver ranges (`v1` ≡ `1.x`). `v1-lts` is not a range, so it's accepted. Nothing was published by the failed run and `latest` was untouched (verified: still 2.3.0).

After this merges I'll delete and re-create the v1.6.0 release so the release event picks up the fixed workflow from the new tag.

Generated by an LLM (Claude Fable 5) pairing with @heskew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)