### PR TITLE
fix(release): publish via OIDC trusted publishing like main — NPM_ACCESS_KEY is gone

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
+      # Trusted publishing (OIDC) requires npm >= 11.5.1; the Node 22 runner
+      # ships npm 10.x, so upgrade before publishing. (Same as main.)
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@^11.5.1
+
       - name: Install dependencies
         run: npm ci
 
@@ -36,11 +41,13 @@ jobs:
       - name: Run tests
         run: npm test
 
+      # Auth is via npm trusted publishing (OIDC) using the id-token, same as
+      # main — no NODE_AUTH_TOKEN (the legacy NPM_ACCESS_KEY secret no longer
+      # exists; it fails ENEEDAUTH). The npmjs.com Trusted Publisher config
+      # (this repo, release.yml, Release environment) matches this workflow.
       - name: Publish to npm
         # --tag v1-lts: this is a maintenance branch — its releases must never
         # take npm's `latest` dist-tag (latest always tracks main). Consumers
         # install via `@harperfast/oauth@1`. (`v1` itself is rejected by npm:
         # tag names must not be valid semver ranges.)
         run: npm publish --provenance --access public --tag v1-lts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_KEY }}


### PR DESCRIPTION
Second and final release-workflow fix for the 1.x line: the re-cut v1.6.0 publish run got past the dist-tag error (the `v1-lts` fix from #179 worked) but then failed `ENEEDAUTH` — this workflow still referenced `secrets.NPM_ACCESS_KEY`, which no longer exists since the org moved to npm trusted publishing.

Ports main's publish mechanism verbatim: `npm install -g npm@^11.5.1` (trusted publishing needs npm ≥ 11.5.1; the Node 22 runner ships 10.x) and no token env — OIDC auth via the existing `id-token: write` permission. The npmjs.com Trusted Publisher config pins repo + `release.yml` + `Release` environment, all of which this workflow already matches, so publishes from the v1.x tag should authenticate identically to main's.

Nothing was published by either failed run; npm `latest` remains 2.3.0. After this merges I'll re-cut v1.6.0 once more and watch it through.

Generated by an LLM (Claude Fable 5) pairing with @heskew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)