### PR TITLE
fix: bind the OAuth callback to the initiating session

### DIFF
--- a/src/lib/handlers.ts
+++ b/src/lib/handlers.ts
@@ -262,7 +262,11 @@ export async function handleCallback(
 	if (tokenData.sessionId && tokenData.sessionId !== request.session?.id) {
 		logger?.warn?.(`State token session mismatch: flow initiated in a different session (provider '${providerName}')`);
 		if (mcpState) {
-			return mcpErrorRedirect(mcpState, 'access_denied', 'Authorization must complete in the session that initiated it');
+			return mcpErrorRedirect(
+				mcpState,
+				'access_denied',
+				'Authorization must complete in the session that initiated it'
+			);
 		}
 		const errorUrl = buildErrorRedirect(tokenData.originalUrl || config.postLoginRedirect || '/', {
 			error: 'auth_failed',

--- a/src/lib/handlers.ts
+++ b/src/lib/handlers.ts
@@ -251,6 +251,26 @@ export async function handleCallback(
 		return { status: 302, headers: { Location: errorUrl } };
 	}
 
+	// State↔session binding (RFC 6749 §10.12 / OAuth Security BCP): the state
+	// token records the session that initiated the flow; a callback arriving in
+	// a different session is CSRF-shaped — an attacker-minted state delivered
+	// into a victim's browser (e.g. to bind the attacker's provider identity to
+	// the victim's account in a linking flow). Rejected before the code
+	// exchange: no upstream calls, no session write. Enforced whenever the
+	// initiating session id is present; sessions are updated in place (never
+	// id-rotated), so the id is stable across initiate → IdP → callback.
+	if (tokenData.sessionId && tokenData.sessionId !== request.session?.id) {
+		logger?.warn?.(`State token session mismatch: flow initiated in a different session (provider '${providerName}')`);
+		if (mcpState) {
+			return mcpErrorRedirect(mcpState, 'access_denied', 'Authorization must complete in the session that initiated it');
+		}
+		const errorUrl = buildErrorRedirect(tokenData.originalUrl || config.postLoginRedirect || '/', {
+			error: 'auth_failed',
+			reason: 'csrf',
+		});
+		return { status: 302, headers: { Location: errorUrl } };
+	}
+
 	// CIMD browser binding — checked BEFORE the upstream code exchange and the
 	// onLogin hook, so a mismatched (self-approved) flow triggers no upstream
 	// exchange, no userinfo fetch, and no provisioning side-effects; it only

--- a/src/lib/mcp/authorize.ts
+++ b/src/lib/mcp/authorize.ts
@@ -337,6 +337,11 @@ async function performUpstreamRedirect(
 	try {
 		csrfToken = await providerEntry.provider.generateCSRFToken({
 			providerName: selection.providerName,
+			// Bind the upstream state to the initiating browser session — the
+			// callback rejects a state processed in a different session (#181).
+			// Both MCP entries (direct authorize and post-CIMD confirm) mint
+			// their upstream state here, so this is the single binding site.
+			sessionId: request.session?.id,
 			mcp: mcpState,
 		});
 	} catch (error) {

--- a/test/lib/handlers.test.js
+++ b/test/lib/handlers.test.js
@@ -1287,4 +1287,99 @@ describe('OAuth Handlers', () => {
 			}
 		});
 	});
+	describe('handleCallback — state↔session binding (#181)', () => {
+		it('rejects a callback processed in a different session than the one that initiated', async () => {
+			mockProvider.verifyCSRFToken = createMockFn(async () => ({
+				originalUrl: '/dashboard',
+				timestamp: Date.now(),
+				providerName: 'test-provider',
+				sessionId: 'attacker-session-999',
+			}));
+
+			const result = await handleCallback(
+				mockRequest,
+				mockTarget,
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.status, 302);
+			assert.equal(result.headers.Location, '/dashboard?error=auth_failed&reason=csrf');
+			// Rejected before any upstream call or session write.
+			assert.equal(mockProvider.exchangeCodeForToken.mock.calls.length, 0);
+			assert.equal(mockRequest.session.update.mock.calls.length, 0);
+		});
+
+		it('allows a callback in the same session that initiated the flow', async () => {
+			mockProvider.verifyCSRFToken = createMockFn(async () => ({
+				originalUrl: '/dashboard',
+				timestamp: Date.now(),
+				providerName: 'test-provider',
+				sessionId: 'session-123',
+			}));
+
+			const result = await handleCallback(
+				mockRequest,
+				mockTarget,
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.status, 302);
+			assert.equal(result.headers.Location, '/dashboard');
+			assert.equal(mockProvider.exchangeCodeForToken.mock.calls.length, 1);
+		});
+
+		it('tolerates state tokens without a sessionId (pre-binding tokens)', async () => {
+			// The default mock tokenData carries no sessionId — enforcement is
+			// conditional on presence so in-flight logins across a deploy survive.
+			const result = await handleCallback(
+				mockRequest,
+				mockTarget,
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.status, 302);
+			assert.equal(result.headers.Location, '/dashboard');
+		});
+
+		it('rejects a foreign-session MCP callback with an MCP error redirect', async () => {
+			mockProvider.verifyCSRFToken = createMockFn(async () => ({
+				timestamp: Date.now(),
+				providerName: 'test-provider',
+				sessionId: 'attacker-session-999',
+				mcp: {
+					clientId: 'mcp-client-1',
+					redirectUri: 'https://mcp-client.example.com/cb',
+					clientState: 'mcp-state-xyz',
+				},
+			}));
+
+			const result = await handleCallback(
+				mockRequest,
+				mockTarget,
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.status, 302);
+			assert.ok(result.headers.Location.startsWith('https://mcp-client.example.com/cb'));
+			assert.ok(result.headers.Location.includes('error=access_denied'));
+			assert.equal(mockProvider.exchangeCodeForToken.mock.calls.length, 0);
+		});
+	});
 });
+

--- a/test/lib/handlers.test.js
+++ b/test/lib/handlers.test.js
@@ -1382,4 +1382,3 @@ describe('OAuth Handlers', () => {
 		});
 	});
 });
-

--- a/test/lib/mcp/authorize.test.js
+++ b/test/lib/mcp/authorize.test.js
@@ -420,6 +420,31 @@ describe('handleAuthorize', () => {
 			assert.equal(metadata.mcp.clientState, BASE_QUERY.state);
 		});
 
+		it('binds the upstream state to the initiating browser session (#181)', async () => {
+			const { entries, harnesses } = newRegistry();
+			const target = makeTarget(BASE_QUERY);
+			const response = await handleAuthorize(
+				makeRequest({ session: { id: 'browser-session-42' } }),
+				target,
+				validConfig,
+				entries
+			);
+
+			assert.equal(response.status, 302);
+			// handleCallback enforces state↔session binding when sessionId is
+			// present — the MCP path must actually mint it or the check never runs.
+			assert.equal(harnesses.github.generatedTokens[0].sessionId, 'browser-session-42');
+		});
+
+		it('mints no sessionId when the request has no session (binding enforce-when-present)', async () => {
+			const { entries, harnesses } = newRegistry();
+			const target = makeTarget(BASE_QUERY);
+			const response = await handleAuthorize(makeRequest(), target, validConfig, entries);
+
+			assert.equal(response.status, 302);
+			assert.equal(harnesses.github.generatedTokens[0].sessionId, undefined);
+		});
+
 		it('accepts a redirect_uri that matches the registered loopback URI', async () => {
 			const { entries } = newRegistry();
 			const target = makeTarget({ ...BASE_QUERY, redirect_uri: 'http://localhost:6274/cb' });


### PR DESCRIPTION
Closes #181.

## What

`handleCallback` now rejects a callback whose state token was minted in a different session. Login initiation has always recorded `sessionId` into the state token; this adds the missing comparison on callback (RFC 6749 §10.12 / OAuth 2.0 Security BCP), placed with the other CSRF-class checks — after provider binding, before CIMD browser binding and the code exchange, so a foreign-session callback triggers no upstream exchange, no userinfo fetch, and no session write.

## Decisions on the issue's open edges

- **Missing `sessionId`: tolerated (enforce-when-present).** Pre-fix in-flight logins and session-less initiations still complete, so the fix deploys without false rejects. Requiring a session at initiation (making the binding universally enforceable) is left as a follow-up decision — happy to file it.
- **Session rotation: confirmed stable.** The plugin updates sessions in place (`session.update`) and never rotates the id across initiate → IdP → callback, so legitimate logins cannot false-reject.
- **MCP path: covered.** MCP flows share `verifyCSRFToken`/`tokenData`, so the binding applies there too; a foreign-session MCP callback gets an `access_denied` error redirect to the client's `redirect_uri` (mirrors the CIMD browser-binding failure shape).

## Tests

All four cases from the issue: foreign-session rejected (with no-upstream-call/no-session-write assertions), same-session allowed, missing-`sessionId` tolerated, foreign-session MCP redirect. Suite: 1069 passing.

## Backport note

The consumer wants this on a `1.6.x` patch as well as `2.x` (see the issue's version-compatibility section). This PR targets main (`2.3.0`); the change is small and self-contained — the same two hunks should cherry-pick cleanly onto a `1.6.x` branch once maintainers confirm where that line lives. Please note the resulting minimum versions in the releases so `central-manager` can pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)