### PR TITLE
fix: MCP DCR defaults to disabled when the config block is absent

### DIFF
--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -164,11 +164,11 @@ form the `WWW-Authenticate` challenge advertises.
 
 ### Authorization server
 
-| Endpoint               | Method | Notes                                                                                                                                     |
-| ---------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `/oauth/mcp/register`  | POST   | RFC 7591 Dynamic Client Registration. Open by default; gate with `initialAccessToken`. Returns `201`.                                     |
-| `/oauth/mcp/authorize` | GET    | OAuth 2.1 + PKCE. Requires `client_id`, `redirect_uri`, `response_type=code`, `code_challenge`, `code_challenge_method=S256`, `resource`. |
-| `/oauth/mcp/token`     | POST   | Grants: `authorization_code`, `refresh_token`, and (opt-in) `client_credentials`. Returns the token pair with `Cache-Control: no-store`.  |
+| Endpoint               | Method | Notes                                                                                                                                                                     |
+| ---------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/oauth/mcp/register`  | POST   | RFC 7591 Dynamic Client Registration. Exists only when `mcp.dynamicClientRegistration` is configured (absent block ⇒ 404); gate with `initialAccessToken`. Returns `201`. |
+| `/oauth/mcp/authorize` | GET    | OAuth 2.1 + PKCE. Requires `client_id`, `redirect_uri`, `response_type=code`, `code_challenge`, `code_challenge_method=S256`, `resource`.                                 |
+| `/oauth/mcp/token`     | POST   | Grants: `authorization_code`, `refresh_token`, and (opt-in) `client_credentials`. Returns the token pair with `Cache-Control: no-store`.                                  |
 
 > `mcp` is a reserved provider name — the plugin refuses to start if you configure
 > a provider called `mcp`, because it would collide with `/oauth/mcp/*`.
@@ -373,9 +373,13 @@ A checklist before you expose MCP OAuth publicly:
       because otherwise `iss` (and `aud`, which derives from it) would float with
       the client-controlled `Host` header, an audience-confusion risk. Pinning
       `resource` alone is not enough; `iss` still floats.
-- [ ] **Gate Dynamic Client Registration.** `/register` is open by default per
-      RFC 7591. Set `mcp.dynamicClientRegistration.initialAccessToken` to require
-      a bearer token, or accept open registration deliberately.
+- [ ] **Gate Dynamic Client Registration (if you enable it).** DCR is disabled
+      until a `mcp.dynamicClientRegistration` block is present (#182) — the
+      endpoint 404s and metadata omits `registration_endpoint`. When you do
+      enable it, set `mcp.dynamicClientRegistration.initialAccessToken` to
+      require a bearer token, or accept open registration deliberately (a
+      once-per-process warning is logged when DCR runs ungated). CIMD-based
+      client identity needs no DCR at all.
 - [ ] **Restrict redirect URI hosts** with
       `mcp.dynamicClientRegistration.allowedRedirectUriHosts`. Loopback is always
       allowed for native clients (RFC 8252).

--- a/integrationTests/fixtures/mcp-auth-app/config.yaml
+++ b/integrationTests/fixtures/mcp-auth-app/config.yaml
@@ -32,6 +32,10 @@ rest: true
     enabled: true
     issuer: 'https://mcp.test'
     resource: 'https://mcp.test/mcp'
+    # DCR is presence-enabled as of #182 — an absent (or bare-null) block 404s
+    # the register endpoint. The e2e flow registers its client via DCR, so the
+    # fixture opts in explicitly with an empty block (open registration).
+    dynamicClientRegistration: {}
 
 jsResource:
   files: 'mcp-app.js'

--- a/integrationTests/fixtures/mcp-oauth/config.yaml
+++ b/integrationTests/fixtures/mcp-oauth/config.yaml
@@ -25,6 +25,10 @@ rest: true
     enabled: true
     issuer: 'https://mcp.test'
     resource: 'https://mcp.test/mcp'
+    # DCR is presence-enabled as of #182 — an absent (or bare-null) block 404s
+    # the register endpoint. The e2e flow registers its client via DCR, so the
+    # fixture opts in explicitly with an empty block (open registration).
+    dynamicClientRegistration: {}
 
 jsResource:
   files: 'mcp-app.js'

--- a/src/lib/mcp/dcr.ts
+++ b/src/lib/mcp/dcr.ts
@@ -199,7 +199,10 @@ function buildClientFromRequest(
  */
 export function dcrEnabled(mcpConfig: MCPConfig | undefined): boolean {
 	const dcrConfig = mcpConfig?.dynamicClientRegistration;
-	return dcrConfig !== undefined && dcrConfig.enabled !== false;
+	// `!= null` (not `!== undefined`): a bare `dynamicClientRegistration:` key
+	// in YAML parses as null — treat it like an absent block (fail-closed)
+	// rather than throwing on `.enabled`. Enabling takes a real block (`{}`).
+	return dcrConfig != null && dcrConfig.enabled !== false;
 }
 
 // Once-per-process: ungated DCR is legitimate (open registration per RFC

--- a/src/lib/mcp/dcr.ts
+++ b/src/lib/mcp/dcr.ts
@@ -187,6 +187,25 @@ function buildClientFromRequest(
  * @param mcpConfig - Plugin MCP configuration
  * @param logger - Optional logger
  */
+/**
+ * DCR is enabled by the PRESENCE of the `dynamicClientRegistration` config
+ * block (and not switched off by `enabled: false`). An absent block means the
+ * endpoint does not exist — "I never configured registration" must mean there
+ * IS no registration. The pre-#182 default (absent block ⇒ open, ungated
+ * registration) silently exposed unauthenticated client creation on every
+ * deployment that had no reason to touch this block; CIMD is the forward path
+ * for client identity and needs no DCR at all. Exported so the well-known
+ * metadata advertises `registration_endpoint` under exactly this predicate.
+ */
+export function dcrEnabled(mcpConfig: MCPConfig | undefined): boolean {
+	const dcrConfig = mcpConfig?.dynamicClientRegistration;
+	return dcrConfig !== undefined && dcrConfig.enabled !== false;
+}
+
+// Once-per-process: ungated DCR is legitimate (open registration per RFC
+// 7591) but should never be running silently.
+let ungatedWarningLogged = false;
+
 export async function handleRegister(
 	request: { headers?: { authorization?: string } } | undefined,
 	body: any,
@@ -195,10 +214,17 @@ export async function handleRegister(
 ): Promise<any> {
 	const dcrConfig = mcpConfig?.dynamicClientRegistration;
 
-	// DCR defaults to enabled when MCP is enabled. Explicit `enabled: false`
-	// turns it off and the endpoint returns 404 (existence-hiding).
-	if (dcrConfig?.enabled === false) {
+	// Absent block or explicit `enabled: false` ⇒ 404 (existence-hiding). See
+	// dcrEnabled above for the default-disabled rationale (#182).
+	if (!dcrEnabled(mcpConfig)) {
 		return { status: 404, body: { error: 'Not found' } };
+	}
+
+	if (!dcrConfig?.initialAccessToken && !ungatedWarningLogged) {
+		ungatedWarningLogged = true;
+		harperLogger?.warn?.(
+			'MCP DCR is enabled WITHOUT an initialAccessToken: /oauth/mcp/register accepts unauthenticated client registrations (open registration per RFC 7591). Set dynamicClientRegistration.initialAccessToken to gate it, or remove the dynamicClientRegistration block to disable the endpoint.'
+		);
 	}
 
 	// Observability: log every registration attempt. Rejections were previously

--- a/src/lib/mcp/wellKnown.ts
+++ b/src/lib/mcp/wellKnown.ts
@@ -23,6 +23,7 @@
  */
 
 import type { Logger, MCPConfig } from '../../types.ts';
+import { dcrEnabled } from './dcr.ts';
 import { MCPKeyStore } from './keyStore.ts';
 import { publicKeyToJwk } from './tokenIssuer.ts';
 
@@ -159,7 +160,9 @@ export function buildAuthorizationServerMetadata(
 		issuer,
 		authorization_endpoint: `${issuer}/oauth/mcp/authorize`,
 		token_endpoint: `${issuer}/oauth/mcp/token`,
-		registration_endpoint: `${issuer}/oauth/mcp/register`,
+		// Advertised under the same predicate the handler enforces (#182):
+		// metadata must not point clients at an endpoint that 404s.
+		...(dcrEnabled(mcpConfig) ? { registration_endpoint: `${issuer}/oauth/mcp/register` } : {}),
 		jwks_uri: `${issuer}${JWKS_PATH}`,
 		response_types_supported: ['code'],
 		grant_types_supported: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,12 @@ export interface MCPConfig {
 	 * chooser UI is v1.1.
 	 */
 	providers?: string[];
-	/** Dynamic Client Registration settings (RFC 7591) */
+	/**
+	 * Dynamic Client Registration settings (RFC 7591). PRESENCE of this block
+	 * enables the /oauth/mcp/register endpoint; omitting it entirely leaves DCR
+	 * disabled (the endpoint 404s and metadata omits `registration_endpoint`).
+	 * Before #182 an absent block meant open, ungated registration.
+	 */
 	dynamicClientRegistration?: MCPDynamicClientRegistrationConfig;
 	/**
 	 * JWT signing algorithm for issued access tokens. Only "RS256" is supported
@@ -142,11 +147,17 @@ export interface MCPClientCredentialsConfig {
  * is opt-in via initialAccessToken or allowedRedirectUriHosts.
  */
 export interface MCPDynamicClientRegistrationConfig {
-	/** Enable the /register endpoint. Default: true. */
+	/**
+	 * Enable the /register endpoint. Default when this block is present: true.
+	 * (DCR as a whole is enabled by the presence of the block — see
+	 * `MCPConfig.dynamicClientRegistration`; `enabled: false` disables it while
+	 * keeping the block around.)
+	 */
 	enabled?: boolean;
 	/**
 	 * If set, registration requests must present `Authorization: Bearer <token>`
-	 * matching this value. Default: open registration per RFC 7591.
+	 * matching this value. Default: open registration per RFC 7591 — a
+	 * once-per-process warning is logged when DCR runs ungated.
 	 */
 	initialAccessToken?: string;
 	/**

--- a/test/lib/mcp/dcr.test.js
+++ b/test/lib/mcp/dcr.test.js
@@ -56,8 +56,17 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 			assert.equal(storedRecords.size, 0);
 		});
 
-		it('proceeds when DCR config is absent (defaults to enabled)', async () => {
+		it('returns 404 when the DCR config block is absent (default disabled, #182)', async () => {
 			const response = await handleRegister(makeRequest(), VALID_BODY, { enabled: true });
+			assert.equal(response.status, 404);
+			assert.equal(storedRecords.size, 0);
+		});
+
+		it('proceeds when the DCR block is present without an explicit enabled flag', async () => {
+			const response = await handleRegister(makeRequest(), VALID_BODY, {
+				enabled: true,
+				dynamicClientRegistration: {},
+			});
 			assert.equal(response.status, 201);
 		});
 
@@ -108,7 +117,7 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 	});
 
 	describe('scalar metadata validation', () => {
-		const config = { enabled: true };
+		const config = { enabled: true, dynamicClientRegistration: {} };
 
 		it('rejects non-string client_name', async () => {
 			const response = await handleRegister(
@@ -140,7 +149,7 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 	});
 
 	describe('redirect_uris validation', () => {
-		const config = { enabled: true };
+		const config = { enabled: true, dynamicClientRegistration: {} };
 
 		it('rejects missing redirect_uris', async () => {
 			const response = await handleRegister(makeRequest(), { client_name: 'X' }, config);
@@ -239,7 +248,10 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 
 	describe('defaults and metadata', () => {
 		it('applies MCP-context defaults (public client, code flow)', async () => {
-			const response = await handleRegister(makeRequest(), VALID_BODY, { enabled: true });
+			const response = await handleRegister(makeRequest(), VALID_BODY, {
+				enabled: true,
+				dynamicClientRegistration: {},
+			});
 			assert.equal(response.status, 201);
 			assert.equal(response.body.token_endpoint_auth_method, 'none');
 			assert.deepEqual(response.body.grant_types, ['authorization_code', 'refresh_token']);
@@ -255,7 +267,7 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 					grant_types: ['authorization_code'],
 					application_type: 'native',
 				},
-				{ enabled: true }
+				{ enabled: true, dynamicClientRegistration: {} }
 			);
 			assert.equal(response.status, 201);
 			assert.deepEqual(response.body.grant_types, ['authorization_code']);
@@ -266,7 +278,7 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 			const response = await handleRegister(
 				makeRequest(),
 				{ redirect_uris: ['https://app.example.com/cb'], grant_types: ['client_credentials'] },
-				{ enabled: true }
+				{ enabled: true, dynamicClientRegistration: {} }
 			);
 			assert.equal(response.status, 400);
 			assert.equal(response.body.error, 'invalid_client_metadata');
@@ -276,7 +288,7 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 			const response = await handleRegister(
 				makeRequest(),
 				{ redirect_uris: ['https://app.example.com/cb'], response_types: ['token'] },
-				{ enabled: true }
+				{ enabled: true, dynamicClientRegistration: {} }
 			);
 			assert.equal(response.status, 400);
 		});
@@ -285,7 +297,7 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 			const response = await handleRegister(
 				makeRequest(),
 				{ redirect_uris: ['https://app.example.com/cb'], token_endpoint_auth_method: 'private_key_jwt' },
-				{ enabled: true }
+				{ enabled: true, dynamicClientRegistration: {} }
 			);
 			assert.equal(response.status, 400);
 		});
@@ -294,7 +306,7 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 			const response = await handleRegister(
 				makeRequest(),
 				{ redirect_uris: ['https://app.example.com/cb'], application_type: 'service' },
-				{ enabled: true }
+				{ enabled: true, dynamicClientRegistration: {} }
 			);
 			assert.equal(response.status, 400);
 		});
@@ -303,7 +315,7 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 			const response = await handleRegister(
 				makeRequest(),
 				{ redirect_uris: ['https://app.example.com/cb'], contacts: ['nathan@example.com', 42] },
-				{ enabled: true }
+				{ enabled: true, dynamicClientRegistration: {} }
 			);
 			assert.equal(response.status, 400);
 		});
@@ -311,7 +323,10 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 
 	describe('issued credentials', () => {
 		it('issues a client_id and persists the record (public client, no secret)', async () => {
-			const response = await handleRegister(makeRequest(), VALID_BODY, { enabled: true });
+			const response = await handleRegister(makeRequest(), VALID_BODY, {
+				enabled: true,
+				dynamicClientRegistration: {},
+			});
 			assert.equal(response.status, 201);
 			assert.ok(response.body.client_id, 'client_id was issued');
 			assert.equal(response.body.client_secret, undefined, 'public clients receive no secret');
@@ -328,7 +343,7 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 					redirect_uris: ['https://app.example.com/cb'],
 					token_endpoint_auth_method: 'client_secret_basic',
 				},
-				{ enabled: true }
+				{ enabled: true, dynamicClientRegistration: {} }
 			);
 			assert.equal(response.status, 201);
 			assert.ok(response.body.client_secret, 'confidential client received a secret');
@@ -336,8 +351,8 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 		});
 
 		it('issues unique client_ids for repeated registrations of the same metadata', async () => {
-			const a = await handleRegister(makeRequest(), VALID_BODY, { enabled: true });
-			const b = await handleRegister(makeRequest(), VALID_BODY, { enabled: true });
+			const a = await handleRegister(makeRequest(), VALID_BODY, { enabled: true, dynamicClientRegistration: {} });
+			const b = await handleRegister(makeRequest(), VALID_BODY, { enabled: true, dynamicClientRegistration: {} });
 			assert.notEqual(a.body.client_id, b.body.client_id);
 			assert.equal(storedRecords.size, 2);
 		});
@@ -345,7 +360,7 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 
 	describe('error handling', () => {
 		it('rejects non-object bodies', async () => {
-			const response = await handleRegister(makeRequest(), null, { enabled: true });
+			const response = await handleRegister(makeRequest(), null, { enabled: true, dynamicClientRegistration: {} });
 			assert.equal(response.status, 400);
 			assert.equal(response.body.error, 'invalid_client_metadata');
 		});
@@ -354,7 +369,10 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 			global.databases.oauth.harper_oauth_mcp_clients.put = async () => {
 				throw new Error('storage failure');
 			};
-			const response = await handleRegister(makeRequest(), VALID_BODY, { enabled: true });
+			const response = await handleRegister(makeRequest(), VALID_BODY, {
+				enabled: true,
+				dynamicClientRegistration: {},
+			});
 			assert.equal(response.status, 500);
 			assert.equal(response.body.error, 'server_error');
 		});

--- a/test/lib/mcp/dcr.test.js
+++ b/test/lib/mcp/dcr.test.js
@@ -62,6 +62,15 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 			assert.equal(storedRecords.size, 0);
 		});
 
+		it('returns 404 when the DCR block is a bare null (YAML `dynamicClientRegistration:` with no children)', async () => {
+			const response = await handleRegister(makeRequest(), VALID_BODY, {
+				enabled: true,
+				dynamicClientRegistration: null,
+			});
+			assert.equal(response.status, 404);
+			assert.equal(storedRecords.size, 0);
+		});
+
 		it('proceeds when the DCR block is present without an explicit enabled flag', async () => {
 			const response = await handleRegister(makeRequest(), VALID_BODY, {
 				enabled: true,

--- a/test/lib/mcp/index.test.js
+++ b/test/lib/mcp/index.test.js
@@ -70,7 +70,10 @@ describe('handleMCPPost (dispatcher)', () => {
 		});
 
 		it('proceeds when mcpConfig.enabled is true', async () => {
-			const response = await handleMCPPost('register', makeRequest(), VALID_BODY, { enabled: true });
+			const response = await handleMCPPost('register', makeRequest(), VALID_BODY, {
+				enabled: true,
+				dynamicClientRegistration: {},
+			});
 			assert.equal(response.status, 201);
 			assert.equal(storedRecords.size, 1);
 		});
@@ -78,7 +81,10 @@ describe('handleMCPPost (dispatcher)', () => {
 
 	describe('action routing', () => {
 		it('dispatches `register` to handleRegister', async () => {
-			const response = await handleMCPPost('register', makeRequest(), VALID_BODY, { enabled: true });
+			const response = await handleMCPPost('register', makeRequest(), VALID_BODY, {
+				enabled: true,
+				dynamicClientRegistration: {},
+			});
 			assert.equal(response.status, 201);
 			assert.ok(response.body.client_id, 'register response carries an issued client_id');
 		});

--- a/test/lib/mcp/wellKnown.test.js
+++ b/test/lib/mcp/wellKnown.test.js
@@ -93,8 +93,26 @@ describe('MCP well-known: AS metadata document (RFC 8414)', () => {
 		assert.equal(doc.issuer, 'https://app.example.com');
 		assert.equal(doc.authorization_endpoint, 'https://app.example.com/oauth/mcp/authorize');
 		assert.equal(doc.token_endpoint, 'https://app.example.com/oauth/mcp/token');
-		assert.equal(doc.registration_endpoint, 'https://app.example.com/oauth/mcp/register');
 		assert.equal(doc.jwks_uri, 'https://app.example.com/.well-known/jwks.json');
+	});
+
+	it('omits registration_endpoint when the DCR block is absent (default disabled, #182)', () => {
+		const doc = buildAuthorizationServerMetadata(makeRequest(), { enabled: true });
+		assert.equal(doc.registration_endpoint, undefined);
+	});
+
+	it('advertises registration_endpoint under the same predicate the handler enforces', () => {
+		const withBlock = buildAuthorizationServerMetadata(makeRequest(), {
+			enabled: true,
+			dynamicClientRegistration: {},
+		});
+		assert.equal(withBlock.registration_endpoint, 'https://app.example.com/oauth/mcp/register');
+
+		const explicitlyDisabled = buildAuthorizationServerMetadata(makeRequest(), {
+			enabled: true,
+			dynamicClientRegistration: { enabled: false },
+		});
+		assert.equal(explicitlyDisabled.registration_endpoint, undefined);
 	});
 
 	it('advertises PKCE S256 only (no plain)', () => {

--- a/test/lib/mcp/wellKnown.test.js
+++ b/test/lib/mcp/wellKnown.test.js
@@ -115,6 +115,14 @@ describe('MCP well-known: AS metadata document (RFC 8414)', () => {
 		assert.equal(explicitlyDisabled.registration_endpoint, undefined);
 	});
 
+	it('omits registration_endpoint for a bare null DCR block (YAML empty key)', () => {
+		const doc = buildAuthorizationServerMetadata(makeRequest(), {
+			enabled: true,
+			dynamicClientRegistration: null,
+		});
+		assert.equal(doc.registration_endpoint, undefined);
+	});
+
 	it('advertises PKCE S256 only (no plain)', () => {
 		const doc = buildAuthorizationServerMetadata(makeRequest(), { enabled: true });
 		assert.deepEqual(doc.code_challenge_methods_supported, ['S256']);


### PR DESCRIPTION
Closes #182.

## What

Implements suggested fix 1 (default disabled), scoped as **presence-enables**: a `dynamicClientRegistration` block in config (minus explicit `enabled: false`) enables `/oauth/mcp/register`; an **absent block now 404s** (existence-hiding). This flips only the exposure case from the issue — deployments that wrote the block (for `initialAccessToken`, `allowedRedirectUriHosts`, or `enabled: true`) keep exactly their current behavior, so the breaking surface is limited to anyone depending on never-configured open registration, which is the vulnerability.

## Consistency

- New exported `dcrEnabled()` predicate used by **both** the handler and the RFC 8414 metadata builder — `registration_endpoint` is advertised iff the endpoint exists, so discovery and enforcement can't drift.
- Issue's suggested fix 3 included as well: a once-per-process warning when DCR runs **ungated** (enabled, no `initialAccessToken`) — open registration stays legitimate per RFC 7591, but never silent.
- Types and `docs/mcp-oauth.md` updated (endpoint table + hardening checklist now describe presence-enables; the old text documented open-by-default as a checklist caveat).

## Tests

1068 passing. New/updated: absent block → 404 (handler) and no `registration_endpoint` (metadata); empty block → active + advertised; explicit `enabled: false` → 404 + not advertised. Pre-existing suites that leaned on the old default (validation, dispatcher) now opt in with an explicit empty block — which doubles as a reviewable inventory of what the flip touches.

## Downstream

flair already writes `enabled: false` explicitly (tpsdev-ai/flair#757) and is unaffected either way; per the issue they'll simplify once this ships. Suggest calling the new default out prominently in the release notes since it's a behavior change for unconfigured deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)