### PR TITLE
ci: sync claude-review.yml with main (fixes the review lane on all v1.x PRs)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -26,7 +26,14 @@ concurrency:
 
 jobs:
   review:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@533f841137114315b0b4d02dabf367e376d9922e # main 2026-05-21 (post #42 — log-script counts from "N blockers found" line + tolerates markdown wrapping, fixing Claude-recap titles undercounting; _claude-review.yml itself unchanged)
+    # Always-on toggle — see ai-review-prompts USAGE.md "Reviewers & the
+    # always-on toggle". CLAUDE_ALWAYS_ON=true (repo/org variable) → auto-
+    # review trusted-author PRs; unset → opt-in via the claude-review
+    # label. The reusable's authorize job still owns WHO is admitted.
+    # Note: the `claude-review` label name is matched there too —
+    # `_claude-review.yml`'s authorize `if:`, not in this caller.
+    if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@9cf49d23cb046ecd6c87f3bba86dc3338d6998fb # main 2026-06-29 (#70 week-of-06-22 calibration + #71 prompt-ref tracking; on 1bbc562 = #67 + #69)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job
     # grants below what they need and breaks the workflow at startup;
@@ -51,7 +58,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 533f841137114315b0b4d02dabf367e376d9922e
+      ai-review-prompts-ref: 9cf49d23cb046ecd6c87f3bba86dc3338d6998fb
       review-layers: |
         universal
         harper/common


### PR DESCRIPTION
Closes #186.

Byte-identical copy of main's `.github/workflows/claude-review.yml` onto `v1.x`. The claude-code-action app-token exchange rejects any caller that differs from the default branch's copy, which made the `review / review` lane fail structurally on every `v1.x`-targeted PR (first seen on #185). The drift was caller-shell only — the always-on toggle `if:` and the pinned `ai-review-prompts` SHA — so behavior on 1.x PRs now simply matches main's review setup.

Self-verifying: this PR's own review lane runs the synced file from the merge ref, so a green `review / review` here is the proof. The intentionally divergent workflows (`release.yml` with the `v1-lts` dist-tag, absent `integration-tests.yml`) are untouched; the drift-guard suggestion lives in #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)