### PR TITLE
Release 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Notable changes to the `@harperfast/oauth` **1.x maintenance line** are documented here, following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). History prior to 1.6.0 lives in the [GitHub release notes](https://github.com/HarperFast/oauth/releases); the 2.x line has its own changelog on `main`.
 
+## [1.6.1] - 2026-07-20
+
+### Security
+
+- **OAuth callbacks are bound to the initiating session** (#181; #185, backport of 2.x/#183): `handleCallback` rejects a state token minted in a different browser session — the RFC 6749 §10.12 login-CSRF class, and the load-bearing prerequisite for authenticated account-linking flows (an attacker-initiated state delivered into a victim's session could otherwise bind the attacker's provider identity to the victim's account). Enforced whenever the state carries the initiating session id (`handleLogin` has always minted it on this line); pre-upgrade tokens pass through, so in-flight logins survive the deploy. Rejection happens before the code exchange: no upstream calls, no session write. Consumers gating on this fix should require `>=1.6.1`.
+
+### Fixed
+
+- Release infrastructure: publishing uses npm trusted publishing (OIDC) with the `v1-lts` dist-tag (#179, #180), and the Claude review lane works on `v1.x`-targeted PRs again (#187 — the caller workflow must stay byte-identical to main's).
+
 ## [1.6.0] - 2026-07-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@harperfast/oauth",
-			"version": "1.6.0",
+			"version": "1.6.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@harperfast/oauth",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"description": "OAuth 2.0 authentication plugin for Harper",
 	"license": "Apache-2.0",
 	"author": {


### PR DESCRIPTION
Cuts `1.6.1` on the 1.x maintenance line: the #185 state↔session binding backport (Security) plus the release-infra notes (#179/#180 OIDC + `v1-lts`, #187 review-lane sync). Changelog entry doubles as the release notes.

On publish (GitHub release → `release.yml`): ships to npm under the `v1-lts` dist-tag — `latest` stays with main. This is the `>=1.6.1` pin target central-manager asked for on #181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)