### PR TITLE
chore(ci): bump ai-review-prompts to 82c9484 (#73 calibration + #74 caller hygiene)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@9cf49d23cb046ecd6c87f3bba86dc3338d6998fb # main 2026-06-29 (#70 week-of-06-22 calibration + #71 prompt-ref tracking; on 1bbc562 = #67 + #69)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@82c9484f6f2560be4a37032858311e429bccd56c # main 2026-07-21 (#73 severity-deflation + fail-closed calibration, #74 caller hygiene; on 9cf49d2 = #70 + #71)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job
     # grants below what they need and breaks the workflow at startup;
@@ -58,7 +58,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 9cf49d23cb046ecd6c87f3bba86dc3338d6998fb
+      ai-review-prompts-ref: 82c9484f6f2560be4a37032858311e429bccd56c
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -45,7 +45,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@9cf49d23cb046ecd6c87f3bba86dc3338d6998fb # main 2026-06-29 (#70 week-of-06-22 calibration + #71 prompt-ref tracking; on 1bbc562 = #67 + #69)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@82c9484f6f2560be4a37032858311e429bccd56c # main 2026-07-21 (#73 severity-deflation + fail-closed calibration, #74 caller hygiene; on 9cf49d2 = #70 + #71)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job
     # grants below what they need and breaks the workflow at startup;
@@ -67,7 +67,7 @@ jobs:
       # in this repo for why the duplication is unavoidable
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
-      ai-review-prompts-ref: 9cf49d23cb046ecd6c87f3bba86dc3338d6998fb
+      ai-review-prompts-ref: 82c9484f6f2560be4a37032858311e429bccd56c
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -25,9 +25,9 @@ on:
 
 jobs:
   validate:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@f6daed301f8a7ece74593506de38c6e80820b00b # main 2026-05-06 (post #11/#12/#14)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@82c9484f6f2560be4a37032858311e429bccd56c # main 2026-07-21 (#74: validator now covers gemini-*.{yml,yaml} callers too)
     with:
       # Same SHA as the `uses:` ref above — the reusable uses this to
       # check out the validator script at the matching version. Same
       # SHA-twice pattern as the other caller workflows in this repo.
-      ai-review-prompts-ref: f6daed301f8a7ece74593506de38c6e80820b00b
+      ai-review-prompts-ref: 82c9484f6f2560be4a37032858311e429bccd56c


### PR DESCRIPTION
Review callers 9cf49d2 → 82c9484, validate pin → same SHA (uses + ai-review-prompts-ref in lockstep, all three caller files). Companion to HarperFast/harper#1891.

**What reviews pick up (#73):** severity-deflation mirror rule, fail-closed / validate-at-registration on new surfaces, secret-redaction routing — targeting the dominant partial class in recent triage.

**What validate picks up (#74):** the caller validator now covers `gemini-*.{yml,yaml}` callers (guard gap from rocksdb-js#701 review feedback).

Note: edits the caller workflows, so its own review checks fail with the expected anti-tamper guard; clears on merge.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)