### PR TITLE
chore(ci): bump mention + issue-to-pr pins to 54d9e61 (Opus 5)

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -22,11 +22,11 @@ concurrency:
 
 jobs:
   work:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@441d2a310cb360adf419d3546dd27566164f1ec2 # main 2026-06-09 (post #58: Opus for :bug/:test, efficiency guidance)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-issue-to-pr.yml@54d9e61c9c827d19e34229a5c460773a9fb080a0 # main 2026-07-24 (#79: deep path / :bug,:test escalation -> claude-opus-5)
     with:
       # Same SHA as the `uses:` ref above. See the comment in
       # claude-mention.yml for why the duplication is unavoidable.
-      ai-review-prompts-ref: 441d2a310cb360adf419d3546dd27566164f1ec2
+      ai-review-prompts-ref: 54d9e61c9c827d19e34229a5c460773a9fb080a0
       # Plugin repo — bun is part of the test path.
       setup-bun: true
       repo-specific-conventions: |

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   mention:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@f6daed301f8a7ece74593506de38c6e80820b00b # main 2026-05-06 (post #11/#12/#14)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-mention.yml@54d9e61c9c827d19e34229a5c460773a9fb080a0 # main 2026-07-24 (#79: deep path / :bug,:test escalation -> claude-opus-5)
     with:
       # Same SHA as the `uses:` ref above. The reusable uses this to
       # check out HarperFast/ai-review-prompts (parse + auth scripts)
@@ -34,7 +34,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to
       # the CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: f6daed301f8a7ece74593506de38c6e80820b00b
+      ai-review-prompts-ref: 54d9e61c9c827d19e34229a5c460773a9fb080a0
       # Plugin repo — opt into bun setup so the agent can run
       # `bun test` and `bun run …` for repo-specific scripts.
       setup-bun: true


### PR DESCRIPTION
Completes the Opus 5 rollout (ai-review-prompts#79) for this repo: the `@claude` mention `deep` path and the `claude-fix:bug`/`:test` issue-to-pr escalation now run `claude-opus-5`. Pins move uses + ai-review-prompts-ref in lockstep to 54d9e61.

Low-risk jump verified: the issue-to-pr reusable's ONLY change since the old pin is the model swap itself; the mention surface's delta is the model bumps plus a net-reverted permissions pair (#39/#40 — no interface change). These callers don't include claude-review.yml, so this PR gets a normal review (no anti-tamper).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)