### PR TITLE
docs: make redirectUri a first-class setup step, not a reference footnote

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add to your `config.yaml`:
 ```bash
 export OAUTH_GITHUB_CLIENT_ID="your-client-id"
 export OAUTH_GITHUB_CLIENT_SECRET="your-client-secret"
-export OAUTH_REDIRECT_URI="https://your-domain/oauth/callback"
+export OAUTH_REDIRECT_URI="http://localhost:9926/oauth/callback" # local dev value — must become your public origin when you deploy (step 3)
 ```
 
 > **Note:** The `export` commands above are for local development and quick testing only. You can also use a `.env` file with `dotenv-cli` for local dev — just don't commit it. For **Harper Fabric** deployments, see the [Harper Fabric documentation](https://docs.harperdb.io/docs/fabric/managing-applications) for managing runtime environment variables.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Add to your `config.yaml`:
 ```yaml
 '@harperfast/oauth':
   package: '@harperfast/oauth'
+  redirectUri: ${OAUTH_REDIRECT_URI} # your app's public origin — required for any deployed app
   providers:
     github:
       clientId: ${OAUTH_GITHUB_CLIENT_ID}
@@ -39,17 +40,23 @@ Add to your `config.yaml`:
 ```bash
 export OAUTH_GITHUB_CLIENT_ID="your-client-id"
 export OAUTH_GITHUB_CLIENT_SECRET="your-client-secret"
+export OAUTH_REDIRECT_URI="https://your-domain/oauth/callback"
 ```
 
 > **Note:** The `export` commands above are for local development and quick testing only. You can also use a `.env` file with `dotenv-cli` for local dev — just don't commit it. For **Harper Fabric** deployments, see the [Harper Fabric documentation](https://docs.harperdb.io/docs/fabric/managing-applications) for managing runtime environment variables.
 
 ### 3. Configure OAuth Callback
 
-Set your OAuth callback URL in your provider settings:
+This has **two sides** — both are required:
+
+1. **In your app config** — set `redirectUri` to your app's public origin plus `/oauth/callback` (step 1 above). The plugin appends the provider name for you, so one setting covers every provider.
+2. **In your provider settings** — register the provider-specific URL the plugin will send:
 
 ```
 https://your-domain/oauth/github/callback
 ```
+
+> **Note:** `redirectUri` defaults to `http://localhost:9926/oauth/callback`. If you skip side 1 on a deployed app, the provider will send your users to `localhost` and login will never complete — with no configuration error to tell you why. See [Understanding Redirects](docs/configuration.md#understanding-redirects).
 
 ### 4. (Optional) Register Lifecycle Hooks
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,7 @@ Complete configuration options for the `@harperfast/oauth` plugin.
 ```yaml
 '@harperfast/oauth':
   package: '@harperfast/oauth'
+  redirectUri: ${OAUTH_REDIRECT_URI} # your public origin + /oauth/callback — required on any deployed app
   providers:
     github:
       clientId: ${OAUTH_GITHUB_CLIENT_ID}
@@ -20,13 +21,13 @@ Complete configuration options for the `@harperfast/oauth` plugin.
 
 ### Global Options
 
-| Option                  | Type              | Default    | Description                                                                                                                                                                                                                                                |
-| ----------------------- | ----------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `debug`                 | boolean           | `false`    | Enable debug endpoints and logging                                                                                                                                                                                                                         |
-| `redirectUri`           | string            | (auto-gen) | OAuth callback URL where providers redirect back to                                                                                                                                                                                                        |
-| `postLoginRedirect`     | string            | `/`        | Default URL to redirect users after successful OAuth login                                                                                                                                                                                                 |
-| `cacheDynamicProviders` | boolean \| number | `300`      | TTL (seconds) for providers resolved via the `onResolveProvider` hook. Number = seconds; `false` = never cache (call the hook every request); `true` = cache forever. Default 300s; freshness is controlled by this TTL (there is no manual invalidation). |
-| `mcp`                   | object            | (off)      | MCP OAuth flow configuration. See [MCP OAuth](#mcp-oauth) below                                                                                                                                                                                            |
+| Option                  | Type              | Default                                | Description                                                                                                                                                                                                                                                                                                                                 |
+| ----------------------- | ----------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `debug`                 | boolean           | `false`                                | Enable debug endpoints and logging                                                                                                                                                                                                                                                                                                          |
+| `redirectUri`           | string            | `http://localhost:9926/oauth/callback` | **Set this on any deployed app.** Base OAuth callback URL providers redirect back to; the plugin appends the provider name. The default is a local-dev convenience — an app that omits it sends providers a `localhost` callback, which silently breaks login for everyone but you. See [Understanding Redirects](#understanding-redirects) |
+| `postLoginRedirect`     | string            | `/`                                    | Default URL to redirect users after successful OAuth login                                                                                                                                                                                                                                                                                  |
+| `cacheDynamicProviders` | boolean \| number | `300`                                  | TTL (seconds) for providers resolved via the `onResolveProvider` hook. Number = seconds; `false` = never cache (call the hook every request); `true` = cache forever. Default 300s; freshness is controlled by this TTL (there is no manual invalidation).                                                                                  |
+| `mcp`                   | object            | (off)                                  | MCP OAuth flow configuration. See [MCP OAuth](#mcp-oauth) below                                                                                                                                                                                                                                                                             |
 
 ### Provider Configuration
 
@@ -207,6 +208,8 @@ The OAuth plugin uses two different redirect configurations that serve distinct 
 - Must be a fully-qualified URL (protocol + domain + path)
 - Must match exactly what's registered with the OAuth provider
 - Used only during the OAuth handshake - users briefly visit this URL but don't stay there
+
+**If you don't set it:** the plugin falls back to `http://localhost:9926/oauth/callback`. That is a local-dev convenience, and it fails in a way that doesn't look like a configuration error — the provider happily redirects your users to `localhost` (their own machine) instead of your app, so login just never completes. Registering the callback URL with your provider is **not** sufficient; the plugin only sends what `redirectUri` is set to. Set it explicitly on every deployed app, and [verify it](./providers.md#verifying-the-authorization-request) after deploying.
 
 ### 2. Post-Login Redirect (`postLoginRedirect`)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,7 @@ Each provider requires:
 - `authorizationUrl` - Authorization endpoint URL (required)
 - `tokenUrl` - Token endpoint URL (required)
 - `userInfoUrl` - User info endpoint URL (required)
-- `jwksUrl` - JWKS endpoint URL (required for ID token verification)
+- `jwksUri` - JWKS endpoint URL (required for ID token verification). Note the spelling: `jwksUri`, not `jwksUrl` — a misspelled key is ignored, leaving ID tokens unverifiable
 
 ### MCP OAuth
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,11 +17,14 @@ Add the plugin to your Harper application's `config.yaml`:
 ```yaml
 '@harperfast/oauth':
   package: '@harperfast/oauth'
+  redirectUri: ${OAUTH_REDIRECT_URI}
   providers:
     github:
       clientId: ${OAUTH_GITHUB_CLIENT_ID}
       clientSecret: ${OAUTH_GITHUB_CLIENT_SECRET}
 ```
+
+`redirectUri` is your app's public origin plus `/oauth/callback` — the plugin appends the provider name (`/oauth/github/callback`) when it talks to the provider. It defaults to `http://localhost:9926/oauth/callback`, which is fine for the local walkthrough below but **must be set on any deployed app** — otherwise the provider redirects your users to `localhost` and login silently never completes. See [Understanding Redirects](./configuration.md#understanding-redirects).
 
 ### 2. Set Environment Variables
 
@@ -30,6 +33,7 @@ For **local development**, export variables in your terminal session:
 ```bash
 export OAUTH_GITHUB_CLIENT_ID="your_github_client_id"
 export OAUTH_GITHUB_CLIENT_SECRET="your_github_client_secret"
+export OAUTH_REDIRECT_URI="http://localhost:9926/oauth/callback" # your public origin once deployed
 ```
 
 > **Note:** These `export` commands are for local development only. You can also use a `.env` file with `dotenv-cli` for local dev — just don't commit it to source control.
@@ -74,6 +78,16 @@ Navigate to:
 ```
 http://localhost:9926/oauth/github/login
 ```
+
+### 6. Verify After Deploying
+
+The login route is a redirect, so you can confirm what the plugin actually sends the provider without completing a login:
+
+```bash
+curl -sS -D - -o /dev/null https://your-domain/oauth/github/login | grep -i '^location'
+```
+
+In the `Location` header, check that `redirect_uri` is your public origin (not `localhost`) and that `client_id` is a real value (not an unexpanded `%24%7BOAUTH_...%7D`, which means the environment variable never reached the deployment). See [Common Issues](./providers.md#common-issues).
 
 ## Supported Providers
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,7 +33,7 @@ For **local development**, export variables in your terminal session:
 ```bash
 export OAUTH_GITHUB_CLIENT_ID="your_github_client_id"
 export OAUTH_GITHUB_CLIENT_SECRET="your_github_client_secret"
-export OAUTH_REDIRECT_URI="http://localhost:9926/oauth/callback" # your public origin once deployed
+export OAUTH_REDIRECT_URI="http://localhost:9926/oauth/callback" # local dev value — change to your public origin once deployed
 ```
 
 > **Note:** These `export` commands are for local development only. You can also use a `.env` file with `dotenv-cli` for local dev — just don't commit it to source control.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -306,10 +306,10 @@ For other OpenID Connect compatible providers:
     custom:
       clientId: ${OAUTH_CUSTOM_CLIENT_ID}
       clientSecret: ${OAUTH_CUSTOM_CLIENT_SECRET}
-      authorizationUrl: 'https://provider.com/oauth/authorize'
-      tokenUrl: 'https://provider.com/oauth/token'
-      userInfoUrl: 'https://provider.com/oauth/userinfo'
-      jwksUrl: 'https://provider.com/.well-known/jwks.json'
+      authorizationUrl: ${OAUTH_CUSTOM_AUTHORIZATION_URL}
+      tokenUrl: ${OAUTH_CUSTOM_TOKEN_URL}
+      userInfoUrl: ${OAUTH_CUSTOM_USERINFO_URL}
+      jwksUri: ${OAUTH_CUSTOM_JWKS_URL} # note: jwksUri, not jwksUrl
       scope: 'openid profile email'
 ```
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -18,6 +18,23 @@ Detailed setup instructions for each supported OAuth provider.
 
 **Example:** The OAuth plugin includes Okta code, but Okta authentication is **not available** unless you configure an Okta provider with credentials. Built-in providers are templates, not active endpoints.
 
+## Callback URLs: Both Sides Are Required
+
+Every provider setup below has you register a callback URL with the provider. That is only half of it — you must **also** tell the plugin to send that URL, via the plugin-level `redirectUri` option:
+
+```yaml
+'@harperfast/oauth':
+  redirectUri: ${OAUTH_REDIRECT_URI} # e.g. https://yourdomain.com/oauth/callback
+  providers:
+    # ...
+```
+
+- Set it **once**, at the plugin level (a sibling of `providers`, not inside a provider). The plugin appends the provider name per request: `https://yourdomain.com/oauth/callback` → `https://yourdomain.com/oauth/github/callback`, `.../oauth/google/callback`, and so on. That's why the value you configure has no provider name in it but the URL you register with the provider does.
+- If you omit it, it defaults to `http://localhost:9926/oauth/callback`. On a deployed app that default is a trap: the provider accepts the request and redirects your users to `localhost` — their own machine — so login never completes and no configuration error is raised anywhere. Set it explicitly on every deployed app.
+- After deploying, [verify what the plugin actually sends](#verifying-the-authorization-request).
+
+See [Understanding Redirects](./configuration.md#understanding-redirects) for how this differs from `postLoginRedirect`.
+
 ## GitHub OAuth
 
 ### 1. Create OAuth App
@@ -35,6 +52,7 @@ Detailed setup instructions for each supported OAuth provider.
 
 ```yaml
 '@harperfast/oauth':
+  redirectUri: ${OAUTH_REDIRECT_URI} # required on any deployed app — see Callback URLs above
   providers:
     github:
       clientId: ${OAUTH_GITHUB_CLIENT_ID}
@@ -47,6 +65,7 @@ Detailed setup instructions for each supported OAuth provider.
 ```bash
 export OAUTH_GITHUB_CLIENT_ID="your_client_id"
 export OAUTH_GITHUB_CLIENT_SECRET="your_client_secret"
+export OAUTH_REDIRECT_URI="https://yourdomain.com/oauth/callback"
 ```
 
 ### Available Scopes
@@ -76,6 +95,7 @@ export OAUTH_GITHUB_CLIENT_SECRET="your_client_secret"
 
 ```yaml
 '@harperfast/oauth':
+  redirectUri: ${OAUTH_REDIRECT_URI} # required on any deployed app — see Callback URLs above
   providers:
     google:
       clientId: ${OAUTH_GOOGLE_CLIENT_ID}
@@ -88,6 +108,7 @@ export OAUTH_GITHUB_CLIENT_SECRET="your_client_secret"
 ```bash
 export OAUTH_GOOGLE_CLIENT_ID="your_client_id"
 export OAUTH_GOOGLE_CLIENT_SECRET="your_client_secret"
+export OAUTH_REDIRECT_URI="https://yourdomain.com/oauth/callback"
 ```
 
 ### Available Scopes
@@ -120,6 +141,7 @@ export OAUTH_GOOGLE_CLIENT_SECRET="your_client_secret"
 
 ```yaml
 '@harperfast/oauth':
+  redirectUri: ${OAUTH_REDIRECT_URI} # required on any deployed app — see Callback URLs above
   providers:
     azure:
       clientId: ${OAUTH_AZURE_CLIENT_ID}
@@ -134,6 +156,7 @@ export OAUTH_GOOGLE_CLIENT_SECRET="your_client_secret"
 export OAUTH_AZURE_CLIENT_ID="your_client_id"
 export OAUTH_AZURE_CLIENT_SECRET="your_client_secret"
 export OAUTH_AZURE_TENANT_ID="your_tenant_id"
+export OAUTH_REDIRECT_URI="https://yourdomain.com/oauth/callback"
 ```
 
 ### Available Scopes
@@ -165,6 +188,7 @@ export OAUTH_AZURE_TENANT_ID="your_tenant_id"
 
 ```yaml
 '@harperfast/oauth':
+  redirectUri: ${OAUTH_REDIRECT_URI} # required on any deployed app — see Callback URLs above
   providers:
     auth0:
       domain: ${OAUTH_AUTH0_DOMAIN}
@@ -179,6 +203,7 @@ export OAUTH_AZURE_TENANT_ID="your_tenant_id"
 export OAUTH_AUTH0_DOMAIN="yourapp.auth0.com"
 export OAUTH_AUTH0_CLIENT_ID="your_client_id"
 export OAUTH_AUTH0_CLIENT_SECRET="your_client_secret"
+export OAUTH_REDIRECT_URI="https://yourdomain.com/oauth/callback"
 ```
 
 ### Available Scopes
@@ -212,6 +237,7 @@ export OAUTH_AUTH0_CLIENT_SECRET="your_client_secret"
 
 ```yaml
 '@harperfast/oauth':
+  redirectUri: ${OAUTH_REDIRECT_URI} # required on any deployed app — see Callback URLs above
   providers:
     okta:
       domain: ${OAUTH_OKTA_DOMAIN}
@@ -226,6 +252,7 @@ export OAUTH_AUTH0_CLIENT_SECRET="your_client_secret"
 export OAUTH_OKTA_DOMAIN="dev-12345.okta.com"
 export OAUTH_OKTA_CLIENT_ID="your_client_id"
 export OAUTH_OKTA_CLIENT_SECRET="your_client_secret"
+export OAUTH_REDIRECT_URI="https://yourdomain.com/oauth/callback"
 ```
 
 ### Available Scopes
@@ -274,6 +301,7 @@ For other OpenID Connect compatible providers:
 
 ```yaml
 '@harperfast/oauth':
+  redirectUri: ${OAUTH_REDIRECT_URI} # required on any deployed app — see Callback URLs above
   providers:
     custom:
       clientId: ${OAUTH_CUSTOM_CLIENT_ID}
@@ -288,6 +316,7 @@ For other OpenID Connect compatible providers:
 ### Environment Variables
 
 ```bash
+export OAUTH_REDIRECT_URI="https://yourdomain.com/oauth/callback"
 export OAUTH_CUSTOM_CLIENT_ID="your_client_id"
 export OAUTH_CUSTOM_CLIENT_SECRET="your_client_secret"
 export OAUTH_CUSTOM_AUTHORIZATION_URL="https://provider.com/oauth/authorize"
@@ -305,17 +334,53 @@ export OAUTH_CUSTOM_JWKS_URL="https://provider.com/.well-known/jwks.json"
 3. Complete the OAuth flow
 4. Check your session for OAuth data
 
+### Verifying the Authorization Request
+
+The login route is a `302`, so you can inspect exactly what the plugin sends the provider without completing a login. Do this after every deployment:
+
+```bash
+curl -sS -D - -o /dev/null https://yourdomain.com/oauth/github/login | grep -i '^location'
+```
+
+In the returned `Location` header, confirm:
+
+- **`redirect_uri`** is your public origin — `https%3A%2F%2Fyourdomain.com%2Foauth%2Fgithub%2Fcallback`, not `localhost`
+- **`client_id`** is a real credential — not `%24%7BOAUTH_..._CLIENT_ID%7D`, which is a URL-encoded `${OAUTH_..._CLIENT_ID}` and means the environment variable never reached the running app
+
+Both failures happen before the provider is involved, so neither shows up in your provider's logs.
+
 ## Common Issues
+
+### Deployed App Redirects Users to `localhost`
+
+**Symptom:** login appears to work — the provider's consent screen shows, you approve — and then the browser lands on `http://localhost:9926/oauth/{provider}/callback` and stalls or loops. No error appears in the app log.
+
+**Cause:** `redirectUri` isn't set, so the plugin fell back to its `http://localhost:9926/oauth/callback` default and sent that to the provider. It reaches the consent screen (rather than failing with `redirect_uri_mismatch`) whenever `localhost` is also registered with the provider — a very common leftover from local development.
+
+**Solution:** set the plugin-level `redirectUri` to your public origin, as described in [Callback URLs](#callback-urls-both-sides-are-required). Registering the URL with your provider does not affect what the plugin sends.
+
+### Provider Rejects an Unexpanded `${OAUTH_...}` Value
+
+**Symptom:** the provider errors immediately with `invalid_client` / "OAuth client was not found", and the authorization URL contains `client_id=%24%7BOAUTH_GITHUB_CLIENT_ID%7D`.
+
+**Cause:** `${VAR}` placeholders in `config.yaml` are substituted from the environment of the running app. When a variable is undefined, the placeholder is passed through **as a literal string** rather than raising a configuration error — so the plugin starts up looking healthy and ships `${OAUTH_GITHUB_CLIENT_ID}` to the provider verbatim.
+
+**Solution:** make the variable available to the deployed app, not just your shell — for **Harper Fabric**, see [managing runtime environment variables](https://docs.harperdb.io/docs/fabric/managing-applications). Then re-check with the `curl` above.
 
 ### Redirect URI Mismatch
 
 **Error:** `redirect_uri_mismatch` or similar
 
-**Solution:** Ensure the redirect URI in your provider settings exactly matches:
+**Solution:** the URL the plugin sends and the URL registered with the provider must match exactly. Check **both** sides:
+
+- **Plugin:** `redirectUri` is set to your public origin plus `/oauth/callback` (the plugin appends the provider name itself)
+- **Provider:** the registered callback is the provider-specific form:
 
 ```
 https://yourdomain.com/oauth/{provider}/callback
 ```
+
+Watch for a trailing slash, `http` vs `https`, and `www.` differences — providers compare byte-for-byte.
 
 ### Invalid Client Credentials
 
@@ -324,7 +389,7 @@ https://yourdomain.com/oauth/{provider}/callback
 **Solution:**
 
 - Verify client ID and secret are correct
-- Check environment variables are set
+- Check environment variables are set **in the deployed app's environment**, and that they expanded (see [above](#provider-rejects-an-unexpanded-oauth_-value))
 - Ensure client secret hasn't expired
 
 ### Missing Email Address

--- a/docs/token-refresh-and-sessions.md
+++ b/docs/token-refresh-and-sessions.md
@@ -277,7 +277,7 @@ custom:
   authorizationUrl: 'https://provider.com/oauth/authorize'
   tokenUrl: 'https://provider.com/oauth/token'
   userInfoUrl: 'https://provider.com/oauth/userinfo'
-  jwksUrl: 'https://provider.com/.well-known/jwks.json'
+  jwksUri: 'https://provider.com/.well-known/jwks.json'
   scope: 'openid profile email'
 ```
 


### PR DESCRIPTION
> _Drafted by Claude (Opus 5, 1M context) on Nathan's behalf, following the harper-engineering-guidelines development lifecycle. Docs-only change; the diff and this description are agent-authored, pushed under Nathan's account because the agent runs locally on his machine. Human review expected before merge._

## Summary

`redirectUri` was documented as a reference footnote, so every on-ramp in this repo taught readers only half of the callback setup. Follow any of them verbatim and a deployed app keeps the local-dev default — after which the OAuth provider redirects your users to `localhost` and login never completes, with no configuration error raised anywhere. An internal adopter lost an afternoon to exactly this; the docs are the reason it wasn't obvious.

## The gap

Each on-ramp tells you to register `https://yourdomain.com/oauth/<provider>/callback` **with your provider**. None of them tell you to set `redirectUri` so the plugin actually **sends** that URL:

| Doc | Register with provider | Set `redirectUri` |
| --- | --- | --- |
| `README.md` § 3 "Configure OAuth Callback" | ✅ | ❌ |
| `docs/getting-started.md` § 1 (+ § 5 tests against `localhost`) | — | ❌ |
| `docs/providers.md` — all six provider sections | ✅ | ❌ |

Only `docs/configuration.md` § Understanding Redirects covered it properly — and its options table listed the default as **`(auto-gen)`**, which reads as "the plugin derives it from the request host." It doesn't: it's a hardcoded fallback (`config.yaml` `redirectUri`, and `src/lib/config.ts` `buildProviderConfig`).

## Why it fails silently

Two independent behaviors combine into a failure with no error message on either side:

1. **The localhost default is reachable.** `buildProviderConfig` falls back to `http://localhost:9926/oauth`, rewrites it to `/oauth/<provider>/callback`, and sends it. The provider does not reject it whenever `localhost` is also registered on the client — a near-universal leftover from local development — so the flow reaches the consent screen, the user approves, and only then does the browser get sent to their own machine. There is no `redirect_uri_mismatch` to search for.
2. **Unexpanded `${VAR}` placeholders are passed through as literals.** `expandEnvVar` returns the literal `${VAR}` string when the variable is undefined, so a deployment missing its env vars ships `client_id=${OAUTH_..._CLIENT_ID}` to the provider verbatim. The plugin logs a healthy startup either way.

Neither is visible in the provider's logs, because both are decided before the provider is involved.

## What changed

- **`redirectUri` in every config example** — README quick start, getting-started, the configuration reference's own basic example, and all six provider sections in `providers.md`, each with the matching `OAUTH_REDIRECT_URI` export.
- **New `providers.md` § "Callback URLs: Both Sides Are Required"** — states the two-sided requirement once, explains that the option is plugin-level (a sibling of `providers`), and explains the provider-name append, i.e. why the value you configure has no provider name in it but the URL you register does.
- **Corrected the configuration reference** — `redirectUri`'s default is now the actual value instead of `(auto-gen)`, with a note that omitting it breaks login for everyone but you.
- **New § "Verifying the Authorization Request"** — the login route is a `302`, so `curl -D -` on it and reading the `Location` header confirms both `redirect_uri` and `client_id` without completing a login. This is the fastest way to catch either failure and it was documented nowhere.
- **Two new Common Issues entries** — "Deployed App Redirects Users to `localhost`" and "Provider Rejects an Unexpanded `${OAUTH_...}` Value" — each with the symptom as experienced, the cause, and the fix. Also extended the existing "Redirect URI Mismatch" entry, whose advice was previously provider-side only.

## Two more silently-ignored keys, found in review

Review flagged that the Custom OIDC Provider example hardcoded its endpoint URLs while the accompanying export block defined `OAUTH_CUSTOM_AUTHORIZATION_URL` and friends — so those exports had no effect. `buildProviderConfig` runs `expandEnvVar` over every provider key, so the placeholders do work; the example now uses them, matching every other provider section.

Verifying that surfaced a second one in the same block: the docs documented **`jwksUrl`**, but the code only ever reads **`jwksUri`** (`src/types.ts`, consumed in `OAuthProvider.ts`), with no alias. A custom OIDC provider configured per these docs therefore had no JWKS at all and could not verify ID tokens. Corrected in `providers.md`, `configuration.md`, and `token-refresh-and-sessions.md`, with a spelling note on the option so it doesn't get re-introduced.

Both are the same failure class as the `redirectUri` gap this PR started from: config the docs tell you to set that the plugin never receives.

## Follow-ups (not in this PR)

This PR documents around two behaviors that arguably shouldn't be silent. Both are small, and would make the failure self-diagnosing instead:

1. **Don't default `redirectUri` to localhost on a deployed app.** Warn at startup (or fail closed) when it's unset, rather than silently emitting a loopback callback.
2. **Warn when a `${VAR}` placeholder survives expansion.** Shipping a literal `${OAUTH_..._CLIENT_ID}` to a provider is never intentional.

Happy to file both as issues if wanted.

## Verification

- `npm run format:check` (prettier) passes on all changed files.
- Every cross-document anchor added here was checked against the target headings: `#understanding-redirects`, `#common-issues`, `#verifying-the-authorization-request`, `#callback-urls-both-sides-are-required`, `#provider-rejects-an-unexpanded-oauth_-value`.
- No source changes, so lint and tests are unaffected by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
