### PR TITLE
fix: bind browser-initiated OAuth flows to the initiating browser

### DIFF
--- a/integrationTests/mcp-oauth-e2e.test.ts
+++ b/integrationTests/mcp-oauth-e2e.test.ts
@@ -305,6 +305,17 @@ suite('MCP OAuth Stage 7: full round-trip e2e', (ctx: ContextWithHarper) => {
 		strictEqual(authorizeRes.status, 302, 'authorize must 302 to stub IdP');
 		const idpLocation = authorizeRes.headers.get('location');
 		ok(idpLocation, 'authorize must redirect to a location');
+
+		// Browser binding (GHSA-xf67-jxfx-jf88): every /oauth/mcp/authorize flow —
+		// including this DCR/stored path — now sets a per-flow __Host- consent
+		// nonce cookie whose hash is carried in the upstream state; the callback
+		// requires the cookie back before minting a code. A real browser stores
+		// this Secure/SameSite=Lax cookie over HTTPS and re-sends it on the
+		// top-level redirect from the IdP. The stub runs over plain HTTP, so we
+		// replay the cookie explicitly on the callback hop to model that.
+		const consentCookie = authorizeRes.headers.getSetCookie().find((c) => c.startsWith('__Host-mcp_consent_'));
+		ok(consentCookie, 'DCR authorize must set the per-flow browser-binding cookie');
+		const consentCookiePair = consentCookie!.split(';')[0];
 		await authorizeRes.body?.cancel();
 
 		// The Location should point at the stub IdP /authorize endpoint.
@@ -326,7 +337,11 @@ suite('MCP OAuth Stage 7: full round-trip e2e', (ctx: ContextWithHarper) => {
 		// and 302s to the client redirect_uri with code + state).
 		const harperCallbackUrl = new URL(harperCallbackLocation!);
 		// The stub IdP redirect target is already an absolute URL to Harper's callback.
-		const callbackRes = await fetch(harperCallbackUrl.toString(), { redirect: 'manual' });
+		// Carry the per-flow consent cookie, as the browser would.
+		const callbackRes = await fetch(harperCallbackUrl.toString(), {
+			redirect: 'manual',
+			headers: { cookie: consentCookiePair },
+		});
 		strictEqual(callbackRes.status, 302, 'Harper callback must 302 to client redirect_uri');
 		const finalLocation = callbackRes.headers.get('location');
 		ok(finalLocation, 'Harper callback must redirect to a location');

--- a/src/lib/handlers.ts
+++ b/src/lib/handlers.ts
@@ -19,7 +19,15 @@ import type {
 	OnLoginResultDenied,
 	OnLoginResultNeedsConfirmation,
 } from '../types.ts';
-import { consentNonceMatches, readConsentNonce } from './mcp/consentBinding.ts';
+import {
+	buildLoginCookie,
+	consentNonceMatches,
+	generateConsentFlowId,
+	generateConsentNonce,
+	hashConsentNonce,
+	readConsentNonce,
+	readLoginNonce,
+} from './mcp/consentBinding.ts';
 import { handleMCPCallback } from './mcp/index.ts';
 import { resolveIssuer } from './mcp/wellKnown.ts';
 import type { HookManager } from './hookManager.ts';
@@ -133,12 +141,24 @@ export async function handleLogin(
 	const referer = request.headers?.referer ? sanitizeRedirect(request.headers.referer) : undefined;
 	const originalUrl = redirectParam || referer || config.postLoginRedirect || '/';
 
+	// Browser binding (GHSA-xf67-jxfx-jf88): session binding below only covers
+	// flows initiated while logged in — Harper mints no anonymous session id, so
+	// the primary logged-out login flow had nothing tying the callback to the
+	// browser that started it (login CSRF: an attacker-minted state+code fed to
+	// a victim's browser silently logs the victim in as the attacker). Same
+	// per-flow nonce-cookie mechanism as the CIMD consent binding — the cookie
+	// stays in this browser, only its hash travels in the state token.
+	const loginFlowId = generateConsentFlowId();
+	const loginNonce = generateConsentNonce();
+
 	// Generate CSRF token with metadata
 	// Bind token to provider to prevent cross-provider CSRF attacks
 	const csrfToken = await provider.generateCSRFToken({
 		originalUrl,
 		sessionId: request.session?.id,
 		providerName, // Bind state token to this provider
+		loginFlowId,
+		browserNonceHash: hashConsentNonce(loginNonce),
 	});
 
 	// Build authorization URL with CSRF token as state parameter
@@ -149,7 +169,8 @@ export async function handleLogin(
 	return {
 		status: 302,
 		headers: {
-			Location: authUrl,
+			'Location': authUrl,
+			'Set-Cookie': buildLoginCookie(loginFlowId, loginNonce),
 		},
 	};
 }
@@ -195,7 +216,10 @@ export async function handleCallback(
 		// echo it to postLoginRedirect with the original reason. Otherwise,
 		// generic invalid_request.
 		if (error) {
-			logger?.error?.(`OAuth error (no state): ${error} - ${errorDescription}`);
+			// JSON.stringify: error/error_description are attacker-controlled
+			// query params, reachable pre-auth — encode CR/LF so a crafted value
+			// can't forge log lines (CWE-117; same treatment as the DCR handler).
+			logger?.error?.(`OAuth error (no state): ${JSON.stringify(error)} - ${JSON.stringify(errorDescription)}`);
 			const errorUrl = buildErrorRedirect(config.postLoginRedirect || '/', {
 				error: 'oauth_failed',
 				reason: error,
@@ -275,6 +299,26 @@ export async function handleCallback(
 		return { status: 302, headers: { Location: errorUrl } };
 	}
 
+	// Login browser binding (GHSA-xf67-jxfx-jf88) — the human-flow counterpart
+	// of the CIMD check below. The state minted by handleLogin carries the hash
+	// of a per-flow nonce cookie set on the initiating browser; a callback
+	// arriving without the matching cookie is a state delivered into a
+	// different browser — the login-CSRF shape the session binding above can't
+	// catch when the flow starts logged out (no session id to record).
+	// Enforced whenever the token carries the hash, so pre-upgrade in-flight
+	// tokens still complete; MCP states never carry a top-level hash (their
+	// binding is the CIMD check below).
+	if (tokenData.browserNonceHash && !mcpState) {
+		if (!consentNonceMatches(readLoginNonce(request, tokenData.loginFlowId), tokenData.browserNonceHash)) {
+			logger?.warn?.(`OAuth callback: login browser binding mismatch (provider '${providerName}')`);
+			const errorUrl = buildErrorRedirect(tokenData.originalUrl || config.postLoginRedirect || '/', {
+				error: 'auth_failed',
+				reason: 'csrf',
+			});
+			return { status: 302, headers: { Location: errorUrl } };
+		}
+	}
+
 	// CIMD browser binding — checked BEFORE the upstream code exchange and the
 	// onLogin hook, so a mismatched (self-approved) flow triggers no upstream
 	// exchange, no userinfo fetch, and no provisioning side-effects; it only
@@ -290,7 +334,8 @@ export async function handleCallback(
 
 	// Now that we know the flow context, handle upstream IdP errors.
 	if (error) {
-		logger?.error?.(`OAuth error: ${error} - ${errorDescription}`);
+		// JSON.stringify: CRLF-safe logging of browser-controlled params (CWE-117).
+		logger?.error?.(`OAuth error: ${JSON.stringify(error)} - ${JSON.stringify(errorDescription)}`);
 		if (mcpState) {
 			return mcpErrorRedirect(mcpState, error, errorDescription || error);
 		}

--- a/src/lib/handlers.ts
+++ b/src/lib/handlers.ts
@@ -30,6 +30,7 @@ import {
 } from './mcp/consentBinding.ts';
 import { handleMCPCallback } from './mcp/index.ts';
 import { resolveIssuer } from './mcp/wellKnown.ts';
+import { getRequestHeader } from './requestHeaders.ts';
 import type { HookManager } from './hookManager.ts';
 
 /**
@@ -138,7 +139,10 @@ export async function handleLogin(
 		redirectParam = sanitizeRedirect(redirectParam);
 	}
 
-	const referer = request.headers?.referer ? sanitizeRedirect(request.headers.referer) : undefined;
+	// getRequestHeader, not request.headers.referer: the live Harper runtime
+	// wraps headers behind `.asObject`, so direct property access is undefined.
+	const refererHeader = getRequestHeader(request.headers, 'referer');
+	const referer = refererHeader ? sanitizeRedirect(refererHeader) : undefined;
 	const originalUrl = redirectParam || referer || config.postLoginRedirect || '/';
 
 	// Browser binding (GHSA-xf67-jxfx-jf88): session binding below only covers

--- a/src/lib/handlers.ts
+++ b/src/lib/handlers.ts
@@ -319,16 +319,30 @@ export async function handleCallback(
 		}
 	}
 
-	// CIMD browser binding — checked BEFORE the upstream code exchange and the
-	// onLogin hook, so a mismatched (self-approved) flow triggers no upstream
-	// exchange, no userinfo fetch, and no provisioning side-effects; it only
-	// applies when the state carries a binding (CIMD), so DCR/human flows are
-	// unaffected. SameSite=Lax sends the per-flow nonce cookie on the top-level
-	// redirect back from the IdP.
-	if (mcpState?.browserNonceHash) {
-		if (!consentNonceMatches(readConsentNonce(request, mcpState.consentFlowId), mcpState.browserNonceHash)) {
-			logger?.warn?.(`MCP callback: consent browser binding mismatch for client=${mcpState.clientId}`);
-			return mcpErrorRedirect(mcpState, 'access_denied', 'Authorization must complete in the browser that approved it');
+	// MCP browser binding — every /oauth/mcp/authorize flow (the CIMD interstitial
+	// AND the direct DCR/stored path) mints a per-flow __Host- nonce cookie and
+	// carries its hash in the upstream state, so the callback can prove the flow
+	// completes in the browser that initiated it. Checked BEFORE the upstream code
+	// exchange and the onLogin hook, so a mismatched (or unbound) flow triggers no
+	// upstream exchange, no userinfo fetch, and no provisioning side-effects. Fail
+	// closed: an MCP state reaching here without a binding is a forged or
+	// pre-upgrade in-flight state — reject it rather than mint an auth code for an
+	// unbound flow (authorization-code injection). Unlike the human flow above —
+	// whose pre-upgrade tolerance stays scoped to `!mcpState` and is deliberately
+	// NOT widened to MCP — an MCP flow's anonymous initiator has no session-id
+	// fallback, so the cookie is its only browser proof. SameSite=Lax sends the
+	// per-flow nonce cookie on the top-level redirect back from the IdP.
+	if (mcpState) {
+		if (
+			!mcpState.browserNonceHash ||
+			!consentNonceMatches(readConsentNonce(request, mcpState.consentFlowId), mcpState.browserNonceHash)
+		) {
+			logger?.warn?.(`MCP callback: browser binding mismatch for client=${mcpState.clientId}`);
+			return mcpErrorRedirect(
+				mcpState,
+				'access_denied',
+				'Authorization must complete in the browser that initiated it'
+			);
 		}
 	}
 

--- a/src/lib/mcp/authorize.ts
+++ b/src/lib/mcp/authorize.ts
@@ -55,7 +55,7 @@ type ErrorJSON = {
 
 type Redirect = {
 	status: 302;
-	headers: { Location: string };
+	headers: { 'Location': string; 'Set-Cookie'?: string };
 };
 
 type HtmlResponse = {
@@ -333,6 +333,27 @@ async function performUpstreamRedirect(
 	const providerEntry = providers[selection.providerName];
 	const providerConfig: OAuthProviderConfig = providerEntry.config;
 
+	// Browser binding for EVERY MCP authorize flow, not just the CIMD interstitial.
+	// CIMD clients arrive here from /oauth/mcp/confirm with the interstitial's
+	// per-flow nonce hash already bound into mcpState (its cookie already lives in
+	// the browser), so leave those untouched. Stored/DCR clients skip the
+	// interstitial and reach here directly with no binding — mint the same
+	// __Host- per-flow nonce cookie here and carry its hash in the upstream state
+	// so the callback can prove the flow completes in the initiating browser.
+	// Without this an anonymous initiator also mints no session id, so an
+	// attacker-minted, unbound state fed to a victim would produce an auth code
+	// for the victim at the attacker's redirect_uri (authorization-code
+	// injection). Only the hash leaves the server; the callback re-checks the
+	// cookie (see handlers.ts).
+	let boundState = mcpState;
+	let bindingCookie: string | undefined;
+	if (!boundState.browserNonceHash) {
+		const consentFlowId = generateConsentFlowId();
+		const consentNonce = generateConsentNonce();
+		boundState = { ...boundState, browserNonceHash: hashConsentNonce(consentNonce), consentFlowId };
+		bindingCookie = buildConsentCookie(consentFlowId, consentNonce);
+	}
+
 	let csrfToken: string;
 	try {
 		csrfToken = await providerEntry.provider.generateCSRFToken({
@@ -342,7 +363,7 @@ async function performUpstreamRedirect(
 			// Both MCP entries (direct authorize and post-CIMD confirm) mint
 			// their upstream state here, so this is the single binding site.
 			sessionId: request.session?.id,
-			mcp: mcpState,
+			mcp: boundState,
 		});
 	} catch (error) {
 		logger?.error?.(
@@ -358,7 +379,9 @@ async function performUpstreamRedirect(
 		`MCP authorize: client=${mcpState.clientId} -> upstream=${selection.providerName}; bound resource=${mcpState.resource}`
 	);
 
-	return { status: 302, headers: { Location: upstreamAuthUrl } };
+	const headers: Redirect['headers'] = { Location: upstreamAuthUrl };
+	if (bindingCookie) headers['Set-Cookie'] = bindingCookie;
+	return { status: 302, headers };
 }
 
 /**

--- a/src/lib/mcp/consentBinding.ts
+++ b/src/lib/mcp/consentBinding.ts
@@ -107,7 +107,7 @@ function readBindingNonce(
 	flowId: string | undefined
 ): string | undefined {
 	if (!flowId) return undefined;
-	const header = request?.headers?.cookie;
+	const header = readCookieHeader(request);
 	if (typeof header !== 'string' || !header) return undefined;
 	const name = prefix + flowId;
 	for (const part of header.split(';')) {
@@ -118,6 +118,29 @@ function readBindingNonce(
 		}
 	}
 	return undefined;
+}
+
+/**
+ * Read the raw `Cookie` header across the shapes a Harper request can carry: a
+ * Web `Headers` object (`.get()`), Harper's runtime headers wrapper (`.asObject`
+ * — what the live server passes to component resources), or a plain Node
+ * `IncomingMessage.headers` object (used in unit tests). Reading
+ * `request.headers.cookie` directly returns undefined against the live wrapper,
+ * which would fail the binding check closed for every browser flow — mirrors the
+ * `getHeader` helper in withMCPAuth.ts.
+ */
+function readCookieHeader(request: Request | undefined): string | undefined {
+	const headers = request?.headers as any;
+	if (!headers) return undefined;
+	let raw: unknown;
+	if (typeof headers.get === 'function') {
+		raw = headers.get('cookie');
+	} else {
+		const obj = headers.asObject ?? headers;
+		raw = obj?.cookie ?? obj?.Cookie;
+	}
+	if (raw == null) return undefined;
+	return Array.isArray(raw) ? raw[0] : String(raw);
 }
 
 /** Constant-time check that `nonce` hashes to `expectedHash`. */

--- a/src/lib/mcp/consentBinding.ts
+++ b/src/lib/mcp/consentBinding.ts
@@ -32,6 +32,13 @@
  * the CSRF store, so a party that observes or replays state tokens still cannot
  * reconstruct the cookie value. Cookies expire via `Max-Age`; per-flow naming
  * makes explicit clearing unnecessary for correctness.
+ *
+ * The human login flow uses the same binding under a distinct cookie namespace
+ * (GHSA-xf67-jxfx-jf88): session binding only protects flows initiated while
+ * logged in, so the logged-out login flow needs the nonce cookie to prove the
+ * callback arrived in the browser that initiated it. handleLogin mints it;
+ * handleCallback enforces it via the `buildLoginCookie`/`readLoginNonce`
+ * variants below.
  */
 
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
@@ -39,6 +46,9 @@ import type { Request } from '../../types.ts';
 
 /** `__Host-` prefix + a per-flow id suffix. See module header for why. */
 const CONSENT_COOKIE_PREFIX = '__Host-mcp_consent_';
+
+/** Human-login binding cookie namespace (GHSA-xf67-jxfx-jf88). */
+const LOGIN_COOKIE_PREFIX = '__Host-oauth_login_';
 
 /** Must comfortably outlast the interstitial pause plus the upstream IdP login. */
 const CONSENT_COOKIE_MAX_AGE_S = 900;
@@ -56,8 +66,8 @@ export function hashConsentNonce(nonce: string): string {
 	return createHash('sha256').update(nonce).digest('base64url');
 }
 
-function cookieName(flowId: string): string {
-	return CONSENT_COOKIE_PREFIX + flowId;
+function buildBindingCookie(prefix: string, flowId: string, nonce: string): string {
+	return `${prefix}${flowId}=${nonce}; Max-Age=${CONSENT_COOKIE_MAX_AGE_S}; Path=/; Secure; HttpOnly; SameSite=Lax`;
 }
 
 /**
@@ -65,7 +75,12 @@ function cookieName(flowId: string): string {
  * `__Host-` requires exactly `Secure` + `Path=/` + no `Domain`.
  */
 export function buildConsentCookie(flowId: string, nonce: string): string {
-	return `${cookieName(flowId)}=${nonce}; Max-Age=${CONSENT_COOKIE_MAX_AGE_S}; Path=/; Secure; HttpOnly; SameSite=Lax`;
+	return buildBindingCookie(CONSENT_COOKIE_PREFIX, flowId, nonce);
+}
+
+/** Set-Cookie value pairing a human login initiation with its state token. */
+export function buildLoginCookie(flowId: string, nonce: string): string {
+	return buildBindingCookie(LOGIN_COOKIE_PREFIX, flowId, nonce);
 }
 
 /**
@@ -78,10 +93,23 @@ export function buildConsentCookie(flowId: string, nonce: string): string {
  * jar). Revisit the parser if the encoding ever changes.
  */
 export function readConsentNonce(request: Request | undefined, flowId: string | undefined): string | undefined {
+	return readBindingNonce(CONSENT_COOKIE_PREFIX, request, flowId);
+}
+
+/** Read this login flow's binding nonce from the request's Cookie header. */
+export function readLoginNonce(request: Request | undefined, flowId: string | undefined): string | undefined {
+	return readBindingNonce(LOGIN_COOKIE_PREFIX, request, flowId);
+}
+
+function readBindingNonce(
+	prefix: string,
+	request: Request | undefined,
+	flowId: string | undefined
+): string | undefined {
 	if (!flowId) return undefined;
 	const header = request?.headers?.cookie;
 	if (typeof header !== 'string' || !header) return undefined;
-	const name = cookieName(flowId);
+	const name = prefix + flowId;
 	for (const part of header.split(';')) {
 		const eq = part.indexOf('=');
 		if (eq === -1) continue;

--- a/src/lib/mcp/consentBinding.ts
+++ b/src/lib/mcp/consentBinding.ts
@@ -42,6 +42,7 @@
  */
 
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { getRequestHeader } from '../requestHeaders.ts';
 import type { Request } from '../../types.ts';
 
 /** `__Host-` prefix + a per-flow id suffix. See module header for why. */
@@ -121,26 +122,13 @@ function readBindingNonce(
 }
 
 /**
- * Read the raw `Cookie` header across the shapes a Harper request can carry: a
- * Web `Headers` object (`.get()`), Harper's runtime headers wrapper (`.asObject`
- * — what the live server passes to component resources), or a plain Node
- * `IncomingMessage.headers` object (used in unit tests). Reading
- * `request.headers.cookie` directly returns undefined against the live wrapper,
- * which would fail the binding check closed for every browser flow — mirrors the
- * `getHeader` helper in withMCPAuth.ts.
+ * Read the raw `Cookie` header. Goes through `getRequestHeader` because reading
+ * `request.headers.cookie` directly returns undefined against Harper's live
+ * runtime headers wrapper, which would fail the binding check closed for every
+ * browser flow.
  */
 function readCookieHeader(request: Request | undefined): string | undefined {
-	const headers = request?.headers as any;
-	if (!headers) return undefined;
-	let raw: unknown;
-	if (typeof headers.get === 'function') {
-		raw = headers.get('cookie');
-	} else {
-		const obj = headers.asObject ?? headers;
-		raw = obj?.cookie ?? obj?.Cookie;
-	}
-	if (raw == null) return undefined;
-	return Array.isArray(raw) ? raw[0] : String(raw);
+	return getRequestHeader(request?.headers, 'cookie');
 }
 
 /** Constant-time check that `nonce` hashes to `expectedHash`. */

--- a/src/lib/mcp/dcr.ts
+++ b/src/lib/mcp/dcr.ts
@@ -22,6 +22,7 @@ import {
 	validateRedirectUri,
 	validateStringArray,
 } from './clientValidator.ts';
+import { getRequestHeader } from '../requestHeaders.ts';
 
 type ErrorResponse = {
 	status: number;
@@ -243,11 +244,11 @@ export async function handleRegister(
 	// — so these JSON.stringify calls run only when the message is actually
 	// emitted. Don't hoist a shared `JSON.stringify(...)` out to a const: that
 	// reintroduces eager work on every request even when the log is suppressed.
+	const authHeader = getRequestHeader(request?.headers, 'authorization');
 	harperLogger?.info?.(
-		`MCP DCR request received: redirect_uris=${JSON.stringify(body?.redirect_uris)} grant_types=${JSON.stringify(body?.grant_types)} response_types=${JSON.stringify(body?.response_types)} token_endpoint_auth_method=${JSON.stringify(body?.token_endpoint_auth_method)} auth_header=${!!request?.headers?.authorization}`
+		`MCP DCR request received: redirect_uris=${JSON.stringify(body?.redirect_uris)} grant_types=${JSON.stringify(body?.grant_types)} response_types=${JSON.stringify(body?.response_types)} token_endpoint_auth_method=${JSON.stringify(body?.token_endpoint_auth_method)} auth_header=${!!authHeader}`
 	);
 
-	const authHeader = request?.headers?.authorization;
 	const authError = checkInitialAccessToken(authHeader, dcrConfig?.initialAccessToken);
 	if (authError) {
 		harperLogger?.warn?.('MCP DCR rejected: initial access token required or invalid');

--- a/src/lib/mcp/token.ts
+++ b/src/lib/mcp/token.ts
@@ -20,6 +20,7 @@ import { CimdClientError, MAX_CLIENT_ID_LENGTH, resolveClient } from './cimd.ts'
 import { CLIENT_ASSERTION_TYPE_JWT_BEARER, verifyClientAssertion } from './clientAssertion.ts';
 import { MCPKeyStore } from './keyStore.ts';
 import { createRateLimiter, type RateLimiter } from './rateLimit.ts';
+import { getRequestHeader } from '../requestHeaders.ts';
 import {
 	hashRefreshToken,
 	makeRefreshToken,
@@ -184,7 +185,7 @@ async function authenticateClient(
 	mcpConfig: MCPConfig | undefined,
 	logger?: Logger
 ): Promise<ClientAuthResult> {
-	const basic = parseBasicAuth(request?.headers?.authorization);
+	const basic = parseBasicAuth(getRequestHeader(request?.headers, 'authorization'));
 	const bodyClientId = typeof body?.client_id === 'string' ? body.client_id : undefined;
 	const bodyClientSecret = typeof body?.client_secret === 'string' ? body.client_secret : undefined;
 
@@ -217,8 +218,12 @@ async function authenticateClient(
 	const method = client.token_endpoint_auth_method ?? 'none';
 
 	if (method === 'none') {
-		// Public client: PKCE is the proof. A presented secret signals misuse.
-		if (basic || bodyClientSecret) {
+		// Public client: PKCE is the proof. A presented *non-empty* secret signals
+		// misuse and is rejected. An empty Basic secret — `Authorization: Basic
+		// base64("<client_id>:")` — carries only the client_id and is how some
+		// clients convey it; tolerate it as "no secret presented" so those public
+		// clients aren't rejected. (Empty values are falsy here.)
+		if (basic?.clientSecret || bodyClientSecret) {
 			return { error: errorResponse(401, 'invalid_client', 'Public client must not present a secret') };
 		}
 		return { client };
@@ -548,7 +553,10 @@ async function handleClientCredentialsGrant(
 	// grant — a Basic header or client_secret must not ride along (#159 req 6:
 	// no credential type may substitute for the private key). Scheme match is
 	// case-insensitive per RFC 9110 §11.1.
-	if (/^basic\s/i.test(request?.headers?.authorization ?? '') || typeof body?.client_secret === 'string') {
+	if (
+		/^basic\s/i.test(getRequestHeader(request?.headers, 'authorization') ?? '') ||
+		typeof body?.client_secret === 'string'
+	) {
 		return errorResponse(
 			400,
 			'invalid_request',

--- a/src/lib/mcp/wellKnown.ts
+++ b/src/lib/mcp/wellKnown.ts
@@ -23,6 +23,7 @@
  */
 
 import type { Logger, MCPConfig } from '../../types.ts';
+import { getRequestHeader } from '../requestHeaders.ts';
 import { dcrEnabled } from './dcr.ts';
 import { MCPKeyStore, resolveEffectiveAlg } from './keyStore.ts';
 import { publicKeyToJwk } from './tokenIssuer.ts';
@@ -82,8 +83,9 @@ export function resolveIssuer(request: HarperRequest, mcpConfig: MCPConfig): str
 		// endpoint URLs don't end up with a doubled slash.
 		return mcpConfig.issuer.replace(/\/+$/, '');
 	}
-	const rawHost = request.host ?? request.headers?.host;
-	const host = (Array.isArray(rawHost) ? rawHost[0] : rawHost) ?? 'localhost';
+	// getRequestHeader for the fallback: the live runtime wraps headers behind
+	// `.asObject`, so `request.headers.host` is undefined there.
+	const host = request.host ?? getRequestHeader(request.headers, 'host') ?? 'localhost';
 	const scheme = request.protocol ?? 'https';
 	return `${scheme}://${host}`;
 }

--- a/src/lib/mcp/withMCPAuth.ts
+++ b/src/lib/mcp/withMCPAuth.ts
@@ -46,6 +46,7 @@ import { MCPKeyStore } from './keyStore.ts';
 import { verifyAccessTokenWithKeySet } from './tokenIssuer.ts';
 import { protectedResourceMetadataUrl, resolveIssuer, resolveResource } from './wellKnown.ts';
 import { emitMCPAuditEvent, type MCPTokenRejectedAuditPayload } from './audit.ts';
+import { getRequestHeader } from '../requestHeaders.ts';
 
 /** Minimal surface withMCPAuth needs from a key source (lets tests inject one). */
 interface KeySource {
@@ -93,32 +94,13 @@ export interface WithMCPAuthOptions {
 type HttpListener = (request: Request, next: (req: Request) => any) => any;
 
 /**
- * Read a header value across the shapes a Harper request can carry: a Web
- * `Headers` object (`.get()`), Harper's headers wrapper (`.asObject`), or a
- * plain Node `IncomingMessage.headers` object (used in tests). Returns the
- * first value when a header is multi-valued.
- */
-function getHeader(headers: any, name: string): string | undefined {
-	if (!headers) return undefined;
-	let raw: unknown;
-	if (typeof headers.get === 'function') {
-		raw = headers.get(name);
-	} else {
-		const obj = headers.asObject ?? headers;
-		raw = obj?.[name.toLowerCase()] ?? obj?.[name];
-	}
-	if (raw == null) return undefined;
-	return Array.isArray(raw) ? raw[0] : String(raw);
-}
-
-/**
  * Extract a bearer token from the `Authorization` header. Header-only by design
  * (RFC 6750 §2.1): query-string and body tokens are never read, so they are
  * treated as "no token presented". Returns undefined for a missing or malformed
  * header (anything that isn't `Bearer <non-empty-token>`).
  */
 function extractBearerToken(headers: any): string | undefined {
-	const authz = getHeader(headers, 'authorization');
+	const authz = getRequestHeader(headers, 'authorization');
 	if (!authz) return undefined;
 	// Scheme is case-insensitive (RFC 7235); the token must be non-empty.
 	const match = /^Bearer[ \t]+(\S.*)$/i.exec(authz.trim());

--- a/src/lib/requestHeaders.ts
+++ b/src/lib/requestHeaders.ts
@@ -1,0 +1,30 @@
+/**
+ * Read a request header across the shapes a Harper request can carry.
+ *
+ * The live Harper runtime passes component resources a headers wrapper that
+ * exposes only `.asObject` (not enumerable header properties), so reading
+ * `request.headers.<name>` directly returns undefined in production even though
+ * it works against the plain `IncomingMessage.headers` object used in unit
+ * tests. Every header read on a Harper request must go through here.
+ *
+ * Handles three shapes:
+ *   - a Web `Headers` object (`.get()`),
+ *   - Harper's runtime headers wrapper (`.asObject`),
+ *   - a plain Node `IncomingMessage.headers` object (tests).
+ *
+ * Header names are matched case-insensitively; the first value is returned when
+ * a header is multi-valued.
+ */
+export function getRequestHeader(headers: unknown, name: string): string | undefined {
+	if (!headers) return undefined;
+	const h = headers as any;
+	let raw: unknown;
+	if (typeof h.get === 'function') {
+		raw = h.get(name);
+	} else {
+		const obj = h.asObject ?? h;
+		raw = obj?.[name.toLowerCase()] ?? obj?.[name];
+	}
+	if (raw == null) return undefined;
+	return Array.isArray(raw) ? raw[0] : String(raw);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -295,14 +295,17 @@ export interface MCPAuthorizeState {
 	/** Original `state` parameter from the MCP client; echoed verbatim on redirect */
 	clientState?: string;
 	/**
-	 * CIMD consent browser binding: SHA-256 of the per-flow nonce cookie set with
-	 * the consent interstitial. Present only on CIMD flows; /oauth/mcp/confirm and
-	 * the upstream OAuth callback both require the caller's cookie to hash-match
-	 * before proceeding (see lib/mcp/consentBinding.ts).
+	 * MCP consent browser binding: SHA-256 of the per-flow nonce cookie set when
+	 * the authorize flow is initiated. Set on EVERY /oauth/mcp/authorize flow —
+	 * the CIMD interstitial mints it up front, and the stored/DCR path mints it in
+	 * performUpstreamRedirect. /oauth/mcp/confirm (CIMD) and the upstream OAuth
+	 * callback (all flows) require the caller's cookie to hash-match before
+	 * proceeding; the callback fails closed on an MCP state that lacks it (see
+	 * lib/mcp/consentBinding.ts and handlers.ts).
 	 */
 	browserNonceHash?: string;
 	/**
-	 * CIMD consent flow id: identifies which per-flow `__Host-` cookie carries
+	 * MCP consent flow id: identifies which per-flow `__Host-` cookie carries
 	 * this flow's nonce, so concurrent authorization flows in one browser don't
 	 * collide. Paired with `browserNonceHash`.
 	 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -674,6 +674,10 @@ export interface CSRFTokenData {
 	originalUrl?: string;
 	/** Session ID to link OAuth flow with existing session */
 	sessionId?: string;
+	/** Per-flow id naming the login browser-binding cookie (GHSA-xf67-jxfx-jf88) */
+	loginFlowId?: string;
+	/** SHA-256 (base64url) of the login browser-binding nonce; the callback requires the cookie to hash-match */
+	browserNonceHash?: string;
 	[key: string]: any;
 }
 

--- a/test/lib/handlers.test.js
+++ b/test/lib/handlers.test.js
@@ -811,6 +811,16 @@ describe('OAuth Handlers', () => {
 		let storedAuthCodes;
 		// Import lazily so the dist symbol load doesn't happen at file parse.
 		let resetMCPAuthCodesTableCache;
+		let hashConsentNonce, buildConsentCookie;
+
+		// Every /oauth/mcp/authorize flow (CIMD and stored/DCR) now mints a
+		// per-flow nonce cookie and binds its hash into the upstream state; the
+		// callback fails closed without a matching cookie. The default fixtures
+		// below therefore carry a valid binding so the happy-path assertions
+		// exercise the bound flow — tests that need an unbound/mismatched state
+		// override them locally.
+		const MCP_NONCE = 'mcp-branch-consent-nonce';
+		const MCP_FLOW_ID = 'mcpbranchflow';
 
 		const MCP_STATE = {
 			clientId: 'mcp-client-1',
@@ -829,6 +839,7 @@ describe('OAuth Handlers', () => {
 
 		beforeEach(async () => {
 			({ resetMCPAuthCodesTableCache } = await import('../../dist/lib/mcp/authCodeStore.js'));
+			({ hashConsentNonce, buildConsentCookie } = await import('../../dist/lib/mcp/consentBinding.js'));
 			resetMCPAuthCodesTableCache();
 			originalDatabases = global.databases;
 			storedAuthCodes = new Map();
@@ -843,12 +854,14 @@ describe('OAuth Handlers', () => {
 					},
 				},
 			};
-			// Replace verifyCSRFToken to return MCP state by default for this block.
+			// Replace verifyCSRFToken to return a browser-bound MCP state by default.
 			mockProvider.verifyCSRFToken = createMockFn(async () => ({
 				timestamp: Date.now(),
 				providerName: 'test-provider',
-				mcp: { ...MCP_STATE },
+				mcp: { ...MCP_STATE, browserNonceHash: hashConsentNonce(MCP_NONCE), consentFlowId: MCP_FLOW_ID },
 			}));
+			// The initiating browser's per-flow consent cookie accompanies the callback.
+			mockRequest.headers.cookie = buildConsentCookie(MCP_FLOW_ID, MCP_NONCE).split(';')[0];
 		});
 
 		// Restore global.databases in afterEach so a failing assertion mid-test
@@ -1163,11 +1176,17 @@ describe('OAuth Handlers', () => {
 				assert.equal(storedAuthCodes.size, 0);
 			});
 
-			it('DCR flows (no browserNonceHash) are unaffected', async () => {
+			it('fails closed on an MCP state with no browser binding (forged/pre-upgrade state)', async () => {
+				// After the DCR browser-binding fix (GHSA-login-csrf), EVERY MCP
+				// authorize flow mints a per-flow nonce cookie and binds its hash into
+				// the upstream state. An MCP state that reaches the callback with no
+				// binding is a forged or pre-upgrade in-flight state and must NOT mint
+				// an auth code — this is the authorization-code injection the fix
+				// closes (an attacker-supplied, unbound state fed to a victim).
 				mockProvider.verifyCSRFToken = createMockFn(async () => ({
 					timestamp: Date.now(),
 					providerName: 'test-provider',
-					mcp: { ...MCP_STATE },
+					mcp: { ...MCP_STATE }, // no browserNonceHash / consentFlowId
 				}));
 				delete mockRequest.headers.cookie;
 				const result = await handleCallback(
@@ -1180,7 +1199,11 @@ describe('OAuth Handlers', () => {
 					{ mcpConfig: MCP_CONFIG, logger: mockLogger }
 				);
 				const url = new URL(result.headers.Location);
-				assert.ok(url.searchParams.get('code'), 'DCR callback mints a code without a consent cookie');
+				assert.equal(url.origin + url.pathname, MCP_STATE.redirectUri, 'error routed to the client redirect_uri');
+				assert.equal(url.searchParams.get('error'), 'access_denied');
+				assert.equal(url.searchParams.get('code'), null, 'no auth code minted for an unbound MCP state');
+				assert.equal(storedAuthCodes.size, 0, 'no auth code persisted');
+				assert.equal(mockProvider.exchangeCodeForToken.mock.calls.length, 0, 'upstream code never exchanged');
 			});
 		});
 	});

--- a/test/lib/handlers.test.js
+++ b/test/lib/handlers.test.js
@@ -151,6 +151,28 @@ describe('OAuth Handlers', () => {
 			const csrfCall = mockProvider.generateCSRFToken.mock.calls[0];
 			assert.equal(csrfCall.arguments[0].sessionId, 'session-123');
 		});
+
+		it('mints a browser-binding nonce: hash in the state token, nonce in a __Host- cookie (GHSA-xf67-jxfx-jf88)', async () => {
+			const { hashConsentNonce } = await import('../../dist/lib/mcp/consentBinding.js');
+			const result = await handleLogin(mockRequest, mockTarget, mockProvider, mockConfig, 'test-provider', mockLogger);
+
+			const meta = mockProvider.generateCSRFToken.mock.calls[0].arguments[0];
+			assert.ok(meta.loginFlowId, 'flow id stored in the state token');
+			assert.ok(meta.browserNonceHash, 'nonce hash stored in the state token');
+
+			const setCookie = result.headers['Set-Cookie'];
+			const [pair, ...attrs] = setCookie.split('; ');
+			const eq = pair.indexOf('=');
+			assert.equal(pair.slice(0, eq), `__Host-oauth_login_${meta.loginFlowId}`, 'cookie name embeds the flow id');
+			assert.equal(
+				hashConsentNonce(pair.slice(eq + 1)),
+				meta.browserNonceHash,
+				'cookie value hashes to the bound hash'
+			);
+			for (const attr of ['Path=/', 'Secure', 'HttpOnly', 'SameSite=Lax']) {
+				assert.ok(attrs.includes(attr), `cookie carries ${attr}`);
+			}
+		});
 	});
 
 	describe('handleCallback', () => {
@@ -1379,6 +1401,148 @@ describe('OAuth Handlers', () => {
 			assert.ok(result.headers.Location.startsWith('https://mcp-client.example.com/cb'));
 			assert.ok(result.headers.Location.includes('error=access_denied'));
 			assert.equal(mockProvider.exchangeCodeForToken.mock.calls.length, 0);
+		});
+	});
+
+	describe('handleCallback — login browser binding (GHSA-xf67-jxfx-jf88)', () => {
+		const NONCE = 'login-binding-nonce';
+		const FLOW_ID = 'loginflow';
+		let hashConsentNonce, buildLoginCookie;
+
+		beforeEach(async () => {
+			({ hashConsentNonce, buildLoginCookie } = await import('../../dist/lib/mcp/consentBinding.js'));
+			// A logged-out flow: no sessionId in the token (the session binding
+			// has nothing to check — the exact gap the nonce cookie closes).
+			mockProvider.verifyCSRFToken = createMockFn(async () => ({
+				originalUrl: '/dashboard',
+				timestamp: Date.now(),
+				providerName: 'test-provider',
+				loginFlowId: FLOW_ID,
+				browserNonceHash: hashConsentNonce(NONCE),
+			}));
+		});
+
+		it('completes when the callback arrives in the browser that initiated the login', async () => {
+			mockRequest.headers.cookie = buildLoginCookie(FLOW_ID, NONCE).split(';')[0];
+
+			const result = await handleCallback(
+				mockRequest,
+				mockTarget,
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.status, 302);
+			assert.equal(result.headers.Location, '/dashboard');
+			assert.equal(mockProvider.exchangeCodeForToken.mock.calls.length, 1);
+		});
+
+		it('rejects when the binding cookie is missing — attacker-minted state in a victim browser', async () => {
+			// Attack: the attacker initiates a login (cookie set in THEIR browser),
+			// completes IdP auth as themselves, then feeds the callback URL to the
+			// victim. The victim's browser has no matching cookie — no login.
+			delete mockRequest.headers.cookie;
+
+			const result = await handleCallback(
+				mockRequest,
+				mockTarget,
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.status, 302);
+			assert.equal(result.headers.Location, '/dashboard?error=auth_failed&reason=csrf');
+			// Rejected before any upstream call or session write.
+			assert.equal(mockProvider.exchangeCodeForToken.mock.calls.length, 0);
+			assert.equal(mockRequest.session.update.mock.calls.length, 0);
+		});
+
+		it('rejects when the binding cookie does not hash-match', async () => {
+			mockRequest.headers.cookie = buildLoginCookie(FLOW_ID, 'some-other-browser-nonce').split(';')[0];
+
+			const result = await handleCallback(
+				mockRequest,
+				mockTarget,
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.headers.Location, '/dashboard?error=auth_failed&reason=csrf');
+			assert.equal(mockProvider.exchangeCodeForToken.mock.calls.length, 0);
+		});
+
+		it('tolerates state tokens without a nonce hash (pre-upgrade in-flight logins)', async () => {
+			mockProvider.verifyCSRFToken = createMockFn(async () => ({
+				originalUrl: '/dashboard',
+				timestamp: Date.now(),
+				providerName: 'test-provider',
+			}));
+			delete mockRequest.headers.cookie;
+
+			const result = await handleCallback(
+				mockRequest,
+				mockTarget,
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.status, 302);
+			assert.equal(result.headers.Location, '/dashboard');
+		});
+	});
+
+	describe('handleCallback — CRLF-safe error logging (CWE-117)', () => {
+		const CRLF_ERROR = 'access_denied\r\nFORGED line';
+		const CRLF_DESC = 'desc\r\ninjected';
+
+		function targetWith(params) {
+			return { get: createMockFn((key) => params[key]) };
+		}
+
+		it('encodes CR/LF in upstream error params on the no-state path', async () => {
+			const result = await handleCallback(
+				mockRequest,
+				targetWith({ error: CRLF_ERROR, error_description: CRLF_DESC }),
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.status, 302);
+			const logged = mockLogger.error.mock.calls[0].arguments[0];
+			assert.ok(!logged.includes('\r') && !logged.includes('\n'), 'no raw CR/LF reaches the log line');
+			assert.ok(logged.includes('\\r\\n'), 'injected control chars are visibly encoded');
+		});
+
+		it('encodes CR/LF in upstream error params on the verified-state path', async () => {
+			const result = await handleCallback(
+				mockRequest,
+				targetWith({ state: 'csrf-token-123', error: CRLF_ERROR, error_description: CRLF_DESC }),
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.status, 302);
+			const logged = mockLogger.error.mock.calls[0].arguments[0];
+			assert.ok(!logged.includes('\r') && !logged.includes('\n'), 'no raw CR/LF reaches the log line');
+			assert.ok(logged.includes('\\r\\n'), 'injected control chars are visibly encoded');
 		});
 	});
 });

--- a/test/lib/handlers.test.js
+++ b/test/lib/handlers.test.js
@@ -137,6 +137,19 @@ describe('OAuth Handlers', () => {
 			assert.equal(csrfCall.arguments[0].originalUrl, '/steal');
 		});
 
+		it('reads referer from a Harper `.asObject` headers wrapper (runtime shape)', async () => {
+			// The live runtime wraps headers behind `.asObject`; direct
+			// `request.headers.referer` is undefined there. Regression guard.
+			const wrapped = {
+				session: mockRequest.session,
+				headers: { asObject: { referer: 'https://app.example.com/deep' } },
+			};
+			await handleLogin(wrapped, mockTarget, mockProvider, mockConfig, 'test-provider', mockLogger);
+
+			const csrfCall = mockProvider.generateCSRFToken.mock.calls[0];
+			assert.equal(csrfCall.arguments[0].originalUrl, '/deep');
+		});
+
 		it('should fall back to postLoginRedirect when no redirect param or referer', async () => {
 			delete mockRequest.headers.referer;
 			await handleLogin(mockRequest, mockTarget, mockProvider, mockConfig, 'test-provider', mockLogger);

--- a/test/lib/mcp/authorize.test.js
+++ b/test/lib/mcp/authorize.test.js
@@ -445,6 +445,32 @@ describe('handleAuthorize', () => {
 			assert.equal(harnesses.github.generatedTokens[0].sessionId, undefined);
 		});
 
+		it('mints a per-flow consent cookie and binds its hash into the DCR upstream state (GHSA-login-csrf)', async () => {
+			// Stored/DCR clients skip the CIMD interstitial, so the browser binding
+			// must be minted here on the direct redirect. Without it an anonymous
+			// initiator (no sessionId) leaves the callback with nothing to prove the
+			// flow completes in the initiating browser — the authorization-code
+			// injection this closes.
+			const { entries, harnesses } = newRegistry();
+			const target = makeTarget(BASE_QUERY);
+			const response = await handleAuthorize(makeRequest(), target, validConfig, entries);
+
+			assert.equal(response.status, 302);
+			const setCookie = response.headers['Set-Cookie'];
+			assert.ok(setCookie, 'stored/DCR authorize sets the per-flow browser-binding cookie');
+			assert.match(setCookie, /^__Host-mcp_consent_[A-Za-z0-9_-]+=/, 'per-flow __Host- cookie');
+			assert.match(setCookie, /HttpOnly/);
+			assert.match(setCookie, /Secure/);
+			assert.match(setCookie, /SameSite=Lax/);
+			assert.doesNotMatch(setCookie, /Domain=/i, '__Host- forbids Domain (blocks sibling injection)');
+
+			const [cookieName, nonce] = setCookie.split(';')[0].split('=');
+			const flowId = cookieName.replace('__Host-mcp_consent_', '');
+			const minted = harnesses.github.generatedTokens[0];
+			assert.equal(minted.mcp.consentFlowId, flowId, 'upstream state carries the cookie flow id');
+			assert.equal(minted.mcp.browserNonceHash, hashConsentNonce(nonce), 'upstream state carries sha256(cookie nonce)');
+		});
+
 		it('accepts a redirect_uri that matches the registered loopback URI', async () => {
 			const { entries } = newRegistry();
 			const target = makeTarget({ ...BASE_QUERY, redirect_uri: 'http://localhost:6274/cb' });

--- a/test/lib/mcp/consentBinding.test.js
+++ b/test/lib/mcp/consentBinding.test.js
@@ -60,6 +60,20 @@ describe('consentBinding', () => {
 		assert.equal(readConsentNonce({ headers: { cookie: 'no-equals-sign' } }, 'f'), undefined);
 	});
 
+	// Regression: the live Harper runtime passes headers as a wrapper exposing
+	// only `.asObject` (or a Web `Headers` with `.get()`), NOT a plain object.
+	// Reading `request.headers.cookie` directly returns undefined there, which
+	// fails every browser-binding check closed. Cover both wrapper shapes.
+	it('readConsentNonce reads the cookie from a Harper `.asObject` headers wrapper', () => {
+		const request = { headers: { asObject: { cookie: `x=1; __Host-mcp_consent_flowA=wrapped-nonce` } } };
+		assert.equal(readConsentNonce(request, 'flowA'), 'wrapped-nonce');
+	});
+
+	it('readConsentNonce reads the cookie from a Web `Headers` object (.get)', () => {
+		const request = { headers: new Headers({ cookie: `__Host-mcp_consent_flowA=header-nonce` }) };
+		assert.equal(readConsentNonce(request, 'flowA'), 'header-nonce');
+	});
+
 	it('consentNonceMatches round-trips and rejects mismatches', () => {
 		const nonce = generateConsentNonce();
 		const hash = hashConsentNonce(nonce);

--- a/test/lib/mcp/dcr.test.js
+++ b/test/lib/mcp/dcr.test.js
@@ -116,6 +116,18 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 			assert.equal(response.status, 201);
 		});
 
+		it('accepts a matching Bearer token via the Harper `.asObject` headers wrapper (runtime shape)', async () => {
+			// Regression: the live runtime wraps headers behind `.asObject`, so
+			// reading request.headers.authorization directly returns undefined and
+			// the token gate would reject every registration in production.
+			const response = await handleRegister(
+				makeRequest({ asObject: { authorization: 'Bearer secret-token' } }),
+				VALID_BODY,
+				config
+			);
+			assert.equal(response.status, 201);
+		});
+
 		it('rejects the capitalized Authorization header (Node HTTP parser lowercases)', async () => {
 			// Production: incoming headers are lowercased before reaching us.
 			// If a caller hands us a literal { Authorization: ... } object, we

--- a/test/lib/mcp/token.test.js
+++ b/test/lib/mcp/token.test.js
@@ -531,6 +531,45 @@ describe('handleToken', () => {
 		assert.equal(res.body.error, 'invalid_request');
 	});
 
+	it('authenticates client_secret_basic when headers use the Harper `.asObject` wrapper (runtime shape)', async () => {
+		// Regression: the live runtime wraps headers behind `.asObject`, so
+		// reading request.headers.authorization directly returns undefined and
+		// confidential-basic auth would fail closed in production.
+		seedCode('code-1', { client_id: 'conf-1' });
+		const res = await handleToken(
+			{ headers: { asObject: basicHeader('conf-1', CONF_SECRET) } },
+			{ grant_type: 'authorization_code', code: 'code-1', code_verifier: CODE_VERIFIER, redirect_uri: REDIRECT },
+			mcpConfig
+		);
+		assert.equal(res.status, 200);
+		assert.ok(res.body.access_token);
+	});
+
+	it('tolerates a public client presenting an empty Basic secret (client_id only)', async () => {
+		// `Authorization: Basic base64("<client_id>:")` carries only the client_id;
+		// some clients always send it. An empty secret is not "presenting a secret",
+		// so a public client must not be rejected for it.
+		seedCode('code-1'); // public-1
+		const res = await handleToken(
+			{ headers: basicHeader('public-1', '') },
+			{ grant_type: 'authorization_code', code: 'code-1', code_verifier: CODE_VERIFIER, redirect_uri: REDIRECT },
+			mcpConfig
+		);
+		assert.equal(res.status, 200, 'empty Basic secret tolerated as no-secret for a public client');
+		assert.ok(res.body.access_token);
+	});
+
+	it('still rejects a public client that presents a real (non-empty) Basic secret', async () => {
+		seedCode('code-1'); // public-1
+		const res = await handleToken(
+			{ headers: basicHeader('public-1', 'unexpected-secret') },
+			{ grant_type: 'authorization_code', code: 'code-1', code_verifier: CODE_VERIFIER, redirect_uri: REDIRECT },
+			mcpConfig
+		);
+		assert.equal(res.status, 401);
+		assert.equal(res.body.error, 'invalid_client');
+	});
+
 	it('authenticates a confidential client via client_secret_post (secret in body)', async () => {
 		clients.set('post-1', {
 			client_id: 'post-1',

--- a/test/lib/requestHeaders.test.js
+++ b/test/lib/requestHeaders.test.js
@@ -1,0 +1,36 @@
+/**
+ * Tests for the wrapper-aware request header reader.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { getRequestHeader } from '../../dist/lib/requestHeaders.js';
+
+describe('getRequestHeader', () => {
+	it('reads from a plain IncomingMessage.headers object (tests)', () => {
+		assert.equal(getRequestHeader({ cookie: 'a=1' }, 'cookie'), 'a=1');
+		assert.equal(getRequestHeader({ referer: '/x' }, 'Referer'), '/x', 'name is case-insensitive');
+	});
+
+	it("reads from Harper's runtime `.asObject` headers wrapper", () => {
+		const wrapper = { asObject: { cookie: 'a=1', authorization: 'Bearer t' } };
+		assert.equal(getRequestHeader(wrapper, 'cookie'), 'a=1');
+		assert.equal(getRequestHeader(wrapper, 'authorization'), 'Bearer t');
+	});
+
+	it('reads from a Web `Headers` object via .get()', () => {
+		const headers = new Headers({ cookie: 'a=1' });
+		assert.equal(getRequestHeader(headers, 'cookie'), 'a=1');
+	});
+
+	it('returns the first value when a header is multi-valued', () => {
+		assert.equal(getRequestHeader({ 'x-forwarded-for': ['1.1.1.1', '2.2.2.2'] }, 'x-forwarded-for'), '1.1.1.1');
+	});
+
+	it('returns undefined for missing headers or missing container', () => {
+		assert.equal(getRequestHeader(undefined, 'cookie'), undefined);
+		assert.equal(getRequestHeader(null, 'cookie'), undefined);
+		assert.equal(getRequestHeader({}, 'cookie'), undefined);
+		assert.equal(getRequestHeader({ asObject: {} }, 'cookie'), undefined);
+	});
+});


### PR DESCRIPTION
Binds every browser-initiated OAuth flow — human login and all MCP authorize paths — to the browser that started it, closing a login-CSRF / authorization-code-injection class where an attacker-initiated flow could be completed in a victim's browser.

- **Human login**: `handleLogin` sets a per-flow `__Host-` nonce cookie and stores only its hash in the state token; the callback requires a constant-time match before any upstream exchange or session write. Conditional on hash-presence so in-flight logins survive the deploy.
- **MCP authorize**: the browser binding previously covered only CIMD clients; `performUpstreamRedirect` now mints the same per-flow cookie for stored/DCR clients too, and the callback fails closed on any MCP state without a matching cookie.
- **Runtime header reads**: the binding readers (and the referer/host/authorization reads elsewhere) used `request.headers.<name>` directly, which is undefined against Harper's runtime headers wrapper — so the binding would have failed closed in production. Consolidated into a shared `getRequestHeader` (Web `Headers` / `.asObject` / plain object) and applied across the cookie, referer, bearer, host, and MCP token/DCR auth reads. The public-client token check now rejects only a non-empty presented secret (tolerates an empty Basic secret) to avoid a client-compat regression.
- **Logging**: `error`/`error_description` callback params are JSON-encoded before logging (CRLF-safe).

Tests: unit 1127, integration 15, `tsc` clean. New coverage for both bindings, the wrapper-aware header reads across all three shapes, and the token/DCR auth paths.