### PR TITLE
fix(mcp): accept unknown grant types in CIMD; DCR filters to supported intersection

### DIFF
--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -10,8 +10,8 @@ Protocol](https://modelcontextprotocol.io) clients (Claude Desktop, Cursor,
 same upstream providers you already configure for human login, then mints
 audience-bound JWT access tokens your MCP routes can verify with a single wrapper.
 
-It implements the [MCP authorization specification (2025-06-18)](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)
-and the OAuth RFCs it builds on:
+It implements the [MCP authorization specification (2026-07-28)](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
+and the OAuth RFCs it builds on. Note: the 2026-07-28 revision deprecates Dynamic Client Registration; our DCR support (`/register`) is retained for backwards compatibility with existing clients.
 
 | RFC                                                   | Role here                                                      |
 | ----------------------------------------------------- | -------------------------------------------------------------- |

--- a/src/lib/mcp/authorize.ts
+++ b/src/lib/mcp/authorize.ts
@@ -427,14 +427,16 @@ export async function handleAuthorize(
 	const redirect = (error: string, description: string) =>
 		buildClientErrorRedirect(query.redirect_uri as string, error, description, clientState, issuer);
 
-	// RFC 6749 §4.1.2.1: reject before initiating authorization if the client
-	// is not authorized for this grant type.
-	if (!allowsGrant(client, 'authorization_code')) {
-		return redirect('unauthorized_client', 'Client is not authorized for the authorization_code grant');
-	}
-
+	// response_type identifies the requested flow; an unsupported one is
+	// unsupported_response_type regardless of the client's grants (RFC 6749
+	// §3.1.1). Only then can §4.1.2.1's unauthorized_client apply to the
+	// authorization_code flow actually being requested.
 	if (query.response_type !== 'code') {
 		return redirect('unsupported_response_type', 'response_type must be "code"');
+	}
+
+	if (!allowsGrant(client, 'authorization_code')) {
+		return redirect('unauthorized_client', 'Client is not authorized for the authorization_code grant');
 	}
 
 	if (!query.code_challenge) {

--- a/src/lib/mcp/authorize.ts
+++ b/src/lib/mcp/authorize.ts
@@ -36,7 +36,7 @@ import type {
 	Request,
 } from '../../types.ts';
 import { CimdClientError, resolveClient } from './cimd.ts';
-import { LOCAL_HOSTS } from './clientValidator.ts';
+import { allowsGrant, LOCAL_HOSTS } from './clientValidator.ts';
 import {
 	buildConsentCookie,
 	consentNonceMatches,
@@ -426,6 +426,12 @@ export async function handleAuthorize(
 	// Phase 2: everything else redirects to the verified client redirect_uri.
 	const redirect = (error: string, description: string) =>
 		buildClientErrorRedirect(query.redirect_uri as string, error, description, clientState, issuer);
+
+	// RFC 6749 §4.1.2.1: reject before initiating authorization if the client
+	// is not authorized for this grant type.
+	if (!allowsGrant(client, 'authorization_code')) {
+		return redirect('unauthorized_client', 'Client is not authorized for the authorization_code grant');
+	}
 
 	if (query.response_type !== 'code') {
 		return redirect('unsupported_response_type', 'response_type must be "code"');

--- a/src/lib/mcp/cimd.ts
+++ b/src/lib/mcp/cimd.ts
@@ -637,9 +637,6 @@ function validateCimdDocument(
 		if (err) throw new CimdClientError('invalid_client', `CIMD document: ${err}`);
 	}
 
-	// Grant types: require authorization_code; store only the supported
-	// intersection so grants declared for other servers (e.g. jwt-bearer) are
-	// never persisted or acted on by this AS.
 	const declaredGrantTypes: string[] = Array.isArray(d.grant_types)
 		? (d.grant_types as string[])
 		: ['authorization_code', 'refresh_token'];

--- a/src/lib/mcp/cimd.ts
+++ b/src/lib/mcp/cimd.ts
@@ -80,6 +80,7 @@ import type { Logger, MCPClientIdMetadataDocumentsConfig, MCPClientRecord, MCPCo
 import { MCPClientStore } from './clientStore.ts';
 import { createRateLimiter } from './rateLimit.ts';
 import {
+	LEGACY_DEFAULT_GRANT_TYPES,
 	filterGrantTypes,
 	validateGrantTypes,
 	validateRedirectUri,
@@ -639,7 +640,7 @@ function validateCimdDocument(
 
 	const declaredGrantTypes: string[] = Array.isArray(d.grant_types)
 		? (d.grant_types as string[])
-		: ['authorization_code', 'refresh_token'];
+		: [...LEGACY_DEFAULT_GRANT_TYPES];
 	const grantErr = validateGrantTypes(declaredGrantTypes);
 	if (grantErr) throw new CimdClientError('invalid_client', `CIMD document: ${grantErr}`);
 	const grantTypes = filterGrantTypes(declaredGrantTypes);

--- a/src/lib/mcp/cimd.ts
+++ b/src/lib/mcp/cimd.ts
@@ -80,6 +80,7 @@ import type { Logger, MCPClientIdMetadataDocumentsConfig, MCPClientRecord, MCPCo
 import { MCPClientStore } from './clientStore.ts';
 import { createRateLimiter } from './rateLimit.ts';
 import {
+	filterGrantTypes,
 	validateGrantTypes,
 	validateRedirectUri,
 	validateResponseTypes,
@@ -636,12 +637,15 @@ function validateCimdDocument(
 		if (err) throw new CimdClientError('invalid_client', `CIMD document: ${err}`);
 	}
 
-	// Grant types.
-	const grantTypes: string[] = Array.isArray(d.grant_types)
+	// Grant types: require authorization_code; store only the supported
+	// intersection so grants declared for other servers (e.g. jwt-bearer) are
+	// never persisted or acted on by this AS.
+	const declaredGrantTypes: string[] = Array.isArray(d.grant_types)
 		? (d.grant_types as string[])
 		: ['authorization_code', 'refresh_token'];
-	const grantErr = validateGrantTypes(grantTypes);
+	const grantErr = validateGrantTypes(declaredGrantTypes);
 	if (grantErr) throw new CimdClientError('invalid_client', `CIMD document: ${grantErr}`);
+	const grantTypes = filterGrantTypes(declaredGrantTypes);
 
 	// Response types.
 	const responseTypes: string[] = Array.isArray(d.response_types) ? (d.response_types as string[]) : ['code'];

--- a/src/lib/mcp/clientValidator.ts
+++ b/src/lib/mcp/clientValidator.ts
@@ -7,6 +7,9 @@
  */
 
 export const SUPPORTED_GRANT_TYPES = new Set(['authorization_code', 'refresh_token']);
+
+/** Grants assumed for clients persisted before grant_types was required. */
+export const LEGACY_DEFAULT_GRANT_TYPES = ['authorization_code', 'refresh_token'];
 export const SUPPORTED_RESPONSE_TYPES = new Set(['code']);
 /** Auth methods supported for DCR clients. CIMD clients in v1 are restricted to 'none'. */
 export const SUPPORTED_AUTH_METHODS = new Set(['none', 'client_secret_basic', 'client_secret_post']);
@@ -61,7 +64,7 @@ export function validateStringArray(value: unknown, fieldName: string): string |
  * ['authorization_code', 'refresh_token'], matching the CIMD and DCR paths.
  */
 export function allowsGrant(client: { grant_types?: string[] }, grant: string): boolean {
-	return (client.grant_types ?? ['authorization_code', 'refresh_token']).includes(grant);
+	return (client.grant_types ?? LEGACY_DEFAULT_GRANT_TYPES).includes(grant);
 }
 
 /** Returns an error if authorization_code is absent from the declared grants. */

--- a/src/lib/mcp/clientValidator.ts
+++ b/src/lib/mcp/clientValidator.ts
@@ -1,9 +1,10 @@
 /**
  * Shared client metadata validators
  *
- * Used by both DCR (dcr.ts) and CIMD (cimd.ts) so both registration paths
- * enforce identical rules. Keep dcr.ts behavior identical when importing
- * from here.
+ * Used by both DCR (dcr.ts) and CIMD (cimd.ts). Grant-type semantics differ
+ * by path: CIMD requires authorization_code to be declared and ignores
+ * unknown grants; DCR filters to the supported intersection and rejects when
+ * the result is unusable (authorization_code absent).
  */
 
 export const SUPPORTED_GRANT_TYPES = new Set(['authorization_code', 'refresh_token']);
@@ -55,13 +56,21 @@ export function validateStringArray(value: unknown, fieldName: string): string |
 	return null;
 }
 
+/**
+ * CIMD validation: authorization_code must be declared (the flow requires it);
+ * unknown grants are ignored — a CIMD document describes the client's
+ * capabilities across all servers, so extra grants are not an error.
+ */
 export function validateGrantTypes(grantTypes: string[]): string | null {
-	for (const grant of grantTypes) {
-		if (!SUPPORTED_GRANT_TYPES.has(grant)) {
-			return `Unsupported grant_type: ${grant}`;
-		}
+	if (!grantTypes.includes('authorization_code')) {
+		return 'Missing required grant_type: authorization_code';
 	}
 	return null;
+}
+
+/** Returns the subset of `grantTypes` that this AS supports. */
+export function filterGrantTypes(grantTypes: string[]): string[] {
+	return grantTypes.filter((g) => SUPPORTED_GRANT_TYPES.has(g));
 }
 
 export function validateResponseTypes(responseTypes: string[]): string | null {

--- a/src/lib/mcp/clientValidator.ts
+++ b/src/lib/mcp/clientValidator.ts
@@ -55,6 +55,15 @@ export function validateStringArray(value: unknown, fieldName: string): string |
 	return null;
 }
 
+/**
+ * Whether the client's registered grant_types permit the requested grant.
+ * Absent/undefined grant_types is treated as the legacy default
+ * ['authorization_code', 'refresh_token'], matching the CIMD and DCR paths.
+ */
+export function allowsGrant(client: { grant_types?: string[] }, grant: string): boolean {
+	return !client.grant_types || client.grant_types.includes(grant);
+}
+
 /** Returns an error if authorization_code is absent from the declared grants. */
 export function validateGrantTypes(grantTypes: string[]): string | null {
 	if (!grantTypes.includes('authorization_code')) {

--- a/src/lib/mcp/clientValidator.ts
+++ b/src/lib/mcp/clientValidator.ts
@@ -1,10 +1,9 @@
 /**
  * Shared client metadata validators
  *
- * Used by both DCR (dcr.ts) and CIMD (cimd.ts). Grant-type semantics differ
- * by path: CIMD requires authorization_code to be declared and ignores
- * unknown grants; DCR filters to the supported intersection and rejects when
- * the result is unusable (authorization_code absent).
+ * Used by both DCR (dcr.ts) and CIMD (cimd.ts). Both paths require
+ * authorization_code in the supported-grant intersection; extra grants this AS
+ * doesn't implement are silently filtered rather than treated as errors.
  */
 
 export const SUPPORTED_GRANT_TYPES = new Set(['authorization_code', 'refresh_token']);
@@ -56,11 +55,7 @@ export function validateStringArray(value: unknown, fieldName: string): string |
 	return null;
 }
 
-/**
- * CIMD validation: authorization_code must be declared (the flow requires it);
- * unknown grants are ignored — a CIMD document describes the client's
- * capabilities across all servers, so extra grants are not an error.
- */
+/** Returns an error if authorization_code is absent from the declared grants. */
 export function validateGrantTypes(grantTypes: string[]): string | null {
 	if (!grantTypes.includes('authorization_code')) {
 		return 'Missing required grant_type: authorization_code';

--- a/src/lib/mcp/clientValidator.ts
+++ b/src/lib/mcp/clientValidator.ts
@@ -61,7 +61,7 @@ export function validateStringArray(value: unknown, fieldName: string): string |
  * ['authorization_code', 'refresh_token'], matching the CIMD and DCR paths.
  */
 export function allowsGrant(client: { grant_types?: string[] }, grant: string): boolean {
-	return !client.grant_types || client.grant_types.includes(grant);
+	return (client.grant_types ?? ['authorization_code', 'refresh_token']).includes(grant);
 }
 
 /** Returns an error if authorization_code is absent from the declared grants. */

--- a/src/lib/mcp/dcr.ts
+++ b/src/lib/mcp/dcr.ts
@@ -114,9 +114,8 @@ function buildClientFromRequest(
 		}
 	}
 
-	// RFC 7591 §3.2.2 permits the AS to register a subset of requested grants.
-	// Filter to the supported intersection; reject only when authorization_code
-	// is absent from the result (the flow cannot proceed without it).
+	// RFC 7591 §3.2.1 permits the AS to register a subset of requested grants.
+	// Reject only when authorization_code is absent from the supported intersection.
 	const grantTypes: string[] = filterGrantTypes(body.grant_types ?? ['authorization_code', 'refresh_token']);
 	if (!grantTypes.includes('authorization_code')) {
 		return {

--- a/src/lib/mcp/dcr.ts
+++ b/src/lib/mcp/dcr.ts
@@ -15,9 +15,9 @@ import { logger as harperLogger } from 'harper';
 import type { Logger, MCPClientMetadata, MCPClientRecord, MCPConfig } from '../../types.ts';
 import { MCPClientStore } from './clientStore.ts';
 import {
-	SUPPORTED_GRANT_TYPES,
 	SUPPORTED_RESPONSE_TYPES,
 	SUPPORTED_AUTH_METHODS,
+	filterGrantTypes,
 	validateOptionalString,
 	validateRedirectUri,
 	validateStringArray,
@@ -114,14 +114,15 @@ function buildClientFromRequest(
 		}
 	}
 
-	const grantTypes: string[] = body.grant_types ?? ['authorization_code', 'refresh_token'];
-	for (const grant of grantTypes) {
-		if (!SUPPORTED_GRANT_TYPES.has(grant)) {
-			return {
-				status: 400,
-				body: { error: 'invalid_client_metadata', error_description: `Unsupported grant_type: ${grant}` },
-			};
-		}
+	// RFC 7591 §3.2.2 permits the AS to register a subset of requested grants.
+	// Filter to the supported intersection; reject only when authorization_code
+	// is absent from the result (the flow cannot proceed without it).
+	const grantTypes: string[] = filterGrantTypes(body.grant_types ?? ['authorization_code', 'refresh_token']);
+	if (!grantTypes.includes('authorization_code')) {
+		return {
+			status: 400,
+			body: { error: 'invalid_client_metadata', error_description: 'Missing required grant_type: authorization_code' },
+		};
 	}
 
 	const responseTypes: string[] = body.response_types ?? ['code'];

--- a/src/lib/mcp/dcr.ts
+++ b/src/lib/mcp/dcr.ts
@@ -15,6 +15,7 @@ import { logger as harperLogger } from 'harper';
 import type { Logger, MCPClientMetadata, MCPClientRecord, MCPConfig } from '../../types.ts';
 import { MCPClientStore } from './clientStore.ts';
 import {
+	LEGACY_DEFAULT_GRANT_TYPES,
 	SUPPORTED_RESPONSE_TYPES,
 	SUPPORTED_AUTH_METHODS,
 	filterGrantTypes,
@@ -116,7 +117,7 @@ function buildClientFromRequest(
 
 	// RFC 7591 §3.2.1 permits the AS to register a subset of requested grants.
 	// Reject only when authorization_code is absent from the supported intersection.
-	const grantTypes: string[] = filterGrantTypes(body.grant_types ?? ['authorization_code', 'refresh_token']);
+	const grantTypes: string[] = filterGrantTypes(body.grant_types ?? LEGACY_DEFAULT_GRANT_TYPES);
 	if (!grantTypes.includes('authorization_code')) {
 		return {
 			status: 400,

--- a/src/lib/mcp/token.ts
+++ b/src/lib/mcp/token.ts
@@ -17,6 +17,7 @@ import { emitMCPAuditEvent } from './audit.ts';
 import { MCPAssertionJtiStore } from './assertionJtiStore.ts';
 import { MCPAuthCodeStore } from './authCodeStore.ts';
 import { CimdClientError, MAX_CLIENT_ID_LENGTH, resolveClient } from './cimd.ts';
+import { allowsGrant } from './clientValidator.ts';
 import { CLIENT_ASSERTION_TYPE_JWT_BEARER, verifyClientAssertion } from './clientAssertion.ts';
 import { MCPKeyStore } from './keyStore.ts';
 import { createRateLimiter, type RateLimiter } from './rateLimit.ts';
@@ -125,9 +126,9 @@ export function _resetGrantRateLimiter(): void {
 	grantLimiterRate = undefined;
 }
 
-/** Does the client's registered grant_types permit refresh tokens? Defaults to true when unspecified (DCR default includes refresh_token). */
+/** Does the client's registered grant_types permit refresh tokens? Defaults to true when unspecified (legacy default includes refresh_token). */
 function allowsRefresh(client: MCPClientRecord): boolean {
-	return !client.grant_types || client.grant_types.includes('refresh_token');
+	return allowsGrant(client, 'refresh_token');
 }
 
 /** Does a space-delimited scope string include `offline_access` (SEP-2207)? */
@@ -351,6 +352,12 @@ async function handleAuthorizationCodeGrant(
 	hookManager?: HookManager,
 	logger?: Logger
 ): Promise<TokenResponse> {
+	// RFC 6749 §5.2: reject if the client's registered grant_types do not
+	// include authorization_code.
+	if (!allowsGrant(client, 'authorization_code')) {
+		return errorResponse(400, 'unauthorized_client', 'Client is not authorized for the authorization_code grant');
+	}
+
 	const code = typeof body?.code === 'string' ? body.code : undefined;
 	const codeVerifier = typeof body?.code_verifier === 'string' ? body.code_verifier : undefined;
 	const redirectUri = typeof body?.redirect_uri === 'string' ? body.redirect_uri : undefined;

--- a/test/lib/mcp/authorize.test.js
+++ b/test/lib/mcp/authorize.test.js
@@ -295,6 +295,25 @@ describe('handleAuthorize', () => {
 				const url = new URL(response.headers.Location);
 				assert.equal(url.host, 'upstream.example.com', 'absent grant_types allows the flow through');
 			});
+
+			it('a restricted client requesting response_type=token gets unsupported_response_type, not unauthorized_client', async () => {
+				const restrictedClient = encodeClientForStorage({
+					...VALID_CLIENT,
+					client_id: 'restricted-3',
+					grant_types: [],
+				});
+				storedClients.set('restricted-3', restrictedClient);
+				const { entries } = newRegistry();
+				const target = makeTarget({ ...BASE_QUERY, client_id: 'restricted-3', response_type: 'token' });
+				const response = await handleAuthorize(makeRequest(), target, validConfig, entries);
+				const { host, params } = parseRedirect(response);
+				assert.equal(host, 'mcp-client.example.com');
+				assert.equal(
+					params.error,
+					'unsupported_response_type',
+					'response_type guard fires before the grant check (RFC 6749 §3.1.1)'
+				);
+			});
 		});
 
 		it('redirects with unsupported_response_type when response_type is not "code"', async () => {

--- a/test/lib/mcp/authorize.test.js
+++ b/test/lib/mcp/authorize.test.js
@@ -253,6 +253,50 @@ describe('handleAuthorize', () => {
 			};
 		}
 
+		describe('grant_types enforcement (RFC 6749 §4.1.2.1)', () => {
+			it('redirects with unauthorized_client when client has grant_types: []', async () => {
+				const restrictedClient = encodeClientForStorage({
+					...VALID_CLIENT,
+					client_id: 'restricted-1',
+					grant_types: [],
+				});
+				storedClients.set('restricted-1', restrictedClient);
+				const { entries } = newRegistry();
+				const target = makeTarget({ ...BASE_QUERY, client_id: 'restricted-1' });
+				const response = await handleAuthorize(makeRequest(), target, validConfig, entries);
+				const { host, params } = parseRedirect(response);
+				assert.equal(host, 'mcp-client.example.com');
+				assert.equal(params.error, 'unauthorized_client');
+			});
+
+			it('redirects with unauthorized_client when client has grant_types: ["refresh_token"]', async () => {
+				const restrictedClient = encodeClientForStorage({
+					...VALID_CLIENT,
+					client_id: 'restricted-2',
+					grant_types: ['refresh_token'],
+				});
+				storedClients.set('restricted-2', restrictedClient);
+				const { entries } = newRegistry();
+				const target = makeTarget({ ...BASE_QUERY, client_id: 'restricted-2' });
+				const response = await handleAuthorize(makeRequest(), target, validConfig, entries);
+				const { host, params } = parseRedirect(response);
+				assert.equal(host, 'mcp-client.example.com');
+				assert.equal(params.error, 'unauthorized_client');
+			});
+
+			it('allows authorization_code when grant_types is absent (legacy default includes authorization_code)', async () => {
+				const legacyClient = encodeClientForStorage({ ...VALID_CLIENT, client_id: 'legacy-1' });
+				delete legacyClient.grant_types; // absent field → legacy default
+				storedClients.set('legacy-1', legacyClient);
+				const { entries } = newRegistry();
+				const target = makeTarget({ ...BASE_QUERY, client_id: 'legacy-1' });
+				const response = await handleAuthorize(makeRequest(), target, validConfig, entries);
+				assert.equal(response.status, 302);
+				const url = new URL(response.headers.Location);
+				assert.equal(url.host, 'upstream.example.com', 'absent grant_types allows the flow through');
+			});
+		});
+
 		it('redirects with unsupported_response_type when response_type is not "code"', async () => {
 			const { entries } = newRegistry();
 			const target = makeTarget({ ...BASE_QUERY, response_type: 'token' });

--- a/test/lib/mcp/cimd.test.js
+++ b/test/lib/mcp/cimd.test.js
@@ -624,6 +624,44 @@ describe('resolveCimdClient — document validation', () => {
 		assert.equal(record.jwks_uri, undefined);
 		assert.equal(record.jwks, undefined);
 	});
+
+	it('accepts the exact claude.ai metadata shape (authorization_code + refresh_token + jwt-bearer)', async () => {
+		// Repro for #199: claude.ai now declares a third grant type the AS does not
+		// implement. The CIMD validator must ignore it and store only the intersection.
+		setupOk({
+			...VALID_DOC,
+			grant_types: ['authorization_code', 'refresh_token', 'urn:ietf:params:oauth:grant-type:jwt-bearer'],
+		});
+		const record = await resolveCimdClient(VALID_URL, undefined);
+		assert.ok(record, 'expected resolution to succeed');
+		assert.deepEqual(
+			record.grant_types,
+			['authorization_code', 'refresh_token'],
+			'stored grants must be the supported intersection only'
+		);
+	});
+
+	it('rejects a document missing authorization_code, naming the absent grant', async () => {
+		setupOk({ ...VALID_DOC, grant_types: ['refresh_token'] });
+		await assert.rejects(
+			() => resolveCimdClient(VALID_URL, undefined),
+			(err) => {
+				assert.ok(err instanceof CimdClientError);
+				assert.equal(err.oauthError, 'invalid_client');
+				assert.match(err.message, /Missing required grant_type: authorization_code/);
+				return true;
+			}
+		);
+	});
+
+	it('ignores all additional non-supported grants (stores only the supported intersection)', async () => {
+		setupOk({
+			...VALID_DOC,
+			grant_types: ['authorization_code', 'urn:custom:grant-a', 'urn:custom:grant-b'],
+		});
+		const record = await resolveCimdClient(VALID_URL, undefined);
+		assert.deepEqual(record.grant_types, ['authorization_code']);
+	});
 });
 
 describe('resolveCimdClient — client_credentials documents (#161)', () => {

--- a/test/lib/mcp/clientValidator.test.js
+++ b/test/lib/mcp/clientValidator.test.js
@@ -1,0 +1,27 @@
+/**
+ * Tests for allowsGrant's legacy-default semantics: an absent grant_types
+ * field means exactly ['authorization_code', 'refresh_token'] — not "any
+ * grant" (gemini review finding on #200).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { allowsGrant } from '../../../dist/lib/mcp/clientValidator.js';
+
+describe('allowsGrant legacy default', () => {
+	it('absent grant_types allows exactly the legacy default set', () => {
+		assert.equal(allowsGrant({}, 'authorization_code'), true);
+		assert.equal(allowsGrant({}, 'refresh_token'), true);
+	});
+
+	it('absent grant_types does NOT allow grants outside the default set', () => {
+		assert.equal(allowsGrant({}, 'client_credentials'), false);
+		assert.equal(allowsGrant({}, 'urn:ietf:params:oauth:grant-type:jwt-bearer'), false);
+	});
+
+	it('explicit empty array allows nothing', () => {
+		assert.equal(allowsGrant({ grant_types: [] }, 'authorization_code'), false);
+		assert.equal(allowsGrant({ grant_types: [] }, 'refresh_token'), false);
+	});
+});

--- a/test/lib/mcp/dcr.test.js
+++ b/test/lib/mcp/dcr.test.js
@@ -294,7 +294,7 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 			assert.match(response.body.error_description, /Missing required grant_type: authorization_code/);
 		});
 
-		it('registers with the supported intersection when a superset of grants is declared (RFC 7591 §3.2.2)', async () => {
+		it('registers with the supported intersection when a superset of grants is declared (RFC 7591 §3.2.1)', async () => {
 			const response = await handleRegister(
 				makeRequest(),
 				{

--- a/test/lib/mcp/dcr.test.js
+++ b/test/lib/mcp/dcr.test.js
@@ -283,7 +283,7 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 			assert.equal(response.body.application_type, 'native');
 		});
 
-		it('rejects unsupported grant_types', async () => {
+		it('rejects when the declared grant_types produce no usable intersection (authorization_code absent)', async () => {
 			const response = await handleRegister(
 				makeRequest(),
 				{ redirect_uris: ['https://app.example.com/cb'], grant_types: ['client_credentials'] },
@@ -291,6 +291,24 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 			);
 			assert.equal(response.status, 400);
 			assert.equal(response.body.error, 'invalid_client_metadata');
+			assert.match(response.body.error_description, /Missing required grant_type: authorization_code/);
+		});
+
+		it('registers with the supported intersection when a superset of grants is declared (RFC 7591 §3.2.2)', async () => {
+			const response = await handleRegister(
+				makeRequest(),
+				{
+					redirect_uris: ['https://app.example.com/cb'],
+					grant_types: ['authorization_code', 'refresh_token', 'urn:ietf:params:oauth:grant-type:jwt-bearer'],
+				},
+				{ enabled: true, dynamicClientRegistration: {} }
+			);
+			assert.equal(response.status, 201);
+			assert.deepEqual(
+				response.body.grant_types,
+				['authorization_code', 'refresh_token'],
+				'only the supported intersection is registered'
+			);
 		});
 
 		it('rejects unsupported response_types', async () => {

--- a/test/lib/mcp/token.test.js
+++ b/test/lib/mcp/token.test.js
@@ -723,6 +723,76 @@ describe('handleToken', () => {
 		);
 		assert.equal(res.body.error, 'invalid_grant');
 	});
+
+	describe('grant_types enforcement at token endpoint (RFC 6749 §5.2)', () => {
+		it('rejects authorization_code exchange when client has grant_types: []', async () => {
+			clients.set('no-grants', {
+				client_id: 'no-grants',
+				token_endpoint_auth_method: 'none',
+				grant_types: JSON.stringify([]),
+				redirect_uris: JSON.stringify([REDIRECT]),
+				client_id_issued_at: 1700000000,
+			});
+			seedCode('code-ng', { client_id: 'no-grants' });
+			const res = await handleToken(
+				{ headers: {} },
+				{
+					grant_type: 'authorization_code',
+					code: 'code-ng',
+					code_verifier: CODE_VERIFIER,
+					redirect_uri: REDIRECT,
+					client_id: 'no-grants',
+				},
+				mcpConfig
+			);
+			assert.equal(res.status, 400);
+			assert.equal(res.body.error, 'unauthorized_client');
+			assert.equal(codes.has('code-ng'), true, 'code not consumed on rejected grant');
+		});
+
+		it('rejects authorization_code exchange when client has grant_types: ["refresh_token"]', async () => {
+			clients.set('refresh-only', {
+				client_id: 'refresh-only',
+				token_endpoint_auth_method: 'none',
+				grant_types: JSON.stringify(['refresh_token']),
+				redirect_uris: JSON.stringify([REDIRECT]),
+				client_id_issued_at: 1700000000,
+			});
+			seedCode('code-ro', { client_id: 'refresh-only' });
+			const res = await handleToken(
+				{ headers: {} },
+				{
+					grant_type: 'authorization_code',
+					code: 'code-ro',
+					code_verifier: CODE_VERIFIER,
+					redirect_uri: REDIRECT,
+					client_id: 'refresh-only',
+				},
+				mcpConfig
+			);
+			assert.equal(res.status, 400);
+			assert.equal(res.body.error, 'unauthorized_client');
+			assert.equal(codes.has('code-ro'), true, 'code not consumed on rejected grant');
+		});
+
+		it('allows authorization_code exchange when grant_types is absent (legacy default includes authorization_code)', async () => {
+			// public-1 has no grant_types field (legacy record) — must succeed.
+			seedCode('code-legacy');
+			const res = await handleToken(
+				{ headers: {} },
+				{
+					grant_type: 'authorization_code',
+					code: 'code-legacy',
+					code_verifier: CODE_VERIFIER,
+					redirect_uri: REDIRECT,
+					client_id: 'public-1',
+				},
+				mcpConfig
+			);
+			assert.equal(res.status, 200);
+			assert.ok(res.body.access_token, 'access token issued for legacy client');
+		});
+	});
 });
 
 describe('handleToken — client_credentials grant (#162)', () => {


### PR DESCRIPTION
## Problem

`claude.ai`'s MCP Client ID Metadata Document (CIMD) now declares three grant types:

```
"grant_types": ["authorization_code","refresh_token","urn:ietf:params:oauth:grant-type:jwt-bearer"]
```

The previous validator rejected the entire client registration on any unknown grant, so every claude.ai custom-connector handshake failed with:

```
invalid_client: CIMD document: Unsupported grant_type: urn:ietf:params:oauth:grant-type:jwt-bearer
```

## Fix

Three complementary changes:

**CIMD path** (`cimd.ts`): require `authorization_code` to be declared; store only the supported intersection (`authorization_code`, `refresh_token`). Extra grants from the document (e.g. `jwt-bearer`) are ignored — the CIMD document describes a client's capabilities across all servers; an AS silently ignoring what it doesn't implement is correct.

**DCR path** (`dcr.ts`): filter the declared grants to the supported intersection per RFC 7591 §3.2.1; reject only when `authorization_code` is absent from the result. Unknown grants are silently dropped.

**Request-path grant enforcement** (folded from Codex finding): a new `allowsGrant(client, grant)` helper in `clientValidator.ts` is checked at the authorization endpoint (RFC 6749 §4.1.2.1) and the token endpoint (RFC 6749 §5.2). Clients with `grant_types: []` or `["refresh_token"]` now receive `unauthorized_client` before any authorization begins. Absent/undefined `grant_types` uses the legacy default `['authorization_code', 'refresh_token']` — matching the CIMD and DCR paths — so pre-#200 records are not broken. The existing `allowsRefresh` private helper in `token.ts` was refactored to call `allowsGrant` (behavior-identical).

## Tests

Original 5 new unit tests (registration path):

- `cimd.test.js`: exact claude.ai shape passes, stored grants = `['authorization_code','refresh_token']`
- `cimd.test.js`: document missing `authorization_code` rejected with `invalid_client`
- `cimd.test.js`: any number of unknown extra grants produces the supported intersection
- `dcr.test.js`: superset declaration registers successfully with the intersection
- `dcr.test.js` (renamed): confirms `authorization_code`-absent case still rejected

Fold adds 6 new unit tests (request-path enforcement):

- `authorize.test.js`: `grant_types: []` → `unauthorized_client` redirect (fails on base)
- `authorize.test.js`: `grant_types: ["refresh_token"]` → `unauthorized_client` redirect (fails on base)
- `authorize.test.js`: absent `grant_types` → allows (legacy default, no regression)
- `token.test.js`: `grant_types: []` → `unauthorized_client` at token exchange, code not consumed (fails on base)
- `token.test.js`: `grant_types: ["refresh_token"]` → `unauthorized_client` at token exchange, code not consumed (fails on base)
- `token.test.js`: absent `grant_types` → allows (legacy default, no regression)

All 4 enforcement tests fail on `origin/heskew/199-cimd-grant-intersection` pre-fold (confirmed via stash-and-build: authorize tests redirect to upstream instead of unauthorized_client; token tests return 200 instead of 400). All 2 no-regression tests pass on both old and new code.

Full suite post-fold: 1115 tests, 0 failures.

## Open questions for reviewer

One architectural decision remains genuinely open:

3. **`silent-filtering-vs-warning`** — Unknown grants are dropped silently at registration. No audit log entry is emitted. RFC 7591 §3.2.1 explicitly blesses the filtering itself ("The authorization server MAY reject or replace any of the requested metadata values"). Fine for now; could add a debug-level log if tracing becomes useful.

Items 1 and 2 from the previous draft are now settled:

1. ~~`require-declared-authorization-code-in-cimd`~~ — resolved by implementation; enforcement is now also at the request path per RFC 6749 §4.1.2.1 / §5.2 (this fold).
2. ~~`client-credentials-remains-a-shape-selector`~~ — out of profile per MCP authorization spec 2026-07-28: auth-code+PKCE for user-delegated connector access; machine clients use RFC 7523 (`private_key_jwt`). Client-credentials-only CIMD clients are not an expected shape.

Closes #199

## Review coverage

- **Gemini** (gemini-code-assist CI bot, final diff): no blockers; 3 suggestion-tier threads resolved with rationale.
- **Codex** (deep review, post-hoc at head): confirmed significant finding — `authorize.ts`/`token.ts` never verify the resolved client's registered `grant_types` includes `authorization_code`, so clients persisted pre-upgrade with `[]`/`["refresh_token"]` still complete the auth-code flow. **Resolved in this PR (folded)**: `allowsGrant` check added at both request paths; 4 new tests fail on pre-fold head and pass post-fold.
- **Gemini at fold head** (agy CLI, Gemini 3.6 Flash, high effort): explicit **no blockers** — verified the authorize placement (redirect-URI validated before the error redirect; `unauthorized_client` over `unsupported_response_type` per §4.1.2.1), token-endpoint ordering (un-consumed codes are client-bound and TTL-expire — no replay exposure), `allowsRefresh` behavior-identity across `[]`/null/non-array shapes, legacy-default consistency across all three interpretation sites, and that the six tests drive the real `handleAuthorize`/`handleToken` entry points.
- **Codex at final head** (delta review, `1f8f3bd^..HEAD`, after the spend cap was lifted): one suggestion-tier finding — the /authorize guard ordering returned `unauthorized_client` for a flow the client never requested (`response_type=token`); **accepted in e882c77** (response_type guard now fires first per RFC 6749 §3.1.1, pinned by a restricted-client+token test). Codex explicitly noted its silence on the other requested axes is not clearance; those axes carry on the agy leg above. Notable: agy had blessed the original ordering — a genuine cross-model disagreement, resolved by the spec text in Codex's favor.
- **Gemini bot re-review**: one medium finding (allowsGrant legacy-default looseness) — **accepted in a254ae6**, pinned by clientValidator.test.js.
- Coverage note: an earlier claim of pre-push cross-model coverage could not be verified (no receipts); the Codex review above is the authoritative outside-family pass for the registration-path changes. Generated with Claude (Sonnet 4.6 worker agent); Codex leg via codex CLI.

## For the human reviewer

Read order for the original fix: `clientValidator.ts` (new `filterGrantTypes` + relaxed `validateGrantTypes`) → `cimd.ts` (validate declared, store intersection) → `dcr.ts` (filter first, require `authorization_code` in the result).

Read order for the fold: `clientValidator.ts` (new `allowsGrant` helper, ~line 58) → `authorize.ts` (check after redirect closure is set up, ~line 430) → `token.ts` (`handleAuthorizationCodeGrant`, first guard; `allowsRefresh` now delegates to `allowsGrant`). Tests in `authorize.test.js` and `token.test.js` under the `grant_types enforcement` sub-describes.

Look hardest at: (1) the `!client.grant_types` branch in `allowsGrant` — this is the legacy-default path and must not tighten behavior for pre-#200 records; (2) the authorize.ts check fires after the redirect URI is validated (correct — can safely redirect at that point) and before `response_type` (correct ordering per RFC 6749 §4.1.2.1); (3) the token.ts check fires before the code is consumed — a rejected grant leaves the code unconsumed (tests pin this).

What the tests do NOT prove: a full browser-driven flow where a real code is minted then presented by a restricted client. The unit tests inject a pre-seeded code record directly. The enforcement chain (authorize rejects before code is issued; token rejects before code is consumed) is tested at each step independently but not as one composed browser session.

Human-Review-Need: elevated — OAuth validation semantics on a security surface; fold commit not yet cross-model reviewed (named degradation above).


