### PR TITLE
fix: bind browser-initiated OAuth flows to the initiating browser

### DIFF
--- a/integrationTests/mcp-oauth-e2e.test.ts
+++ b/integrationTests/mcp-oauth-e2e.test.ts
@@ -306,15 +306,13 @@ suite('MCP OAuth Stage 7: full round-trip e2e', (ctx: ContextWithHarper) => {
 		const idpLocation = authorizeRes.headers.get('location');
 		ok(idpLocation, 'authorize must redirect to a location');
 
-		// Browser binding: every /oauth/mcp/authorize flow —
-		// including this DCR/stored path — now sets a per-flow __Host- consent
-		// nonce cookie whose hash is carried in the upstream state; the callback
-		// requires the cookie back before minting a code. A real browser stores
-		// this Secure/SameSite=Lax cookie over HTTPS and re-sends it on the
-		// top-level redirect from the IdP. The stub runs over plain HTTP, so we
-		// replay the cookie explicitly on the callback hop to model that.
-		const consentCookie = authorizeRes.headers.getSetCookie().find((c) => c.startsWith('__Host-mcp_consent_'));
-		ok(consentCookie, 'DCR authorize must set the per-flow browser-binding cookie');
+		// Browser binding: every /oauth/mcp/authorize flow — including this DCR/stored
+		// path — sets the stable __Host-oauth_browser secret cookie whose hash is carried
+		// in upstream state; the callback requires it back before minting a code. A real
+		// browser stores this Secure/SameSite=Lax cookie and re-sends it on the top-level
+		// redirect from the IdP. The stub runs over plain HTTP, so we replay it explicitly.
+		const consentCookie = authorizeRes.headers.getSetCookie().find((c) => c.startsWith('__Host-oauth_browser'));
+		ok(consentCookie, 'DCR authorize must set the stable browser-binding cookie');
 		const consentCookiePair = consentCookie!.split(';')[0];
 		await authorizeRes.body?.cancel();
 
@@ -337,7 +335,7 @@ suite('MCP OAuth Stage 7: full round-trip e2e', (ctx: ContextWithHarper) => {
 		// and 302s to the client redirect_uri with code + state).
 		const harperCallbackUrl = new URL(harperCallbackLocation!);
 		// The stub IdP redirect target is already an absolute URL to Harper's callback.
-		// Carry the per-flow consent cookie, as the browser would.
+		// Carry the stable browser-binding cookie, as the browser would.
 		const callbackRes = await fetch(harperCallbackUrl.toString(), {
 			redirect: 'manual',
 			headers: { cookie: consentCookiePair },

--- a/integrationTests/mcp-oauth-e2e.test.ts
+++ b/integrationTests/mcp-oauth-e2e.test.ts
@@ -305,6 +305,17 @@ suite('MCP OAuth Stage 7: full round-trip e2e', (ctx: ContextWithHarper) => {
 		strictEqual(authorizeRes.status, 302, 'authorize must 302 to stub IdP');
 		const idpLocation = authorizeRes.headers.get('location');
 		ok(idpLocation, 'authorize must redirect to a location');
+
+		// Browser binding: every /oauth/mcp/authorize flow —
+		// including this DCR/stored path — now sets a per-flow __Host- consent
+		// nonce cookie whose hash is carried in the upstream state; the callback
+		// requires the cookie back before minting a code. A real browser stores
+		// this Secure/SameSite=Lax cookie over HTTPS and re-sends it on the
+		// top-level redirect from the IdP. The stub runs over plain HTTP, so we
+		// replay the cookie explicitly on the callback hop to model that.
+		const consentCookie = authorizeRes.headers.getSetCookie().find((c) => c.startsWith('__Host-mcp_consent_'));
+		ok(consentCookie, 'DCR authorize must set the per-flow browser-binding cookie');
+		const consentCookiePair = consentCookie!.split(';')[0];
 		await authorizeRes.body?.cancel();
 
 		// The Location should point at the stub IdP /authorize endpoint.
@@ -326,7 +337,11 @@ suite('MCP OAuth Stage 7: full round-trip e2e', (ctx: ContextWithHarper) => {
 		// and 302s to the client redirect_uri with code + state).
 		const harperCallbackUrl = new URL(harperCallbackLocation!);
 		// The stub IdP redirect target is already an absolute URL to Harper's callback.
-		const callbackRes = await fetch(harperCallbackUrl.toString(), { redirect: 'manual' });
+		// Carry the per-flow consent cookie, as the browser would.
+		const callbackRes = await fetch(harperCallbackUrl.toString(), {
+			redirect: 'manual',
+			headers: { cookie: consentCookiePair },
+		});
 		strictEqual(callbackRes.status, 302, 'Harper callback must 302 to client redirect_uri');
 		const finalLocation = callbackRes.headers.get('location');
 		ok(finalLocation, 'Harper callback must redirect to a location');

--- a/src/lib/handlers.ts
+++ b/src/lib/handlers.ts
@@ -19,9 +19,18 @@ import type {
 	OnLoginResultDenied,
 	OnLoginResultNeedsConfirmation,
 } from '../types.ts';
-import { consentNonceMatches, readConsentNonce } from './mcp/consentBinding.ts';
+import {
+	buildLoginCookie,
+	consentNonceMatches,
+	generateConsentFlowId,
+	generateConsentNonce,
+	hashConsentNonce,
+	readConsentNonce,
+	readLoginNonce,
+} from './mcp/consentBinding.ts';
 import { handleMCPCallback } from './mcp/index.ts';
 import { resolveIssuer } from './mcp/wellKnown.ts';
+import { getRequestHeader } from './requestHeaders.ts';
 import type { HookManager } from './hookManager.ts';
 
 /**
@@ -130,8 +139,21 @@ export async function handleLogin(
 		redirectParam = sanitizeRedirect(redirectParam);
 	}
 
-	const referer = request.headers?.referer ? sanitizeRedirect(request.headers.referer) : undefined;
+	// getRequestHeader, not request.headers.referer: the live Harper runtime
+	// wraps headers behind `.asObject`, so direct property access is undefined.
+	const refererHeader = getRequestHeader(request.headers, 'referer');
+	const referer = refererHeader ? sanitizeRedirect(refererHeader) : undefined;
 	const originalUrl = redirectParam || referer || config.postLoginRedirect || '/';
+
+	// Browser binding: session binding below only covers
+	// flows initiated while logged in — Harper mints no anonymous session id, so
+	// the primary logged-out login flow had nothing tying the callback to the
+	// browser that started it (login CSRF: an attacker-minted state+code fed to
+	// a victim's browser silently logs the victim in as the attacker). Same
+	// per-flow nonce-cookie mechanism as the CIMD consent binding — the cookie
+	// stays in this browser, only its hash travels in the state token.
+	const loginFlowId = generateConsentFlowId();
+	const loginNonce = generateConsentNonce();
 
 	// Generate CSRF token with metadata
 	// Bind token to provider to prevent cross-provider CSRF attacks
@@ -139,6 +161,8 @@ export async function handleLogin(
 		originalUrl,
 		sessionId: request.session?.id,
 		providerName, // Bind state token to this provider
+		loginFlowId,
+		browserNonceHash: hashConsentNonce(loginNonce),
 	});
 
 	// Build authorization URL with CSRF token as state parameter
@@ -149,7 +173,8 @@ export async function handleLogin(
 	return {
 		status: 302,
 		headers: {
-			Location: authUrl,
+			'Location': authUrl,
+			'Set-Cookie': buildLoginCookie(loginFlowId, loginNonce),
 		},
 	};
 }
@@ -195,7 +220,10 @@ export async function handleCallback(
 		// echo it to postLoginRedirect with the original reason. Otherwise,
 		// generic invalid_request.
 		if (error) {
-			logger?.error?.(`OAuth error (no state): ${error} - ${errorDescription}`);
+			// JSON.stringify: error/error_description are attacker-controlled
+			// query params, reachable pre-auth — encode CR/LF so a crafted value
+			// can't forge log lines (CWE-117; same treatment as the DCR handler).
+			logger?.error?.(`OAuth error (no state): ${JSON.stringify(error)} - ${JSON.stringify(errorDescription)}`);
 			const errorUrl = buildErrorRedirect(config.postLoginRedirect || '/', {
 				error: 'oauth_failed',
 				reason: error,
@@ -275,22 +303,57 @@ export async function handleCallback(
 		return { status: 302, headers: { Location: errorUrl } };
 	}
 
-	// CIMD browser binding — checked BEFORE the upstream code exchange and the
-	// onLogin hook, so a mismatched (self-approved) flow triggers no upstream
-	// exchange, no userinfo fetch, and no provisioning side-effects; it only
-	// applies when the state carries a binding (CIMD), so DCR/human flows are
-	// unaffected. SameSite=Lax sends the per-flow nonce cookie on the top-level
-	// redirect back from the IdP.
-	if (mcpState?.browserNonceHash) {
-		if (!consentNonceMatches(readConsentNonce(request, mcpState.consentFlowId), mcpState.browserNonceHash)) {
-			logger?.warn?.(`MCP callback: consent browser binding mismatch for client=${mcpState.clientId}`);
-			return mcpErrorRedirect(mcpState, 'access_denied', 'Authorization must complete in the browser that approved it');
+	// Login browser binding — the human-flow counterpart
+	// of the CIMD check below. The state minted by handleLogin carries the hash
+	// of a per-flow nonce cookie set on the initiating browser; a callback
+	// arriving without the matching cookie is a state delivered into a
+	// different browser — the login-CSRF shape the session binding above can't
+	// catch when the flow starts logged out (no session id to record).
+	// Enforced whenever the token carries the hash, so pre-upgrade in-flight
+	// tokens still complete; MCP states never carry a top-level hash (their
+	// binding is the CIMD check below).
+	if (tokenData.browserNonceHash && !mcpState) {
+		if (!consentNonceMatches(readLoginNonce(request, tokenData.loginFlowId), tokenData.browserNonceHash)) {
+			logger?.warn?.(`OAuth callback: login browser binding mismatch (provider '${providerName}')`);
+			const errorUrl = buildErrorRedirect(tokenData.originalUrl || config.postLoginRedirect || '/', {
+				error: 'auth_failed',
+				reason: 'csrf',
+			});
+			return { status: 302, headers: { Location: errorUrl } };
+		}
+	}
+
+	// MCP browser binding — every /oauth/mcp/authorize flow (the CIMD interstitial
+	// AND the direct DCR/stored path) mints a per-flow __Host- nonce cookie and
+	// carries its hash in the upstream state, so the callback can prove the flow
+	// completes in the browser that initiated it. Checked BEFORE the upstream code
+	// exchange and the onLogin hook, so a mismatched (or unbound) flow triggers no
+	// upstream exchange, no userinfo fetch, and no provisioning side-effects. Fail
+	// closed: an MCP state reaching here without a binding is a forged or
+	// pre-upgrade in-flight state — reject it rather than mint an auth code for an
+	// unbound flow (authorization-code injection). Unlike the human flow above —
+	// whose pre-upgrade tolerance stays scoped to `!mcpState` and is deliberately
+	// NOT widened to MCP — an MCP flow's anonymous initiator has no session-id
+	// fallback, so the cookie is its only browser proof. SameSite=Lax sends the
+	// per-flow nonce cookie on the top-level redirect back from the IdP.
+	if (mcpState) {
+		if (
+			!mcpState.browserNonceHash ||
+			!consentNonceMatches(readConsentNonce(request, mcpState.consentFlowId), mcpState.browserNonceHash)
+		) {
+			logger?.warn?.(`MCP callback: browser binding mismatch for client=${mcpState.clientId}`);
+			return mcpErrorRedirect(
+				mcpState,
+				'access_denied',
+				'Authorization must complete in the browser that initiated it'
+			);
 		}
 	}
 
 	// Now that we know the flow context, handle upstream IdP errors.
 	if (error) {
-		logger?.error?.(`OAuth error: ${error} - ${errorDescription}`);
+		// JSON.stringify: CRLF-safe logging of browser-controlled params (CWE-117).
+		logger?.error?.(`OAuth error: ${JSON.stringify(error)} - ${JSON.stringify(errorDescription)}`);
 		if (mcpState) {
 			return mcpErrorRedirect(mcpState, error, errorDescription || error);
 		}

--- a/src/lib/handlers.ts
+++ b/src/lib/handlers.ts
@@ -20,13 +20,11 @@ import type {
 	OnLoginResultNeedsConfirmation,
 } from '../types.ts';
 import {
-	buildLoginCookie,
-	consentNonceMatches,
-	generateConsentFlowId,
-	generateConsentNonce,
-	hashConsentNonce,
-	readConsentNonce,
-	readLoginNonce,
+	browserSecretMatches,
+	buildBrowserSecretCookie,
+	generateBrowserSecret,
+	hashBrowserSecret,
+	readBrowserSecret,
 } from './mcp/consentBinding.ts';
 import { handleMCPCallback } from './mcp/index.ts';
 import { resolveIssuer } from './mcp/wellKnown.ts';
@@ -145,15 +143,15 @@ export async function handleLogin(
 	const referer = refererHeader ? sanitizeRedirect(refererHeader) : undefined;
 	const originalUrl = redirectParam || referer || config.postLoginRedirect || '/';
 
-	// Browser binding: session binding below only covers
-	// flows initiated while logged in — Harper mints no anonymous session id, so
-	// the primary logged-out login flow had nothing tying the callback to the
-	// browser that started it (login CSRF: an attacker-minted state+code fed to
-	// a victim's browser silently logs the victim in as the attacker). Same
-	// per-flow nonce-cookie mechanism as the CIMD consent binding — the cookie
-	// stays in this browser, only its hash travels in the state token.
-	const loginFlowId = generateConsentFlowId();
-	const loginNonce = generateConsentNonce();
+	// Browser binding: session binding only covers flows initiated while logged
+	// in — Harper mints no anonymous session id, so the logged-out login flow
+	// needs the browser secret cookie to prove the callback arrived in the
+	// initiating browser (login-CSRF: attacker-minted state+code fed to a
+	// victim silently logs them in as the attacker).
+	// One stable `__Host-oauth_browser` cookie per browser; reused across flows;
+	// Max-Age refreshed here so active browsers never hit silent expiry.
+	const existingSecret = readBrowserSecret(request);
+	const browserSecret = existingSecret ?? generateBrowserSecret();
 
 	// Generate CSRF token with metadata
 	// Bind token to provider to prevent cross-provider CSRF attacks
@@ -161,8 +159,7 @@ export async function handleLogin(
 		originalUrl,
 		sessionId: request.session?.id,
 		providerName, // Bind state token to this provider
-		loginFlowId,
-		browserNonceHash: hashConsentNonce(loginNonce),
+		browserNonceHash: hashBrowserSecret(browserSecret),
 	});
 
 	// Build authorization URL with CSRF token as state parameter
@@ -174,7 +171,7 @@ export async function handleLogin(
 		status: 302,
 		headers: {
 			'Location': authUrl,
-			'Set-Cookie': buildLoginCookie(loginFlowId, loginNonce),
+			'Set-Cookie': buildBrowserSecretCookie(browserSecret),
 		},
 	};
 }
@@ -303,17 +300,16 @@ export async function handleCallback(
 		return { status: 302, headers: { Location: errorUrl } };
 	}
 
-	// Login browser binding — the human-flow counterpart
-	// of the CIMD check below. The state minted by handleLogin carries the hash
-	// of a per-flow nonce cookie set on the initiating browser; a callback
-	// arriving without the matching cookie is a state delivered into a
-	// different browser — the login-CSRF shape the session binding above can't
-	// catch when the flow starts logged out (no session id to record).
+	// Login browser binding — the human-flow counterpart of the MCP check below.
+	// handleLogin stores hash(browser_secret) in the state; a callback arriving
+	// without the matching stable cookie is a state delivered into a different
+	// browser — the login-CSRF shape that session binding can't catch when the
+	// flow starts logged out (no session id to record).
 	// Enforced whenever the token carries the hash, so pre-upgrade in-flight
-	// tokens still complete; MCP states never carry a top-level hash (their
-	// binding is the CIMD check below).
+	// tokens (without browserNonceHash) still complete; MCP states never carry a
+	// top-level hash (their binding is checked below).
 	if (tokenData.browserNonceHash && !mcpState) {
-		if (!consentNonceMatches(readLoginNonce(request, tokenData.loginFlowId), tokenData.browserNonceHash)) {
+		if (!browserSecretMatches(readBrowserSecret(request), tokenData.browserNonceHash)) {
 			logger?.warn?.(`OAuth callback: login browser binding mismatch (provider '${providerName}')`);
 			const errorUrl = buildErrorRedirect(tokenData.originalUrl || config.postLoginRedirect || '/', {
 				error: 'auth_failed',
@@ -324,23 +320,17 @@ export async function handleCallback(
 	}
 
 	// MCP browser binding — every /oauth/mcp/authorize flow (the CIMD interstitial
-	// AND the direct DCR/stored path) mints a per-flow __Host- nonce cookie and
-	// carries its hash in the upstream state, so the callback can prove the flow
-	// completes in the browser that initiated it. Checked BEFORE the upstream code
-	// exchange and the onLogin hook, so a mismatched (or unbound) flow triggers no
-	// upstream exchange, no userinfo fetch, and no provisioning side-effects. Fail
-	// closed: an MCP state reaching here without a binding is a forged or
-	// pre-upgrade in-flight state — reject it rather than mint an auth code for an
-	// unbound flow (authorization-code injection). Unlike the human flow above —
-	// whose pre-upgrade tolerance stays scoped to `!mcpState` and is deliberately
-	// NOT widened to MCP — an MCP flow's anonymous initiator has no session-id
-	// fallback, so the cookie is its only browser proof. SameSite=Lax sends the
-	// per-flow nonce cookie on the top-level redirect back from the IdP.
+	// AND the direct DCR/stored path) reads or generates a stable per-browser
+	// secret cookie and carries its hash in the upstream state, so the callback
+	// can prove the flow completes in the browser that initiated it. Checked
+	// BEFORE the upstream code exchange and the onLogin hook so a mismatched (or
+	// unbound) flow triggers no upstream exchange, no userinfo fetch, and no
+	// provisioning side-effects. Fail closed: an MCP state without a binding is
+	// a forged or pre-upgrade state — reject rather than mint an auth code for an
+	// unbound flow (authorization-code injection). SameSite=Lax sends the stable
+	// cookie on the top-level redirect back from the upstream IdP.
 	if (mcpState) {
-		if (
-			!mcpState.browserNonceHash ||
-			!consentNonceMatches(readConsentNonce(request, mcpState.consentFlowId), mcpState.browserNonceHash)
-		) {
+		if (!mcpState.browserNonceHash || !browserSecretMatches(readBrowserSecret(request), mcpState.browserNonceHash)) {
 			logger?.warn?.(`MCP callback: browser binding mismatch for client=${mcpState.clientId}`);
 			return mcpErrorRedirect(
 				mcpState,

--- a/src/lib/mcp/authorize.ts
+++ b/src/lib/mcp/authorize.ts
@@ -38,12 +38,11 @@ import type {
 import { CimdClientError, resolveClient } from './cimd.ts';
 import { allowsGrant, LOCAL_HOSTS } from './clientValidator.ts';
 import {
-	buildConsentCookie,
-	consentNonceMatches,
-	generateConsentFlowId,
-	generateConsentNonce,
-	hashConsentNonce,
-	readConsentNonce,
+	browserSecretMatches,
+	buildBrowserSecretCookie,
+	generateBrowserSecret,
+	hashBrowserSecret,
+	readBrowserSecret,
 } from './consentBinding.ts';
 import { resolveIssuer, resolveResource } from './wellKnown.ts';
 
@@ -333,25 +332,20 @@ async function performUpstreamRedirect(
 	const providerEntry = providers[selection.providerName];
 	const providerConfig: OAuthProviderConfig = providerEntry.config;
 
-	// Browser binding for EVERY MCP authorize flow, not just the CIMD interstitial.
-	// CIMD clients arrive here from /oauth/mcp/confirm with the interstitial's
-	// per-flow nonce hash already bound into mcpState (its cookie already lives in
-	// the browser), so leave those untouched. Stored/DCR clients skip the
-	// interstitial and reach here directly with no binding — mint the same
-	// __Host- per-flow nonce cookie here and carry its hash in the upstream state
-	// so the callback can prove the flow completes in the initiating browser.
-	// Without this an anonymous initiator also mints no session id, so an
-	// attacker-minted, unbound state fed to a victim would produce an auth code
-	// for the victim at the attacker's redirect_uri (authorization-code
-	// injection). Only the hash leaves the server; the callback re-checks the
-	// cookie (see handlers.ts).
+	// Browser binding for EVERY MCP authorize flow. Read (or generate) the
+	// stable `__Host-oauth_browser` secret and carry its hash in the upstream
+	// CSRF state. The cookie Max-Age is always refreshed so active browsers
+	// never hit silent expiry. Without this binding an anonymous initiator has
+	// no session id, so an attacker-minted state fed to a victim's browser
+	// would produce an auth code for the victim at the attacker's redirect_uri
+	// (authorization-code injection). Only the hash leaves this server; the
+	// callback re-checks the cookie (see handlers.ts).
+	const existingSecret = readBrowserSecret(request);
+	const browserSecret = existingSecret ?? generateBrowserSecret();
+	const bindingCookie = buildBrowserSecretCookie(browserSecret);
 	let boundState = mcpState;
-	let bindingCookie: string | undefined;
 	if (!boundState.browserNonceHash) {
-		const consentFlowId = generateConsentFlowId();
-		const consentNonce = generateConsentNonce();
-		boundState = { ...boundState, browserNonceHash: hashConsentNonce(consentNonce), consentFlowId };
-		bindingCookie = buildConsentCookie(consentFlowId, consentNonce);
+		boundState = { ...boundState, browserNonceHash: hashBrowserSecret(browserSecret) };
 	}
 
 	let csrfToken: string;
@@ -379,9 +373,7 @@ async function performUpstreamRedirect(
 		`MCP authorize: client=${mcpState.clientId} -> upstream=${selection.providerName}; bound resource=${mcpState.resource}`
 	);
 
-	const headers: Redirect['headers'] = { Location: upstreamAuthUrl };
-	if (bindingCookie) headers['Set-Cookie'] = bindingCookie;
-	return { status: 302, headers };
+	return { status: 302, headers: { 'Location': upstreamAuthUrl, 'Set-Cookie': bindingCookie } };
 }
 
 /**
@@ -502,18 +494,18 @@ export async function handleAuthorize(
 		}
 		const providerEntry = providers[selection.providerName];
 
-		// Browser binding: the per-flow nonce cookie set below must accompany both
-		// the /confirm POST and the eventual upstream callback; only its hash is
-		// stored server-side (see consentBinding.ts). The flow id names the cookie
-		// so parallel authorization flows in one browser don't collide.
-		const consentFlowId = generateConsentFlowId();
-		const consentNonce = generateConsentNonce();
+		// Browser binding: read (or generate) the stable browser secret cookie,
+		// carry its hash in the confirm token's mcp state. The same cookie must
+		// accompany both the /confirm POST and the eventual upstream callback.
+		// Max-Age refreshed here so active browsers never hit silent expiry.
+		const existingSecret = readBrowserSecret(request);
+		const browserSecret = existingSecret ?? generateBrowserSecret();
 
 		let confirmToken: string;
 		try {
 			confirmToken = await providerEntry.provider.generateCSRFToken({
 				providerName: selection.providerName,
-				mcp: { ...mcpState, browserNonceHash: hashConsentNonce(consentNonce), consentFlowId },
+				mcp: { ...mcpState, browserNonceHash: hashBrowserSecret(browserSecret) },
 				_confirm: true,
 			});
 		} catch (error) {
@@ -537,7 +529,7 @@ export async function handleAuthorize(
 				'X-Frame-Options': 'DENY',
 				'Content-Security-Policy': "frame-ancestors 'none'",
 				'Cache-Control': 'no-store',
-				'Set-Cookie': buildConsentCookie(consentFlowId, consentNonce),
+				'Set-Cookie': buildBrowserSecretCookie(browserSecret),
 			},
 			body: html,
 		};
@@ -614,13 +606,10 @@ export async function handleAuthorizeConfirm(
 	}
 
 	// Browser binding: the confirm POST must come from the browser that was
-	// served the interstitial (and its per-flow nonce cookie). Without this, the
-	// malicious client itself could fetch and "confirm" the interstitial, then
-	// hand the victim the resulting upstream URL — consent bypassed.
-	if (
-		!mcpState.browserNonceHash ||
-		!consentNonceMatches(readConsentNonce(request, mcpState.consentFlowId), mcpState.browserNonceHash)
-	) {
+	// served the interstitial (and its stable browser-secret cookie). Without
+	// this, the malicious client itself could fetch and "confirm" the
+	// interstitial, hand the victim the resulting upstream URL — consent bypassed.
+	if (!mcpState.browserNonceHash || !browserSecretMatches(readBrowserSecret(request), mcpState.browserNonceHash)) {
 		logger?.warn?.(`MCP confirm: consent browser binding mismatch for client=${mcpState.clientId}`);
 		return {
 			status: 400,

--- a/src/lib/mcp/authorize.ts
+++ b/src/lib/mcp/authorize.ts
@@ -55,7 +55,7 @@ type ErrorJSON = {
 
 type Redirect = {
 	status: 302;
-	headers: { Location: string };
+	headers: { 'Location': string; 'Set-Cookie'?: string };
 };
 
 type HtmlResponse = {
@@ -333,6 +333,27 @@ async function performUpstreamRedirect(
 	const providerEntry = providers[selection.providerName];
 	const providerConfig: OAuthProviderConfig = providerEntry.config;
 
+	// Browser binding for EVERY MCP authorize flow, not just the CIMD interstitial.
+	// CIMD clients arrive here from /oauth/mcp/confirm with the interstitial's
+	// per-flow nonce hash already bound into mcpState (its cookie already lives in
+	// the browser), so leave those untouched. Stored/DCR clients skip the
+	// interstitial and reach here directly with no binding — mint the same
+	// __Host- per-flow nonce cookie here and carry its hash in the upstream state
+	// so the callback can prove the flow completes in the initiating browser.
+	// Without this an anonymous initiator also mints no session id, so an
+	// attacker-minted, unbound state fed to a victim would produce an auth code
+	// for the victim at the attacker's redirect_uri (authorization-code
+	// injection). Only the hash leaves the server; the callback re-checks the
+	// cookie (see handlers.ts).
+	let boundState = mcpState;
+	let bindingCookie: string | undefined;
+	if (!boundState.browserNonceHash) {
+		const consentFlowId = generateConsentFlowId();
+		const consentNonce = generateConsentNonce();
+		boundState = { ...boundState, browserNonceHash: hashConsentNonce(consentNonce), consentFlowId };
+		bindingCookie = buildConsentCookie(consentFlowId, consentNonce);
+	}
+
 	let csrfToken: string;
 	try {
 		csrfToken = await providerEntry.provider.generateCSRFToken({
@@ -342,7 +363,7 @@ async function performUpstreamRedirect(
 			// Both MCP entries (direct authorize and post-CIMD confirm) mint
 			// their upstream state here, so this is the single binding site.
 			sessionId: request.session?.id,
-			mcp: mcpState,
+			mcp: boundState,
 		});
 	} catch (error) {
 		logger?.error?.(
@@ -358,7 +379,9 @@ async function performUpstreamRedirect(
 		`MCP authorize: client=${mcpState.clientId} -> upstream=${selection.providerName}; bound resource=${mcpState.resource}`
 	);
 
-	return { status: 302, headers: { Location: upstreamAuthUrl } };
+	const headers: Redirect['headers'] = { Location: upstreamAuthUrl };
+	if (bindingCookie) headers['Set-Cookie'] = bindingCookie;
+	return { status: 302, headers };
 }
 
 /**

--- a/src/lib/mcp/consentBinding.ts
+++ b/src/lib/mcp/consentBinding.ts
@@ -30,6 +30,7 @@
  */
 
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { readRawHeader } from '../requestHeaders.ts';
 import type { Request } from '../../types.ts';
 
 export const BROWSER_SECRET_COOKIE_NAME = '__Host-oauth_browser';
@@ -94,15 +95,7 @@ export function readBrowserSecret(request: Request | undefined): string | undefi
  * tail would reject valid callbacks with a binding mismatch.
  */
 function readCookieHeader(request: Request | undefined): string | undefined {
-	const headers = request?.headers as any;
-	if (!headers) return undefined;
-	let raw: unknown;
-	if (typeof headers.get === 'function') {
-		raw = headers.get('cookie');
-	} else {
-		const obj = headers.asObject ?? headers;
-		raw = obj?.cookie ?? obj?.Cookie;
-	}
+	const raw = readRawHeader(request?.headers, 'cookie');
 	if (raw == null) return undefined;
 	return Array.isArray(raw) ? raw.join('; ') : String(raw);
 }

--- a/src/lib/mcp/consentBinding.ts
+++ b/src/lib/mcp/consentBinding.ts
@@ -1,126 +1,81 @@
 /**
- * CIMD consent browser binding
+ * OAuth browser binding via a stable per-browser secret cookie.
  *
- * The consent interstitial (#166) is only meaningful if the browser that
- * approves it is the browser the upstream authorization completes in. Without
- * a binding, a malicious CIMD client can fetch the interstitial itself,
- * confirm it, and hand the victim the resulting upstream IdP URL — the victim
- * never sees the client identity or redirect-host disclosure but an existing
- * IdP session still produces an authorization code at the attacker's
- * redirect_uri.
+ * Every browser-initiated OAuth flow — human login and all MCP authorize paths
+ * — binds to the browser that started it, closing login-CSRF /
+ * authorization-code-injection attacks where an attacker-initiated flow is
+ * completed in a victim's browser.
  *
- * Binding: when the interstitial is served, a random nonce is set as a cookie
- * and its SHA-256 hash is stored in the confirm token's `mcp` state. POST
- * /oauth/mcp/confirm requires the cookie to hash-match, and the hash is carried
- * through the upstream CSRF state so the OAuth callback re-checks the same
- * cookie before minting an MCP authorization code.
+ * Binding: when a flow is initiated, this module reads (or generates) a single
+ * stable `__Host-oauth_browser` cookie. The SHA-256 hash of the secret is
+ * stored in the server-side flow state (CSRF token or confirm token); the
+ * callback/confirm step re-reads the cookie and constant-time-checks the hash.
+ * Only the hash leaves this server; the cookie value never appears in state.
+ *
+ * Single stable cookie design (resolves issue #205 — per-flow cookie exhaustion):
+ * - Each browser carries ONE `__Host-oauth_browser` cookie across all flows.
+ *   Parallel tabs share it (same browser — the property we bind on).
+ * - The secret is generated once and reused; Max-Age is refreshed on every
+ *   flow initiation so active browsers never hit silent expiry.
+ * - Abandoned flows leave only server-side CSRF rows, which Harper's built-in
+ *   table expiration already reaps — no per-flow cookie, no accumulation.
  *
  * Cookie hardening:
- * - `__Host-` prefix: the browser only accepts a `__Host-`-named cookie when it
- *   is `Secure`, `Path=/`, and has NO `Domain` — which means a sibling origin
- *   (evil.example.com attacking auth.example.com) CANNOT plant a parent-domain
- *   cookie to forge the binding. Plain `SameSite=Lax` does not stop that,
- *   because sibling subdomains are same-site. (RFC 6265bis §4.1.3.2.)
- * - Per-flow name: the cookie name embeds a random flow id (also carried in the
- *   confirm/upstream state), so concurrent authorization flows in the same
- *   browser (parallel tabs) don't overwrite each other's binding.
- * - `SameSite=Lax` keeps the cookie on the top-level redirect back from the
- *   IdP while excluding it from cross-site subresource/framed requests;
- *   `HttpOnly` keeps it out of script.
- *
- * Only the hash ever leaves the cookie: the state payload lives server-side in
- * the CSRF store, so a party that observes or replays state tokens still cannot
- * reconstruct the cookie value. Cookies expire via `Max-Age`; per-flow naming
- * makes explicit clearing unnecessary for correctness.
- *
- * The human login flow uses the same binding under a distinct cookie namespace:
- * session binding only protects flows initiated while logged in, so the
- * logged-out login flow needs the nonce cookie to prove the
- * callback arrived in the browser that initiated it. handleLogin mints it;
- * handleCallback enforces it via the `buildLoginCookie`/`readLoginNonce`
- * variants below.
+ * - `__Host-` prefix: only accepted when `Secure`, `Path=/`, no `Domain` —
+ *   a sibling origin cannot plant a parent-domain cookie to forge the binding
+ *   (RFC 6265bis §4.1.3.2).
+ * - `HttpOnly` keeps it out of script.
+ * - `SameSite=Lax` sends the cookie on the top-level redirect back from the
+ *   upstream IdP while excluding cross-site subresource/framed requests.
  */
 
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 import type { Request } from '../../types.ts';
 
-/** `__Host-` prefix + a per-flow id suffix. See module header for why. */
-const CONSENT_COOKIE_PREFIX = '__Host-mcp_consent_';
-
-/** Human-login binding cookie namespace. */
-const LOGIN_COOKIE_PREFIX = '__Host-oauth_login_';
+export const BROWSER_SECRET_COOKIE_NAME = '__Host-oauth_browser';
 
 /**
- * Must outlast TWO sequential CSRF-token lifetimes: the interstitial pause
- * (bounded by the confirm token, ~10 min) THEN the upstream IdP login (bounded
- * by the upstream state token, ~10 min). At 900 s the cookie could expire during
- * a slow login/MFA while the upstream state is still valid, rejecting an
- * otherwise-good callback. 30 min covers 2×10 min plus margin.
+ * Rolling 7-day lifetime: refreshed on every flow initiation so an active
+ * browser never hits silent expiry. An inactive browser's cookie expires
+ * naturally and a new secret is generated on the next flow.
  */
-const CONSENT_COOKIE_MAX_AGE_S = 1800;
+const BROWSER_SECRET_MAX_AGE_S = 7 * 24 * 60 * 60;
 
-/** Random, cookie-name-safe id identifying one authorization flow. */
-export function generateConsentFlowId(): string {
-	return randomBytes(16).toString('base64url');
-}
-
-export function generateConsentNonce(): string {
+/** Generate a new cryptographically random browser secret. */
+export function generateBrowserSecret(): string {
 	return randomBytes(32).toString('base64url');
 }
 
-export function hashConsentNonce(nonce: string): string {
-	return createHash('sha256').update(nonce).digest('base64url');
-}
-
-function buildBindingCookie(prefix: string, flowId: string, nonce: string): string {
-	return `${prefix}${flowId}=${nonce}; Max-Age=${CONSENT_COOKIE_MAX_AGE_S}; Path=/; Secure; HttpOnly; SameSite=Lax`;
+/** SHA-256 (base64url) of the browser secret. Only the hash is stored server-side. */
+export function hashBrowserSecret(secret: string): string {
+	return createHash('sha256').update(secret).digest('base64url');
 }
 
 /**
- * Set-Cookie value pairing the interstitial page with its confirm token.
+ * Build the `Set-Cookie` value for the stable browser secret.
  * `__Host-` requires exactly `Secure` + `Path=/` + no `Domain`.
+ * Always call this on every flow initiation to refresh the rolling Max-Age.
  */
-export function buildConsentCookie(flowId: string, nonce: string): string {
-	return buildBindingCookie(CONSENT_COOKIE_PREFIX, flowId, nonce);
-}
-
-/** Set-Cookie value pairing a human login initiation with its state token. */
-export function buildLoginCookie(flowId: string, nonce: string): string {
-	return buildBindingCookie(LOGIN_COOKIE_PREFIX, flowId, nonce);
+export function buildBrowserSecretCookie(secret: string): string {
+	return `${BROWSER_SECRET_COOKIE_NAME}=${secret}; Max-Age=${BROWSER_SECRET_MAX_AGE_S}; Path=/; Secure; HttpOnly; SameSite=Lax`;
 }
 
 /**
- * Read this flow's consent nonce from the request's Cookie header, if present.
+ * Read the browser secret from the request's Cookie header.
  *
- * Simple split parser, first name-match wins. Safe because both the name
- * suffix (flow id) and the value (nonce) are base64url — no `=`, `;`, quotes,
- * or spaces — and `__Host-` naming means a same-name cookie can only be set
- * by this origin over TLS at `Path=/` (one cookie per name+host+path in the
- * jar). Revisit the parser if the encoding ever changes.
+ * Simple split parser, first name-match wins. Safe because the cookie name is
+ * a fixed constant and the value is base64url — no `=`, `;`, quotes, or
+ * spaces — and `__Host-` naming means a same-name cookie can only be set by
+ * this origin over TLS at `Path=/`. Revisit the parser if the encoding changes.
  */
-export function readConsentNonce(request: Request | undefined, flowId: string | undefined): string | undefined {
-	return readBindingNonce(CONSENT_COOKIE_PREFIX, request, flowId);
-}
-
-/** Read this login flow's binding nonce from the request's Cookie header. */
-export function readLoginNonce(request: Request | undefined, flowId: string | undefined): string | undefined {
-	return readBindingNonce(LOGIN_COOKIE_PREFIX, request, flowId);
-}
-
-function readBindingNonce(
-	prefix: string,
-	request: Request | undefined,
-	flowId: string | undefined
-): string | undefined {
-	if (!flowId) return undefined;
+export function readBrowserSecret(request: Request | undefined): string | undefined {
 	const header = readCookieHeader(request);
 	if (typeof header !== 'string' || !header) return undefined;
-	const name = prefix + flowId;
 	for (const part of header.split(';')) {
 		const eq = part.indexOf('=');
 		if (eq === -1) continue;
-		if (part.slice(0, eq).trim() === name) {
-			return part.slice(eq + 1).trim();
+		if (part.slice(0, eq).trim() === BROWSER_SECRET_COOKIE_NAME) {
+			return part.slice(eq + 1).trim() || undefined;
 		}
 	}
 	return undefined;
@@ -152,10 +107,10 @@ function readCookieHeader(request: Request | undefined): string | undefined {
 	return Array.isArray(raw) ? raw.join('; ') : String(raw);
 }
 
-/** Constant-time check that `nonce` hashes to `expectedHash`. */
-export function consentNonceMatches(nonce: string | undefined, expectedHash: string | undefined): boolean {
-	if (!nonce || !expectedHash) return false;
-	const actual = Buffer.from(hashConsentNonce(nonce));
+/** Constant-time check that `secret` hashes to `expectedHash`. */
+export function browserSecretMatches(secret: string | undefined, expectedHash: string | undefined): boolean {
+	if (!secret || !expectedHash) return false;
+	const actual = Buffer.from(hashBrowserSecret(secret));
 	const expected = Buffer.from(expectedHash);
 	return actual.length === expected.length && timingSafeEqual(actual, expected);
 }

--- a/src/lib/mcp/consentBinding.ts
+++ b/src/lib/mcp/consentBinding.ts
@@ -42,7 +42,6 @@
  */
 
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
-import { getRequestHeader } from '../requestHeaders.ts';
 import type { Request } from '../../types.ts';
 
 /** `__Host-` prefix + a per-flow id suffix. See module header for why. */
@@ -51,8 +50,14 @@ const CONSENT_COOKIE_PREFIX = '__Host-mcp_consent_';
 /** Human-login binding cookie namespace. */
 const LOGIN_COOKIE_PREFIX = '__Host-oauth_login_';
 
-/** Must comfortably outlast the interstitial pause plus the upstream IdP login. */
-const CONSENT_COOKIE_MAX_AGE_S = 900;
+/**
+ * Must outlast TWO sequential CSRF-token lifetimes: the interstitial pause
+ * (bounded by the confirm token, ~10 min) THEN the upstream IdP login (bounded
+ * by the upstream state token, ~10 min). At 900 s the cookie could expire during
+ * a slow login/MFA while the upstream state is still valid, rejecting an
+ * otherwise-good callback. 30 min covers 2×10 min plus margin.
+ */
+const CONSENT_COOKIE_MAX_AGE_S = 1800;
 
 /** Random, cookie-name-safe id identifying one authorization flow. */
 export function generateConsentFlowId(): string {
@@ -122,13 +127,29 @@ function readBindingNonce(
 }
 
 /**
- * Read the raw `Cookie` header. Goes through `getRequestHeader` because reading
- * `request.headers.cookie` directly returns undefined against Harper's live
- * runtime headers wrapper, which would fail the binding check closed for every
- * browser flow.
+ * Read the raw `Cookie` header, wrapper-aware (`getRequestHeader`'s three shapes)
+ * — reading `request.headers.cookie` directly is undefined against Harper's live
+ * runtime wrapper, which would fail the binding check closed for every browser
+ * flow.
+ *
+ * Unlike `getRequestHeader` (first value only), repeated `Cookie` lines must ALL
+ * be parsed: HTTP/2 cookie crumbling — and transports that preserve repeated
+ * header fields as an array — can put the binding cookie in a non-first crumb.
+ * Join array crumbs with `"; "` so the parser sees every cookie; dropping the
+ * tail would reject valid callbacks with a binding mismatch.
  */
 function readCookieHeader(request: Request | undefined): string | undefined {
-	return getRequestHeader(request?.headers, 'cookie');
+	const headers = request?.headers as any;
+	if (!headers) return undefined;
+	let raw: unknown;
+	if (typeof headers.get === 'function') {
+		raw = headers.get('cookie');
+	} else {
+		const obj = headers.asObject ?? headers;
+		raw = obj?.cookie ?? obj?.Cookie;
+	}
+	if (raw == null) return undefined;
+	return Array.isArray(raw) ? raw.join('; ') : String(raw);
 }
 
 /** Constant-time check that `nonce` hashes to `expectedHash`. */

--- a/src/lib/mcp/consentBinding.ts
+++ b/src/lib/mcp/consentBinding.ts
@@ -32,13 +32,24 @@
  * the CSRF store, so a party that observes or replays state tokens still cannot
  * reconstruct the cookie value. Cookies expire via `Max-Age`; per-flow naming
  * makes explicit clearing unnecessary for correctness.
+ *
+ * The human login flow uses the same binding under a distinct cookie namespace:
+ * session binding only protects flows initiated while logged in, so the
+ * logged-out login flow needs the nonce cookie to prove the
+ * callback arrived in the browser that initiated it. handleLogin mints it;
+ * handleCallback enforces it via the `buildLoginCookie`/`readLoginNonce`
+ * variants below.
  */
 
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { getRequestHeader } from '../requestHeaders.ts';
 import type { Request } from '../../types.ts';
 
 /** `__Host-` prefix + a per-flow id suffix. See module header for why. */
 const CONSENT_COOKIE_PREFIX = '__Host-mcp_consent_';
+
+/** Human-login binding cookie namespace. */
+const LOGIN_COOKIE_PREFIX = '__Host-oauth_login_';
 
 /** Must comfortably outlast the interstitial pause plus the upstream IdP login. */
 const CONSENT_COOKIE_MAX_AGE_S = 900;
@@ -56,8 +67,8 @@ export function hashConsentNonce(nonce: string): string {
 	return createHash('sha256').update(nonce).digest('base64url');
 }
 
-function cookieName(flowId: string): string {
-	return CONSENT_COOKIE_PREFIX + flowId;
+function buildBindingCookie(prefix: string, flowId: string, nonce: string): string {
+	return `${prefix}${flowId}=${nonce}; Max-Age=${CONSENT_COOKIE_MAX_AGE_S}; Path=/; Secure; HttpOnly; SameSite=Lax`;
 }
 
 /**
@@ -65,7 +76,12 @@ function cookieName(flowId: string): string {
  * `__Host-` requires exactly `Secure` + `Path=/` + no `Domain`.
  */
 export function buildConsentCookie(flowId: string, nonce: string): string {
-	return `${cookieName(flowId)}=${nonce}; Max-Age=${CONSENT_COOKIE_MAX_AGE_S}; Path=/; Secure; HttpOnly; SameSite=Lax`;
+	return buildBindingCookie(CONSENT_COOKIE_PREFIX, flowId, nonce);
+}
+
+/** Set-Cookie value pairing a human login initiation with its state token. */
+export function buildLoginCookie(flowId: string, nonce: string): string {
+	return buildBindingCookie(LOGIN_COOKIE_PREFIX, flowId, nonce);
 }
 
 /**
@@ -78,10 +94,23 @@ export function buildConsentCookie(flowId: string, nonce: string): string {
  * jar). Revisit the parser if the encoding ever changes.
  */
 export function readConsentNonce(request: Request | undefined, flowId: string | undefined): string | undefined {
+	return readBindingNonce(CONSENT_COOKIE_PREFIX, request, flowId);
+}
+
+/** Read this login flow's binding nonce from the request's Cookie header. */
+export function readLoginNonce(request: Request | undefined, flowId: string | undefined): string | undefined {
+	return readBindingNonce(LOGIN_COOKIE_PREFIX, request, flowId);
+}
+
+function readBindingNonce(
+	prefix: string,
+	request: Request | undefined,
+	flowId: string | undefined
+): string | undefined {
 	if (!flowId) return undefined;
-	const header = request?.headers?.cookie;
+	const header = readCookieHeader(request);
 	if (typeof header !== 'string' || !header) return undefined;
-	const name = cookieName(flowId);
+	const name = prefix + flowId;
 	for (const part of header.split(';')) {
 		const eq = part.indexOf('=');
 		if (eq === -1) continue;
@@ -90,6 +119,16 @@ export function readConsentNonce(request: Request | undefined, flowId: string | 
 		}
 	}
 	return undefined;
+}
+
+/**
+ * Read the raw `Cookie` header. Goes through `getRequestHeader` because reading
+ * `request.headers.cookie` directly returns undefined against Harper's live
+ * runtime headers wrapper, which would fail the binding check closed for every
+ * browser flow.
+ */
+function readCookieHeader(request: Request | undefined): string | undefined {
+	return getRequestHeader(request?.headers, 'cookie');
 }
 
 /** Constant-time check that `nonce` hashes to `expectedHash`. */

--- a/src/lib/mcp/dcr.ts
+++ b/src/lib/mcp/dcr.ts
@@ -39,7 +39,7 @@ function checkInitialAccessToken(authHeader: string | undefined, configured: str
 		return null;
 	}
 	// Scheme name is case-insensitive (RFC 7235 §2.1 / RFC 6750 §2.1).
-	if (!authHeader || !/^bearer /i.test(authHeader)) {
+	if (!authHeader || !/^bearer\s/i.test(authHeader)) {
 		return {
 			status: 401,
 			body: { error: 'invalid_token', error_description: 'Missing initial access token' },

--- a/src/lib/mcp/dcr.ts
+++ b/src/lib/mcp/dcr.ts
@@ -38,7 +38,8 @@ function checkInitialAccessToken(authHeader: string | undefined, configured: str
 	if (!configured) {
 		return null;
 	}
-	if (!authHeader || !authHeader.startsWith('Bearer ')) {
+	// Scheme name is case-insensitive (RFC 7235 §2.1 / RFC 6750 §2.1).
+	if (!authHeader || !/^bearer /i.test(authHeader)) {
 		return {
 			status: 401,
 			body: { error: 'invalid_token', error_description: 'Missing initial access token' },

--- a/src/lib/mcp/dcr.ts
+++ b/src/lib/mcp/dcr.ts
@@ -22,6 +22,7 @@ import {
 	validateRedirectUri,
 	validateStringArray,
 } from './clientValidator.ts';
+import { getRequestHeader } from '../requestHeaders.ts';
 
 type ErrorResponse = {
 	status: number;
@@ -243,11 +244,11 @@ export async function handleRegister(
 	// — so these JSON.stringify calls run only when the message is actually
 	// emitted. Don't hoist a shared `JSON.stringify(...)` out to a const: that
 	// reintroduces eager work on every request even when the log is suppressed.
+	const authHeader = getRequestHeader(request?.headers, 'authorization');
 	harperLogger?.info?.(
-		`MCP DCR request received: redirect_uris=${JSON.stringify(body?.redirect_uris)} grant_types=${JSON.stringify(body?.grant_types)} response_types=${JSON.stringify(body?.response_types)} token_endpoint_auth_method=${JSON.stringify(body?.token_endpoint_auth_method)} auth_header=${!!request?.headers?.authorization}`
+		`MCP DCR request received: redirect_uris=${JSON.stringify(body?.redirect_uris)} grant_types=${JSON.stringify(body?.grant_types)} response_types=${JSON.stringify(body?.response_types)} token_endpoint_auth_method=${JSON.stringify(body?.token_endpoint_auth_method)} auth_header=${!!authHeader}`
 	);
 
-	const authHeader = request?.headers?.authorization;
 	const authError = checkInitialAccessToken(authHeader, dcrConfig?.initialAccessToken);
 	if (authError) {
 		harperLogger?.warn?.('MCP DCR rejected: initial access token required or invalid');

--- a/src/lib/mcp/dcr.ts
+++ b/src/lib/mcp/dcr.ts
@@ -259,8 +259,12 @@ export async function handleRegister(
 	const built = buildClientFromRequest(body, dcrConfig?.allowedRedirectUriHosts);
 	if ('status' in built) {
 		const errBody = (built as { body?: { error?: string; error_description?: string } }).body;
+		// JSON.stringify: error_description echoes attacker-controlled metadata
+		// (e.g. an invalid grant_type value) and DCR is reachable pre-auth when
+		// open — encode CR/LF so it can't forge log lines (CWE-117; matches the
+		// request-received log above).
 		harperLogger?.warn?.(
-			`MCP DCR rejected: ${errBody?.error} — ${errBody?.error_description} (redirect_uris=${JSON.stringify(body?.redirect_uris)})`
+			`MCP DCR rejected: ${JSON.stringify(errBody?.error)} — ${JSON.stringify(errBody?.error_description)} (redirect_uris=${JSON.stringify(body?.redirect_uris)})`
 		);
 		return built;
 	}

--- a/src/lib/mcp/index.ts
+++ b/src/lib/mcp/index.ts
@@ -17,7 +17,14 @@ export { MCPAuthCodeStore, resetMCPAuthCodesTableCache } from './authCodeStore.t
 export { handleAuthorize, handleAuthorizeConfirm, selectMCPProvider } from './authorize.ts';
 export { handleMCPCallback } from './callback.ts';
 export { isCimdClientId, resolveClient, CimdClientError } from './cimd.ts';
-export { buildConsentCookie, generateConsentFlowId, hashConsentNonce } from './consentBinding.ts';
+export {
+	BROWSER_SECRET_COOKIE_NAME,
+	browserSecretMatches,
+	buildBrowserSecretCookie,
+	generateBrowserSecret,
+	hashBrowserSecret,
+	readBrowserSecret,
+} from './consentBinding.ts';
 export { MCPClientStore, resetMCPClientsTableCache } from './clientStore.ts';
 export { handleRegister } from './dcr.ts';
 export { MCPKeyStore, resetMCPKeysTableCache, SIGNING_KEY_ID } from './keyStore.ts';

--- a/src/lib/mcp/token.ts
+++ b/src/lib/mcp/token.ts
@@ -159,7 +159,22 @@ function safeEqual(a: string, b: string): boolean {
 	return ab.length === bb.length && timingSafeEqual(ab, bb);
 }
 
-function parseBasicAuth(authHeader: string | undefined): { clientId: string; clientSecret: string } | null {
+/**
+ * application/x-www-form-urlencoded decode of one Basic credential field
+ * (RFC 6749 §2.3.1: `+` is a space, then percent-decode). Returns null on
+ * malformed percent-encoding so a corrupt credential is rejected, not
+ * looked up as-is.
+ */
+function formUrlDecode(field: string): string | null {
+	try {
+		return decodeURIComponent(field.replace(/\+/g, ' '));
+	} catch {
+		return null;
+	}
+}
+
+/** @internal — exported for tests. */
+export function parseBasicAuth(authHeader: string | undefined): { clientId: string; clientSecret: string } | null {
 	// Scheme name is case-insensitive (RFC 9110 §11.1) — matches the `/^basic\s/i`
 	// check on the client_credentials path.
 	if (!authHeader || !/^basic\s/i.test(authHeader)) return null;
@@ -169,9 +184,16 @@ function parseBasicAuth(authHeader: string | undefined): { clientId: string; cli
 	} catch {
 		return null;
 	}
+	// RFC 6749 §2.3.1: each field is form-urlencoded before base64, so the first
+	// literal `:` separates them (a `:` inside a field is `%3A`). Split there,
+	// then form-decode both — otherwise a URL-shaped CIMD client_id is looked up
+	// with its `%3A`/`%2F` literal, or an unencoded one splits at its scheme colon.
 	const sep = decoded.indexOf(':');
 	if (sep < 0) return null;
-	return { clientId: decoded.slice(0, sep), clientSecret: decoded.slice(sep + 1) };
+	const clientId = formUrlDecode(decoded.slice(0, sep));
+	const clientSecret = formUrlDecode(decoded.slice(sep + 1));
+	if (clientId === null || clientSecret === null) return null;
+	return { clientId, clientSecret };
 }
 
 type ClientAuthResult = { client: MCPClientRecord } | { error: TokenResponse };

--- a/src/lib/mcp/token.ts
+++ b/src/lib/mcp/token.ts
@@ -20,6 +20,7 @@ import { CimdClientError, MAX_CLIENT_ID_LENGTH, resolveClient } from './cimd.ts'
 import { CLIENT_ASSERTION_TYPE_JWT_BEARER, verifyClientAssertion } from './clientAssertion.ts';
 import { MCPKeyStore } from './keyStore.ts';
 import { createRateLimiter, type RateLimiter } from './rateLimit.ts';
+import { getRequestHeader } from '../requestHeaders.ts';
 import {
 	hashRefreshToken,
 	makeRefreshToken,
@@ -184,7 +185,7 @@ async function authenticateClient(
 	mcpConfig: MCPConfig | undefined,
 	logger?: Logger
 ): Promise<ClientAuthResult> {
-	const basic = parseBasicAuth(request?.headers?.authorization);
+	const basic = parseBasicAuth(getRequestHeader(request?.headers, 'authorization'));
 	const bodyClientId = typeof body?.client_id === 'string' ? body.client_id : undefined;
 	const bodyClientSecret = typeof body?.client_secret === 'string' ? body.client_secret : undefined;
 
@@ -217,8 +218,12 @@ async function authenticateClient(
 	const method = client.token_endpoint_auth_method ?? 'none';
 
 	if (method === 'none') {
-		// Public client: PKCE is the proof. A presented secret signals misuse.
-		if (basic || bodyClientSecret) {
+		// Public client: PKCE is the proof. A presented *non-empty* secret signals
+		// misuse and is rejected. An empty Basic secret — `Authorization: Basic
+		// base64("<client_id>:")` — carries only the client_id and is how some
+		// clients convey it; tolerate it as "no secret presented" so those public
+		// clients aren't rejected. (Empty values are falsy here.)
+		if (basic?.clientSecret || bodyClientSecret) {
 			return { error: errorResponse(401, 'invalid_client', 'Public client must not present a secret') };
 		}
 		return { client };
@@ -548,7 +553,10 @@ async function handleClientCredentialsGrant(
 	// grant — a Basic header or client_secret must not ride along (#159 req 6:
 	// no credential type may substitute for the private key). Scheme match is
 	// case-insensitive per RFC 9110 §11.1.
-	if (/^basic\s/i.test(request?.headers?.authorization ?? '') || typeof body?.client_secret === 'string') {
+	if (
+		/^basic\s/i.test(getRequestHeader(request?.headers, 'authorization') ?? '') ||
+		typeof body?.client_secret === 'string'
+	) {
 		return errorResponse(
 			400,
 			'invalid_request',

--- a/src/lib/mcp/token.ts
+++ b/src/lib/mcp/token.ts
@@ -159,7 +159,9 @@ function safeEqual(a: string, b: string): boolean {
 }
 
 function parseBasicAuth(authHeader: string | undefined): { clientId: string; clientSecret: string } | null {
-	if (!authHeader || !authHeader.startsWith('Basic ')) return null;
+	// Scheme name is case-insensitive (RFC 9110 §11.1) — matches the `/^basic\s/i`
+	// check on the client_credentials path.
+	if (!authHeader || !/^basic /i.test(authHeader)) return null;
 	let decoded: string;
 	try {
 		decoded = Buffer.from(authHeader.slice('Basic '.length).trim(), 'base64').toString('utf8');

--- a/src/lib/mcp/token.ts
+++ b/src/lib/mcp/token.ts
@@ -161,7 +161,7 @@ function safeEqual(a: string, b: string): boolean {
 function parseBasicAuth(authHeader: string | undefined): { clientId: string; clientSecret: string } | null {
 	// Scheme name is case-insensitive (RFC 9110 §11.1) — matches the `/^basic\s/i`
 	// check on the client_credentials path.
-	if (!authHeader || !/^basic /i.test(authHeader)) return null;
+	if (!authHeader || !/^basic\s/i.test(authHeader)) return null;
 	let decoded: string;
 	try {
 		decoded = Buffer.from(authHeader.slice('Basic '.length).trim(), 'base64').toString('utf8');

--- a/src/lib/mcp/wellKnown.ts
+++ b/src/lib/mcp/wellKnown.ts
@@ -23,6 +23,7 @@
  */
 
 import type { Logger, MCPConfig } from '../../types.ts';
+import { getRequestHeader } from '../requestHeaders.ts';
 import { dcrEnabled } from './dcr.ts';
 import { MCPKeyStore, resolveEffectiveAlg } from './keyStore.ts';
 import { publicKeyToJwk } from './tokenIssuer.ts';
@@ -82,8 +83,9 @@ export function resolveIssuer(request: HarperRequest, mcpConfig: MCPConfig): str
 		// endpoint URLs don't end up with a doubled slash.
 		return mcpConfig.issuer.replace(/\/+$/, '');
 	}
-	const rawHost = request.host ?? request.headers?.host;
-	const host = (Array.isArray(rawHost) ? rawHost[0] : rawHost) ?? 'localhost';
+	// getRequestHeader for the fallback: the live runtime wraps headers behind
+	// `.asObject`, so `request.headers.host` is undefined there.
+	const host = request.host ?? getRequestHeader(request.headers, 'host') ?? 'localhost';
 	const scheme = request.protocol ?? 'https';
 	return `${scheme}://${host}`;
 }

--- a/src/lib/mcp/withMCPAuth.ts
+++ b/src/lib/mcp/withMCPAuth.ts
@@ -46,6 +46,7 @@ import { MCPKeyStore } from './keyStore.ts';
 import { verifyAccessTokenWithKeySet } from './tokenIssuer.ts';
 import { protectedResourceMetadataUrl, resolveIssuer, resolveResource } from './wellKnown.ts';
 import { emitMCPAuditEvent, type MCPTokenRejectedAuditPayload } from './audit.ts';
+import { getRequestHeader } from '../requestHeaders.ts';
 
 /** Minimal surface withMCPAuth needs from a key source (lets tests inject one). */
 interface KeySource {
@@ -93,32 +94,13 @@ export interface WithMCPAuthOptions {
 type HttpListener = (request: Request, next: (req: Request) => any) => any;
 
 /**
- * Read a header value across the shapes a Harper request can carry: a Web
- * `Headers` object (`.get()`), Harper's headers wrapper (`.asObject`), or a
- * plain Node `IncomingMessage.headers` object (used in tests). Returns the
- * first value when a header is multi-valued.
- */
-function getHeader(headers: any, name: string): string | undefined {
-	if (!headers) return undefined;
-	let raw: unknown;
-	if (typeof headers.get === 'function') {
-		raw = headers.get(name);
-	} else {
-		const obj = headers.asObject ?? headers;
-		raw = obj?.[name.toLowerCase()] ?? obj?.[name];
-	}
-	if (raw == null) return undefined;
-	return Array.isArray(raw) ? raw[0] : String(raw);
-}
-
-/**
  * Extract a bearer token from the `Authorization` header. Header-only by design
  * (RFC 6750 §2.1): query-string and body tokens are never read, so they are
  * treated as "no token presented". Returns undefined for a missing or malformed
  * header (anything that isn't `Bearer <non-empty-token>`).
  */
 function extractBearerToken(headers: any): string | undefined {
-	const authz = getHeader(headers, 'authorization');
+	const authz = getRequestHeader(headers, 'authorization');
 	if (!authz) return undefined;
 	// Scheme is case-insensitive (RFC 7235); the token must be non-empty.
 	const match = /^Bearer[ \t]+(\S.*)$/i.exec(authz.trim());

--- a/src/lib/requestHeaders.ts
+++ b/src/lib/requestHeaders.ts
@@ -26,5 +26,9 @@ export function getRequestHeader(headers: unknown, name: string): string | undef
 		raw = obj?.[name.toLowerCase()] ?? obj?.[name];
 	}
 	if (raw == null) return undefined;
-	return Array.isArray(raw) ? raw[0] : String(raw);
+	// Take the first value for a multi-valued header, and always coerce to string
+	// (or undefined) so the declared return type holds even for a malformed
+	// headers object with a non-string / empty-array value.
+	const value = Array.isArray(raw) ? raw[0] : raw;
+	return value == null ? undefined : String(value);
 }

--- a/src/lib/requestHeaders.ts
+++ b/src/lib/requestHeaders.ts
@@ -1,0 +1,30 @@
+/**
+ * Read a request header across the shapes a Harper request can carry.
+ *
+ * The live Harper runtime passes component resources a headers wrapper that
+ * exposes only `.asObject` (not enumerable header properties), so reading
+ * `request.headers.<name>` directly returns undefined in production even though
+ * it works against the plain `IncomingMessage.headers` object used in unit
+ * tests. Every header read on a Harper request must go through here.
+ *
+ * Handles three shapes:
+ *   - a Web `Headers` object (`.get()`),
+ *   - Harper's runtime headers wrapper (`.asObject`),
+ *   - a plain Node `IncomingMessage.headers` object (tests).
+ *
+ * Header names are matched case-insensitively; the first value is returned when
+ * a header is multi-valued.
+ */
+export function getRequestHeader(headers: unknown, name: string): string | undefined {
+	if (!headers) return undefined;
+	const h = headers as any;
+	let raw: unknown;
+	if (typeof h.get === 'function') {
+		raw = h.get(name);
+	} else {
+		const obj = h.asObject ?? h;
+		raw = obj?.[name.toLowerCase()] ?? obj?.[name];
+	}
+	if (raw == null) return undefined;
+	return Array.isArray(raw) ? raw[0] : String(raw);
+}

--- a/src/lib/requestHeaders.ts
+++ b/src/lib/requestHeaders.ts
@@ -16,19 +16,26 @@
  * a header is multi-valued.
  */
 export function getRequestHeader(headers: unknown, name: string): string | undefined {
-	if (!headers) return undefined;
-	const h = headers as any;
-	let raw: unknown;
-	if (typeof h.get === 'function') {
-		raw = h.get(name);
-	} else {
-		const obj = h.asObject ?? h;
-		raw = obj?.[name.toLowerCase()] ?? obj?.[name];
-	}
+	const raw = readRawHeader(headers, name);
 	if (raw == null) return undefined;
 	// Take the first value for a multi-valued header, and always coerce to string
 	// (or undefined) so the declared return type holds even for a malformed
 	// headers object with a non-string / empty-array value.
 	const value = Array.isArray(raw) ? raw[0] : raw;
 	return value == null ? undefined : String(value);
+}
+
+/**
+ * Read the RAW header value from the container without collapsing multi-value —
+ * the shared wrapper-shape detection (Web `Headers` `.get()`, Harper `.asObject`,
+ * plain object) behind `getRequestHeader`. Callers decide first-value vs. join
+ * (the `Cookie` header must join all crumbs; see consentBinding.ts). Returns a
+ * string, an array, or undefined.
+ */
+export function readRawHeader(headers: unknown, name: string): unknown {
+	if (!headers) return undefined;
+	const h = headers as any;
+	if (typeof h.get === 'function') return h.get(name);
+	const obj = h.asObject ?? h;
+	return obj?.[name.toLowerCase()] ?? obj?.[name];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -295,14 +295,17 @@ export interface MCPAuthorizeState {
 	/** Original `state` parameter from the MCP client; echoed verbatim on redirect */
 	clientState?: string;
 	/**
-	 * CIMD consent browser binding: SHA-256 of the per-flow nonce cookie set with
-	 * the consent interstitial. Present only on CIMD flows; /oauth/mcp/confirm and
-	 * the upstream OAuth callback both require the caller's cookie to hash-match
-	 * before proceeding (see lib/mcp/consentBinding.ts).
+	 * MCP consent browser binding: SHA-256 of the per-flow nonce cookie set when
+	 * the authorize flow is initiated. Set on EVERY /oauth/mcp/authorize flow —
+	 * the CIMD interstitial mints it up front, and the stored/DCR path mints it in
+	 * performUpstreamRedirect. /oauth/mcp/confirm (CIMD) and the upstream OAuth
+	 * callback (all flows) require the caller's cookie to hash-match before
+	 * proceeding; the callback fails closed on an MCP state that lacks it (see
+	 * lib/mcp/consentBinding.ts and handlers.ts).
 	 */
 	browserNonceHash?: string;
 	/**
-	 * CIMD consent flow id: identifies which per-flow `__Host-` cookie carries
+	 * MCP consent flow id: identifies which per-flow `__Host-` cookie carries
 	 * this flow's nonce, so concurrent authorization flows in one browser don't
 	 * collide. Paired with `browserNonceHash`.
 	 */
@@ -674,6 +677,10 @@ export interface CSRFTokenData {
 	originalUrl?: string;
 	/** Session ID to link OAuth flow with existing session */
 	sessionId?: string;
+	/** Per-flow id naming the login browser-binding cookie */
+	loginFlowId?: string;
+	/** SHA-256 (base64url) of the login browser-binding nonce; the callback requires the cookie to hash-match */
+	browserNonceHash?: string;
 	[key: string]: any;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -295,21 +295,14 @@ export interface MCPAuthorizeState {
 	/** Original `state` parameter from the MCP client; echoed verbatim on redirect */
 	clientState?: string;
 	/**
-	 * MCP consent browser binding: SHA-256 of the per-flow nonce cookie set when
-	 * the authorize flow is initiated. Set on EVERY /oauth/mcp/authorize flow —
-	 * the CIMD interstitial mints it up front, and the stored/DCR path mints it in
-	 * performUpstreamRedirect. /oauth/mcp/confirm (CIMD) and the upstream OAuth
+	 * MCP browser binding: SHA-256 (base64url) of the stable `__Host-oauth_browser`
+	 * cookie set when the authorize flow is initiated. Set on EVERY
+	 * /oauth/mcp/authorize flow. /oauth/mcp/confirm (CIMD) and the upstream OAuth
 	 * callback (all flows) require the caller's cookie to hash-match before
 	 * proceeding; the callback fails closed on an MCP state that lacks it (see
 	 * lib/mcp/consentBinding.ts and handlers.ts).
 	 */
 	browserNonceHash?: string;
-	/**
-	 * MCP consent flow id: identifies which per-flow `__Host-` cookie carries
-	 * this flow's nonce, so concurrent authorization flows in one browser don't
-	 * collide. Paired with `browserNonceHash`.
-	 */
-	consentFlowId?: string;
 }
 
 /**
@@ -677,9 +670,7 @@ export interface CSRFTokenData {
 	originalUrl?: string;
 	/** Session ID to link OAuth flow with existing session */
 	sessionId?: string;
-	/** Per-flow id naming the login browser-binding cookie */
-	loginFlowId?: string;
-	/** SHA-256 (base64url) of the login browser-binding nonce; the callback requires the cookie to hash-match */
+	/** SHA-256 (base64url) of the stable browser-binding secret; the callback requires the cookie to hash-match */
 	browserNonceHash?: string;
 	[key: string]: any;
 }

--- a/test/lib/OAuthResource.responses.test.js
+++ b/test/lib/OAuthResource.responses.test.js
@@ -351,7 +351,7 @@ describe('OAuthResource - Response Builders', () => {
 			const redirect = {
 				status: 302,
 				headers: {
-					Location: 'https://idp.example/authorize',
+					'Location': 'https://idp.example/authorize',
 					'Set-Cookie': '__Host-oauth_browser=abc123; Max-Age=604800; Path=/; Secure; HttpOnly; SameSite=Lax',
 				},
 			};

--- a/test/lib/OAuthResource.responses.test.js
+++ b/test/lib/OAuthResource.responses.test.js
@@ -342,6 +342,22 @@ describe('OAuthResource - Response Builders', () => {
 			assert.equal(toHttpResponse(redirect), redirect, 'redirects already work — leave them be');
 		});
 
+		it('passes through a redirect with Set-Cookie unchanged (cookie must reach the HTTP layer)', () => {
+			// The authorize handler returns { status:302, headers:{ Location, 'Set-Cookie' } }.
+			// toHttpResponse must leave it untouched so the Set-Cookie header reaches Harper's
+			// REST → http layers and is emitted to the browser. If toHttpResponse wraps it in
+			// { body: JSON.stringify(...) } the HTTP layer still forwards the headers, but the
+			// intent here is that the passthrough path is exercised for responses with Set-Cookie.
+			const redirect = {
+				status: 302,
+				headers: {
+					Location: 'https://idp.example/authorize',
+					'Set-Cookie': '__Host-oauth_browser=abc123; Max-Age=604800; Path=/; Secure; HttpOnly; SameSite=Lax',
+				},
+			};
+			assert.equal(toHttpResponse(redirect), redirect, 'redirect with Set-Cookie passes through');
+		});
+
 		it('leaves non-object values untouched', () => {
 			assert.equal(toHttpResponse(undefined), undefined);
 			assert.equal(toHttpResponse('raw'), 'raw');

--- a/test/lib/handlers.test.js
+++ b/test/lib/handlers.test.js
@@ -165,20 +165,20 @@ describe('OAuth Handlers', () => {
 			assert.equal(csrfCall.arguments[0].sessionId, 'session-123');
 		});
 
-		it('mints a browser-binding nonce: hash in the state token, nonce in a __Host- cookie', async () => {
-			const { hashConsentNonce } = await import('../../dist/lib/mcp/consentBinding.js');
+		it('mints a browser-binding secret: hash in the state token, stable secret in a __Host- cookie', async () => {
+			const { BROWSER_SECRET_COOKIE_NAME, hashBrowserSecret } = await import('../../dist/lib/mcp/consentBinding.js');
 			const result = await handleLogin(mockRequest, mockTarget, mockProvider, mockConfig, 'test-provider', mockLogger);
 
 			const meta = mockProvider.generateCSRFToken.mock.calls[0].arguments[0];
-			assert.ok(meta.loginFlowId, 'flow id stored in the state token');
-			assert.ok(meta.browserNonceHash, 'nonce hash stored in the state token');
+			assert.ok(meta.browserNonceHash, 'secret hash stored in the state token');
+			assert.equal(meta.loginFlowId, undefined, 'no per-flow id in the state (stable cookie)');
 
 			const setCookie = result.headers['Set-Cookie'];
 			const [pair, ...attrs] = setCookie.split('; ');
 			const eq = pair.indexOf('=');
-			assert.equal(pair.slice(0, eq), `__Host-oauth_login_${meta.loginFlowId}`, 'cookie name embeds the flow id');
+			assert.equal(pair.slice(0, eq), BROWSER_SECRET_COOKIE_NAME, 'stable cookie name (no per-flow suffix)');
 			assert.equal(
-				hashConsentNonce(pair.slice(eq + 1)),
+				hashBrowserSecret(pair.slice(eq + 1)),
 				meta.browserNonceHash,
 				'cookie value hashes to the bound hash'
 			);
@@ -824,16 +824,14 @@ describe('OAuth Handlers', () => {
 		let storedAuthCodes;
 		// Import lazily so the dist symbol load doesn't happen at file parse.
 		let resetMCPAuthCodesTableCache;
-		let hashConsentNonce, buildConsentCookie;
+		let hashBrowserSecret, buildBrowserSecretCookie;
 
-		// Every /oauth/mcp/authorize flow (CIMD and stored/DCR) now mints a
-		// per-flow nonce cookie and binds its hash into the upstream state; the
+		// Every /oauth/mcp/authorize flow (CIMD and stored/DCR) mints a stable
+		// browser-secret cookie and binds its hash into the upstream state; the
 		// callback fails closed without a matching cookie. The default fixtures
-		// below therefore carry a valid binding so the happy-path assertions
-		// exercise the bound flow — tests that need an unbound/mismatched state
-		// override them locally.
-		const MCP_NONCE = 'mcp-branch-consent-nonce';
-		const MCP_FLOW_ID = 'mcpbranchflow';
+		// below carry a valid binding so happy-path assertions exercise the bound
+		// flow — tests that need an unbound/mismatched state override them locally.
+		const MCP_SECRET = 'mcp-branch-browser-secret';
 
 		const MCP_STATE = {
 			clientId: 'mcp-client-1',
@@ -852,7 +850,7 @@ describe('OAuth Handlers', () => {
 
 		beforeEach(async () => {
 			({ resetMCPAuthCodesTableCache } = await import('../../dist/lib/mcp/authCodeStore.js'));
-			({ hashConsentNonce, buildConsentCookie } = await import('../../dist/lib/mcp/consentBinding.js'));
+			({ hashBrowserSecret, buildBrowserSecretCookie } = await import('../../dist/lib/mcp/consentBinding.js'));
 			resetMCPAuthCodesTableCache();
 			originalDatabases = global.databases;
 			storedAuthCodes = new Map();
@@ -871,10 +869,10 @@ describe('OAuth Handlers', () => {
 			mockProvider.verifyCSRFToken = createMockFn(async () => ({
 				timestamp: Date.now(),
 				providerName: 'test-provider',
-				mcp: { ...MCP_STATE, browserNonceHash: hashConsentNonce(MCP_NONCE), consentFlowId: MCP_FLOW_ID },
+				mcp: { ...MCP_STATE, browserNonceHash: hashBrowserSecret(MCP_SECRET) },
 			}));
-			// The initiating browser's per-flow consent cookie accompanies the callback.
-			mockRequest.headers.cookie = buildConsentCookie(MCP_FLOW_ID, MCP_NONCE).split(';')[0];
+			// The initiating browser's stable cookie accompanies the callback.
+			mockRequest.headers.cookie = buildBrowserSecretCookie(MCP_SECRET).split(';')[0];
 		});
 
 		// Restore global.databases in afterEach so a failing assertion mid-test
@@ -1119,23 +1117,22 @@ describe('OAuth Handlers', () => {
 			assert.equal(mockProvider.exchangeCodeForToken.mock.calls.length, 0, 'upstream code never exchanged');
 		});
 
-		describe('CIMD consent browser binding', () => {
-			const NONCE = 'callback-consent-nonce';
-			const FLOW_ID = 'cbflow';
-			let hashConsentNonce, buildConsentCookie, cookieHeader;
+		describe('MCP browser binding (stable cookie)', () => {
+			const SECRET = 'callback-browser-secret';
+			let cookieHeader;
 
 			beforeEach(async () => {
-				({ hashConsentNonce, buildConsentCookie } = await import('../../dist/lib/mcp/consentBinding.js'));
-				// The per-flow Set-Cookie value minus its attributes → a Cookie header pair.
-				cookieHeader = buildConsentCookie(FLOW_ID, NONCE).split(';')[0];
+				// The stable browser-secret cookie accompanies the callback.
+				// Reuse the BROWSER_SECRET_COOKIE_NAME / buildBrowserSecretCookie imported in the outer beforeEach.
+				cookieHeader = buildBrowserSecretCookie(SECRET).split(';')[0];
 				mockProvider.verifyCSRFToken = createMockFn(async () => ({
 					timestamp: Date.now(),
 					providerName: 'test-provider',
-					mcp: { ...MCP_STATE, browserNonceHash: hashConsentNonce(NONCE), consentFlowId: FLOW_ID },
+					mcp: { ...MCP_STATE, browserNonceHash: hashBrowserSecret(SECRET) },
 				}));
 			});
 
-			it('completes when the callback arrives with the consent cookie', async () => {
+			it('completes when the callback arrives with the stable browser-secret cookie', async () => {
 				mockRequest.headers.cookie = cookieHeader;
 				const result = await handleCallback(
 					mockRequest,
@@ -1151,10 +1148,9 @@ describe('OAuth Handlers', () => {
 				assert.ok(url.searchParams.get('code'), 'auth code minted for the bound browser');
 			});
 
-			it('rejects when the consent cookie is missing — victim browser never approved', async () => {
-				// Attack: the malicious client self-approves the interstitial, then
-				// sends the victim the upstream IdP URL. The victim's browser has no
-				// (or a different) consent cookie, so no code may be minted.
+			it('rejects when the browser-secret cookie is missing — victim browser never approved', async () => {
+				// Attack: the malicious client initiates the flow (cookie in THEIR browser),
+				// then sends the victim the upstream IdP URL. The victim has no cookie.
 				delete mockRequest.headers.cookie;
 				const result = await handleCallback(
 					mockRequest,
@@ -1173,8 +1169,8 @@ describe('OAuth Handlers', () => {
 				assert.equal(storedAuthCodes.size, 0);
 			});
 
-			it('rejects when the consent cookie does not match the bound hash', async () => {
-				mockRequest.headers.cookie = buildConsentCookie(FLOW_ID, 'some-other-browser-nonce').split(';')[0];
+			it('rejects when the browser-secret cookie does not match the bound hash', async () => {
+				mockRequest.headers.cookie = buildBrowserSecretCookie('some-other-browser-secret').split(';')[0];
 				const result = await handleCallback(
 					mockRequest,
 					mockTarget,
@@ -1190,16 +1186,12 @@ describe('OAuth Handlers', () => {
 			});
 
 			it('fails closed on an MCP state with no browser binding (forged/pre-upgrade state)', async () => {
-				// After the DCR browser-binding fix, EVERY MCP
-				// authorize flow mints a per-flow nonce cookie and binds its hash into
-				// the upstream state. An MCP state that reaches the callback with no
-				// binding is a forged or pre-upgrade in-flight state and must NOT mint
-				// an auth code — this is the authorization-code injection the fix
-				// closes (an attacker-supplied, unbound state fed to a victim).
+				// An MCP state with no browserNonceHash is a forged or pre-upgrade
+				// in-flight state — must NOT mint an auth code (authorization-code injection).
 				mockProvider.verifyCSRFToken = createMockFn(async () => ({
 					timestamp: Date.now(),
 					providerName: 'test-provider',
-					mcp: { ...MCP_STATE }, // no browserNonceHash / consentFlowId
+					mcp: { ...MCP_STATE }, // no browserNonceHash
 				}));
 				delete mockRequest.headers.cookie;
 				const result = await handleCallback(
@@ -1441,25 +1433,23 @@ describe('OAuth Handlers', () => {
 	});
 
 	describe('handleCallback — login browser binding', () => {
-		const NONCE = 'login-binding-nonce';
-		const FLOW_ID = 'loginflow';
-		let hashConsentNonce, buildLoginCookie;
+		const SECRET = 'login-binding-secret';
+		let hashBrowserSecret, buildBrowserSecretCookie;
 
 		beforeEach(async () => {
-			({ hashConsentNonce, buildLoginCookie } = await import('../../dist/lib/mcp/consentBinding.js'));
+			({ hashBrowserSecret, buildBrowserSecretCookie } = await import('../../dist/lib/mcp/consentBinding.js'));
 			// A logged-out flow: no sessionId in the token (the session binding
-			// has nothing to check — the exact gap the nonce cookie closes).
+			// has nothing to check — the exact gap the browser-secret cookie closes).
 			mockProvider.verifyCSRFToken = createMockFn(async () => ({
 				originalUrl: '/dashboard',
 				timestamp: Date.now(),
 				providerName: 'test-provider',
-				loginFlowId: FLOW_ID,
-				browserNonceHash: hashConsentNonce(NONCE),
+				browserNonceHash: hashBrowserSecret(SECRET),
 			}));
 		});
 
 		it('completes when the callback arrives in the browser that initiated the login', async () => {
-			mockRequest.headers.cookie = buildLoginCookie(FLOW_ID, NONCE).split(';')[0];
+			mockRequest.headers.cookie = buildBrowserSecretCookie(SECRET).split(';')[0];
 
 			const result = await handleCallback(
 				mockRequest,
@@ -1499,8 +1489,8 @@ describe('OAuth Handlers', () => {
 			assert.equal(mockRequest.session.update.mock.calls.length, 0);
 		});
 
-		it('rejects when the binding cookie does not hash-match', async () => {
-			mockRequest.headers.cookie = buildLoginCookie(FLOW_ID, 'some-other-browser-nonce').split(';')[0];
+		it('rejects when the browser-secret cookie does not hash-match', async () => {
+			mockRequest.headers.cookie = buildBrowserSecretCookie('some-other-browser-secret').split(';')[0];
 
 			const result = await handleCallback(
 				mockRequest,

--- a/test/lib/handlers.test.js
+++ b/test/lib/handlers.test.js
@@ -137,6 +137,19 @@ describe('OAuth Handlers', () => {
 			assert.equal(csrfCall.arguments[0].originalUrl, '/steal');
 		});
 
+		it('reads referer from a Harper `.asObject` headers wrapper (runtime shape)', async () => {
+			// The live runtime wraps headers behind `.asObject`; direct
+			// `request.headers.referer` is undefined there. Regression guard.
+			const wrapped = {
+				session: mockRequest.session,
+				headers: { asObject: { referer: 'https://app.example.com/deep' } },
+			};
+			await handleLogin(wrapped, mockTarget, mockProvider, mockConfig, 'test-provider', mockLogger);
+
+			const csrfCall = mockProvider.generateCSRFToken.mock.calls[0];
+			assert.equal(csrfCall.arguments[0].originalUrl, '/deep');
+		});
+
 		it('should fall back to postLoginRedirect when no redirect param or referer', async () => {
 			delete mockRequest.headers.referer;
 			await handleLogin(mockRequest, mockTarget, mockProvider, mockConfig, 'test-provider', mockLogger);
@@ -150,6 +163,28 @@ describe('OAuth Handlers', () => {
 
 			const csrfCall = mockProvider.generateCSRFToken.mock.calls[0];
 			assert.equal(csrfCall.arguments[0].sessionId, 'session-123');
+		});
+
+		it('mints a browser-binding nonce: hash in the state token, nonce in a __Host- cookie', async () => {
+			const { hashConsentNonce } = await import('../../dist/lib/mcp/consentBinding.js');
+			const result = await handleLogin(mockRequest, mockTarget, mockProvider, mockConfig, 'test-provider', mockLogger);
+
+			const meta = mockProvider.generateCSRFToken.mock.calls[0].arguments[0];
+			assert.ok(meta.loginFlowId, 'flow id stored in the state token');
+			assert.ok(meta.browserNonceHash, 'nonce hash stored in the state token');
+
+			const setCookie = result.headers['Set-Cookie'];
+			const [pair, ...attrs] = setCookie.split('; ');
+			const eq = pair.indexOf('=');
+			assert.equal(pair.slice(0, eq), `__Host-oauth_login_${meta.loginFlowId}`, 'cookie name embeds the flow id');
+			assert.equal(
+				hashConsentNonce(pair.slice(eq + 1)),
+				meta.browserNonceHash,
+				'cookie value hashes to the bound hash'
+			);
+			for (const attr of ['Path=/', 'Secure', 'HttpOnly', 'SameSite=Lax']) {
+				assert.ok(attrs.includes(attr), `cookie carries ${attr}`);
+			}
 		});
 	});
 
@@ -789,6 +824,16 @@ describe('OAuth Handlers', () => {
 		let storedAuthCodes;
 		// Import lazily so the dist symbol load doesn't happen at file parse.
 		let resetMCPAuthCodesTableCache;
+		let hashConsentNonce, buildConsentCookie;
+
+		// Every /oauth/mcp/authorize flow (CIMD and stored/DCR) now mints a
+		// per-flow nonce cookie and binds its hash into the upstream state; the
+		// callback fails closed without a matching cookie. The default fixtures
+		// below therefore carry a valid binding so the happy-path assertions
+		// exercise the bound flow — tests that need an unbound/mismatched state
+		// override them locally.
+		const MCP_NONCE = 'mcp-branch-consent-nonce';
+		const MCP_FLOW_ID = 'mcpbranchflow';
 
 		const MCP_STATE = {
 			clientId: 'mcp-client-1',
@@ -807,6 +852,7 @@ describe('OAuth Handlers', () => {
 
 		beforeEach(async () => {
 			({ resetMCPAuthCodesTableCache } = await import('../../dist/lib/mcp/authCodeStore.js'));
+			({ hashConsentNonce, buildConsentCookie } = await import('../../dist/lib/mcp/consentBinding.js'));
 			resetMCPAuthCodesTableCache();
 			originalDatabases = global.databases;
 			storedAuthCodes = new Map();
@@ -821,12 +867,14 @@ describe('OAuth Handlers', () => {
 					},
 				},
 			};
-			// Replace verifyCSRFToken to return MCP state by default for this block.
+			// Replace verifyCSRFToken to return a browser-bound MCP state by default.
 			mockProvider.verifyCSRFToken = createMockFn(async () => ({
 				timestamp: Date.now(),
 				providerName: 'test-provider',
-				mcp: { ...MCP_STATE },
+				mcp: { ...MCP_STATE, browserNonceHash: hashConsentNonce(MCP_NONCE), consentFlowId: MCP_FLOW_ID },
 			}));
+			// The initiating browser's per-flow consent cookie accompanies the callback.
+			mockRequest.headers.cookie = buildConsentCookie(MCP_FLOW_ID, MCP_NONCE).split(';')[0];
 		});
 
 		// Restore global.databases in afterEach so a failing assertion mid-test
@@ -1141,11 +1189,17 @@ describe('OAuth Handlers', () => {
 				assert.equal(storedAuthCodes.size, 0);
 			});
 
-			it('DCR flows (no browserNonceHash) are unaffected', async () => {
+			it('fails closed on an MCP state with no browser binding (forged/pre-upgrade state)', async () => {
+				// After the DCR browser-binding fix, EVERY MCP
+				// authorize flow mints a per-flow nonce cookie and binds its hash into
+				// the upstream state. An MCP state that reaches the callback with no
+				// binding is a forged or pre-upgrade in-flight state and must NOT mint
+				// an auth code — this is the authorization-code injection the fix
+				// closes (an attacker-supplied, unbound state fed to a victim).
 				mockProvider.verifyCSRFToken = createMockFn(async () => ({
 					timestamp: Date.now(),
 					providerName: 'test-provider',
-					mcp: { ...MCP_STATE },
+					mcp: { ...MCP_STATE }, // no browserNonceHash / consentFlowId
 				}));
 				delete mockRequest.headers.cookie;
 				const result = await handleCallback(
@@ -1158,7 +1212,11 @@ describe('OAuth Handlers', () => {
 					{ mcpConfig: MCP_CONFIG, logger: mockLogger }
 				);
 				const url = new URL(result.headers.Location);
-				assert.ok(url.searchParams.get('code'), 'DCR callback mints a code without a consent cookie');
+				assert.equal(url.origin + url.pathname, MCP_STATE.redirectUri, 'error routed to the client redirect_uri');
+				assert.equal(url.searchParams.get('error'), 'access_denied');
+				assert.equal(url.searchParams.get('code'), null, 'no auth code minted for an unbound MCP state');
+				assert.equal(storedAuthCodes.size, 0, 'no auth code persisted');
+				assert.equal(mockProvider.exchangeCodeForToken.mock.calls.length, 0, 'upstream code never exchanged');
 			});
 		});
 	});
@@ -1379,6 +1437,148 @@ describe('OAuth Handlers', () => {
 			assert.ok(result.headers.Location.startsWith('https://mcp-client.example.com/cb'));
 			assert.ok(result.headers.Location.includes('error=access_denied'));
 			assert.equal(mockProvider.exchangeCodeForToken.mock.calls.length, 0);
+		});
+	});
+
+	describe('handleCallback — login browser binding', () => {
+		const NONCE = 'login-binding-nonce';
+		const FLOW_ID = 'loginflow';
+		let hashConsentNonce, buildLoginCookie;
+
+		beforeEach(async () => {
+			({ hashConsentNonce, buildLoginCookie } = await import('../../dist/lib/mcp/consentBinding.js'));
+			// A logged-out flow: no sessionId in the token (the session binding
+			// has nothing to check — the exact gap the nonce cookie closes).
+			mockProvider.verifyCSRFToken = createMockFn(async () => ({
+				originalUrl: '/dashboard',
+				timestamp: Date.now(),
+				providerName: 'test-provider',
+				loginFlowId: FLOW_ID,
+				browserNonceHash: hashConsentNonce(NONCE),
+			}));
+		});
+
+		it('completes when the callback arrives in the browser that initiated the login', async () => {
+			mockRequest.headers.cookie = buildLoginCookie(FLOW_ID, NONCE).split(';')[0];
+
+			const result = await handleCallback(
+				mockRequest,
+				mockTarget,
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.status, 302);
+			assert.equal(result.headers.Location, '/dashboard');
+			assert.equal(mockProvider.exchangeCodeForToken.mock.calls.length, 1);
+		});
+
+		it('rejects when the binding cookie is missing — attacker-minted state in a victim browser', async () => {
+			// Attack: the attacker initiates a login (cookie set in THEIR browser),
+			// completes IdP auth as themselves, then feeds the callback URL to the
+			// victim. The victim's browser has no matching cookie — no login.
+			delete mockRequest.headers.cookie;
+
+			const result = await handleCallback(
+				mockRequest,
+				mockTarget,
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.status, 302);
+			assert.equal(result.headers.Location, '/dashboard?error=auth_failed&reason=csrf');
+			// Rejected before any upstream call or session write.
+			assert.equal(mockProvider.exchangeCodeForToken.mock.calls.length, 0);
+			assert.equal(mockRequest.session.update.mock.calls.length, 0);
+		});
+
+		it('rejects when the binding cookie does not hash-match', async () => {
+			mockRequest.headers.cookie = buildLoginCookie(FLOW_ID, 'some-other-browser-nonce').split(';')[0];
+
+			const result = await handleCallback(
+				mockRequest,
+				mockTarget,
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.headers.Location, '/dashboard?error=auth_failed&reason=csrf');
+			assert.equal(mockProvider.exchangeCodeForToken.mock.calls.length, 0);
+		});
+
+		it('tolerates state tokens without a nonce hash (pre-upgrade in-flight logins)', async () => {
+			mockProvider.verifyCSRFToken = createMockFn(async () => ({
+				originalUrl: '/dashboard',
+				timestamp: Date.now(),
+				providerName: 'test-provider',
+			}));
+			delete mockRequest.headers.cookie;
+
+			const result = await handleCallback(
+				mockRequest,
+				mockTarget,
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.status, 302);
+			assert.equal(result.headers.Location, '/dashboard');
+		});
+	});
+
+	describe('handleCallback — CRLF-safe error logging (CWE-117)', () => {
+		const CRLF_ERROR = 'access_denied\r\nFORGED line';
+		const CRLF_DESC = 'desc\r\ninjected';
+
+		function targetWith(params) {
+			return { get: createMockFn((key) => params[key]) };
+		}
+
+		it('encodes CR/LF in upstream error params on the no-state path', async () => {
+			const result = await handleCallback(
+				mockRequest,
+				targetWith({ error: CRLF_ERROR, error_description: CRLF_DESC }),
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.status, 302);
+			const logged = mockLogger.error.mock.calls[0].arguments[0];
+			assert.ok(!logged.includes('\r') && !logged.includes('\n'), 'no raw CR/LF reaches the log line');
+			assert.ok(logged.includes('\\r\\n'), 'injected control chars are visibly encoded');
+		});
+
+		it('encodes CR/LF in upstream error params on the verified-state path', async () => {
+			const result = await handleCallback(
+				mockRequest,
+				targetWith({ state: 'csrf-token-123', error: CRLF_ERROR, error_description: CRLF_DESC }),
+				mockProvider,
+				mockConfig,
+				mockHookManager,
+				'test-provider',
+				{ logger: mockLogger }
+			);
+
+			assert.equal(result.status, 302);
+			const logged = mockLogger.error.mock.calls[0].arguments[0];
+			assert.ok(!logged.includes('\r') && !logged.includes('\n'), 'no raw CR/LF reaches the log line');
+			assert.ok(logged.includes('\\r\\n'), 'injected control chars are visibly encoded');
 		});
 	});
 });

--- a/test/lib/mcp/authorize.test.js
+++ b/test/lib/mcp/authorize.test.js
@@ -542,6 +542,31 @@ describe('handleAuthorize', () => {
 			);
 		});
 
+		it('emits the stable browser-binding cookie over plain HTTP (loopback is a web-platform secure context)', async () => {
+			// Per the web platform spec, http://127.0.0.1 is a secure context and
+			// browsers accept __Host- cookies served over loopback plain HTTP.
+			// The integration test fixture runs over plain HTTP, so the server must
+			// NOT gate the Set-Cookie on TLS — an HTTP/HTTPS conditional would cause
+			// the integration test to see no cookie even though the handler returned one.
+			// Use a fixed issuer so validateCanonicalResource resolves the same value
+			// regardless of request protocol/host.
+			const { entries } = newRegistry();
+			const configWithFixedIssuer = { enabled: true, issuer: 'https://mcp.example.com' };
+			const target = makeTarget({ ...BASE_QUERY, resource: 'https://mcp.example.com/mcp' });
+			const httpRequest = makeRequest({
+				protocol: 'http',
+				host: '127.0.0.1:9998',
+				headers: { host: '127.0.0.1:9998' },
+			});
+			const response = await handleAuthorize(httpRequest, target, configWithFixedIssuer, entries);
+
+			assert.equal(response.status, 302);
+			const setCookie = response.headers['Set-Cookie'];
+			assert.ok(setCookie, 'Set-Cookie must be present even over plain HTTP (loopback = secure context)');
+			assert.match(setCookie, new RegExp(`^${BROWSER_SECRET_COOKIE_NAME}=`), 'stable cookie name present');
+			assert.match(setCookie, /Secure/, 'Secure attribute always emitted (browsers accept over loopback)');
+		});
+
 		it('accepts a redirect_uri that matches the registered loopback URI', async () => {
 			const { entries } = newRegistry();
 			const target = makeTarget({ ...BASE_QUERY, redirect_uri: 'http://localhost:6274/cb' });

--- a/test/lib/mcp/authorize.test.js
+++ b/test/lib/mcp/authorize.test.js
@@ -882,6 +882,23 @@ describe('handleAuthorizeConfirm', () => {
 		assert.match(result.headers.Location, /upstream\.example\.com/);
 	});
 
+	it('confirm does not re-mint a binding cookie — the interstitial cookie is preserved (CIMD)', async () => {
+		// The interstitial already set the per-flow cookie and bound its hash into
+		// this state; performUpstreamRedirect must see the hash present and NOT mint
+		// a second cookie. Overwriting it would break the callback's binding check.
+		const { entries, provider } = makeProviderWithCsrf();
+		const token = await provider.generateCSRFToken({ providerName: 'github', mcp: MCP_STATE, _confirm: true });
+
+		const result = await handleAuthorizeConfirm(
+			makeConsentRequest(),
+			{ confirm_token: token },
+			{ enabled: true },
+			entries
+		);
+		assert.equal(result.status, 302);
+		assert.equal(result.headers['Set-Cookie'], undefined, 'no new/overwriting binding cookie on confirm');
+	});
+
 	it('token is single-use: second confirm returns 400', async () => {
 		const { entries, provider } = makeProviderWithCsrf();
 		const token = await provider.generateCSRFToken({

--- a/test/lib/mcp/authorize.test.js
+++ b/test/lib/mcp/authorize.test.js
@@ -445,6 +445,32 @@ describe('handleAuthorize', () => {
 			assert.equal(harnesses.github.generatedTokens[0].sessionId, undefined);
 		});
 
+		it('mints a per-flow consent cookie and binds its hash into the DCR upstream state', async () => {
+			// Stored/DCR clients skip the CIMD interstitial, so the browser binding
+			// must be minted here on the direct redirect. Without it an anonymous
+			// initiator (no sessionId) leaves the callback with nothing to prove the
+			// flow completes in the initiating browser — the authorization-code
+			// injection this closes.
+			const { entries, harnesses } = newRegistry();
+			const target = makeTarget(BASE_QUERY);
+			const response = await handleAuthorize(makeRequest(), target, validConfig, entries);
+
+			assert.equal(response.status, 302);
+			const setCookie = response.headers['Set-Cookie'];
+			assert.ok(setCookie, 'stored/DCR authorize sets the per-flow browser-binding cookie');
+			assert.match(setCookie, /^__Host-mcp_consent_[A-Za-z0-9_-]+=/, 'per-flow __Host- cookie');
+			assert.match(setCookie, /HttpOnly/);
+			assert.match(setCookie, /Secure/);
+			assert.match(setCookie, /SameSite=Lax/);
+			assert.doesNotMatch(setCookie, /Domain=/i, '__Host- forbids Domain (blocks sibling injection)');
+
+			const [cookieName, nonce] = setCookie.split(';')[0].split('=');
+			const flowId = cookieName.replace('__Host-mcp_consent_', '');
+			const minted = harnesses.github.generatedTokens[0];
+			assert.equal(minted.mcp.consentFlowId, flowId, 'upstream state carries the cookie flow id');
+			assert.equal(minted.mcp.browserNonceHash, hashConsentNonce(nonce), 'upstream state carries sha256(cookie nonce)');
+		});
+
 		it('accepts a redirect_uri that matches the registered loopback URI', async () => {
 			const { entries } = newRegistry();
 			const target = makeTarget({ ...BASE_QUERY, redirect_uri: 'http://localhost:6274/cb' });

--- a/test/lib/mcp/authorize.test.js
+++ b/test/lib/mcp/authorize.test.js
@@ -14,7 +14,11 @@ import {
 } from '../../../dist/lib/mcp/authorize.js';
 import { resetMCPClientsTableCache } from '../../../dist/lib/mcp/clientStore.js';
 import { _setDnsLookup, _setFetch, _clearCimdCache } from '../../../dist/lib/mcp/cimd.js';
-import { buildConsentCookie, hashConsentNonce } from '../../../dist/lib/mcp/consentBinding.js';
+import {
+	BROWSER_SECRET_COOKIE_NAME,
+	buildBrowserSecretCookie,
+	hashBrowserSecret,
+} from '../../../dist/lib/mcp/consentBinding.js';
 
 /**
  * Minimal RequestTarget stub for the existing target.get?.() pattern.
@@ -508,7 +512,7 @@ describe('handleAuthorize', () => {
 			assert.equal(harnesses.github.generatedTokens[0].sessionId, undefined);
 		});
 
-		it('mints a per-flow consent cookie and binds its hash into the DCR upstream state', async () => {
+		it('mints a stable browser-secret cookie and binds its hash into the DCR upstream state', async () => {
 			// Stored/DCR clients skip the CIMD interstitial, so the browser binding
 			// must be minted here on the direct redirect. Without it an anonymous
 			// initiator (no sessionId) leaves the callback with nothing to prove the
@@ -520,18 +524,22 @@ describe('handleAuthorize', () => {
 
 			assert.equal(response.status, 302);
 			const setCookie = response.headers['Set-Cookie'];
-			assert.ok(setCookie, 'stored/DCR authorize sets the per-flow browser-binding cookie');
-			assert.match(setCookie, /^__Host-mcp_consent_[A-Za-z0-9_-]+=/, 'per-flow __Host- cookie');
+			assert.ok(setCookie, 'stored/DCR authorize sets the stable browser-binding cookie');
+			// Stable cookie: exactly __Host-oauth_browser (no per-flow suffix)
+			assert.match(setCookie, new RegExp(`^${BROWSER_SECRET_COOKIE_NAME}=`), 'stable __Host- cookie name');
 			assert.match(setCookie, /HttpOnly/);
 			assert.match(setCookie, /Secure/);
 			assert.match(setCookie, /SameSite=Lax/);
 			assert.doesNotMatch(setCookie, /Domain=/i, '__Host- forbids Domain (blocks sibling injection)');
 
-			const [cookieName, nonce] = setCookie.split(';')[0].split('=');
-			const flowId = cookieName.replace('__Host-mcp_consent_', '');
+			const secret = setCookie.split(';')[0].split('=').slice(1).join('=');
 			const minted = harnesses.github.generatedTokens[0];
-			assert.equal(minted.mcp.consentFlowId, flowId, 'upstream state carries the cookie flow id');
-			assert.equal(minted.mcp.browserNonceHash, hashConsentNonce(nonce), 'upstream state carries sha256(cookie nonce)');
+			assert.equal(minted.mcp.consentFlowId, undefined, 'no per-flow id in upstream state (stable cookie)');
+			assert.equal(
+				minted.mcp.browserNonceHash,
+				hashBrowserSecret(secret),
+				'upstream state carries sha256(browser secret)'
+			);
 		});
 
 		it('accepts a redirect_uri that matches the registered loopback URI', async () => {
@@ -773,25 +781,25 @@ describe('handleAuthorize — CIMD interstitial', () => {
 		assert.equal(response.headers['Cache-Control'], 'no-store');
 	});
 
-	it('sets the consent cookie whose hash is bound into the confirm token state', async () => {
+	it('sets the stable browser-secret cookie whose hash is bound into the confirm token state', async () => {
 		_setFetch(makeCimdFetch(makeCimdDoc(CIMD_CLIENT_ID)));
 		const { entries, harnesses } = makeProviderRegistry('github');
 		const response = await handleAuthorize(makeRequest(), makeTarget(CIMD_QUERY), { enabled: true }, entries);
 
 		const setCookie = response.headers['Set-Cookie'];
-		assert.ok(setCookie, 'interstitial sets the consent cookie');
-		assert.match(setCookie, /^__Host-mcp_consent_[A-Za-z0-9_-]+=/, 'per-flow __Host- cookie');
+		assert.ok(setCookie, 'interstitial sets the stable browser-secret cookie');
+		// Stable cookie: exactly __Host-oauth_browser (no per-flow suffix)
+		assert.match(setCookie, new RegExp(`^${BROWSER_SECRET_COOKIE_NAME}=`), 'stable __Host- cookie name');
 		assert.match(setCookie, /HttpOnly/);
 		assert.match(setCookie, /Secure/);
 		assert.match(setCookie, /SameSite=Lax/);
 		assert.doesNotMatch(setCookie, /Domain=/i, '__Host- forbids Domain (blocks sibling injection)');
 
-		const [cookieName, nonce] = setCookie.split(';')[0].split('=');
-		const flowId = cookieName.replace('__Host-mcp_consent_', '');
+		const secret = setCookie.split(';')[0].split('=').slice(1).join('=');
 		const minted = harnesses.github.generatedTokens[0];
 		assert.equal(minted._confirm, true);
-		assert.equal(minted.mcp.consentFlowId, flowId, 'state carries the cookie flow id');
-		assert.equal(minted.mcp.browserNonceHash, hashConsentNonce(nonce), 'state carries sha256(cookie nonce)');
+		assert.equal(minted.mcp.consentFlowId, undefined, 'no per-flow id in confirm state (stable cookie)');
+		assert.equal(minted.mcp.browserNonceHash, hashBrowserSecret(secret), 'state carries sha256(browser secret)');
 	});
 
 	it('displays the authoritative client_id hostname and labels client_uri unverified', async () => {
@@ -860,8 +868,7 @@ describe('handleAuthorize — CIMD interstitial', () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe('handleAuthorizeConfirm', () => {
-	const NONCE = 'test-consent-nonce';
-	const FLOW_ID = 'testflowid';
+	const SECRET = 'test-browser-secret';
 	const MCP_STATE = {
 		clientId: 'https://mcp-client.example.com/client.json',
 		resource: 'https://app.example.com/mcp',
@@ -870,14 +877,13 @@ describe('handleAuthorizeConfirm', () => {
 		redirectUri: 'https://mcp-client.example.com/cb',
 		scope: 'mcp:read',
 		clientState: 'state-xyz',
-		browserNonceHash: hashConsentNonce(NONCE),
-		consentFlowId: FLOW_ID,
+		browserNonceHash: hashBrowserSecret(SECRET),
 	};
 
-	/** Request carrying the per-flow consent nonce cookie, as the interstitial browser would. */
-	function makeConsentRequest(nonce = NONCE, flowId = FLOW_ID) {
+	/** Request carrying the stable browser-secret cookie, as the interstitial browser would. */
+	function makeConsentRequest(secret = SECRET) {
 		return makeRequest({
-			headers: { host: 'app.example.com', cookie: `other=1; ${buildConsentCookie(flowId, nonce).split(';')[0]}` },
+			headers: { host: 'app.example.com', cookie: `other=1; ${buildBrowserSecretCookie(secret).split(';')[0]}` },
 		});
 	}
 
@@ -945,10 +951,10 @@ describe('handleAuthorizeConfirm', () => {
 		assert.match(result.headers.Location, /upstream\.example\.com/);
 	});
 
-	it('confirm does not re-mint a binding cookie — the interstitial cookie is preserved (CIMD)', async () => {
-		// The interstitial already set the per-flow cookie and bound its hash into
-		// this state; performUpstreamRedirect must see the hash present and NOT mint
-		// a second cookie. Overwriting it would break the callback's binding check.
+	it('confirm refreshes the stable browser-secret cookie (rolling Max-Age)', async () => {
+		// performUpstreamRedirect always refreshes the cookie so active browsers
+		// never hit silent expiry. For the CIMD path, the hash is already in the
+		// state from the interstitial — the secret reused from the existing cookie.
 		const { entries, provider } = makeProviderWithCsrf();
 		const token = await provider.generateCSRFToken({ providerName: 'github', mcp: MCP_STATE, _confirm: true });
 
@@ -959,7 +965,12 @@ describe('handleAuthorizeConfirm', () => {
 			entries
 		);
 		assert.equal(result.status, 302);
-		assert.equal(result.headers['Set-Cookie'], undefined, 'no new/overwriting binding cookie on confirm');
+		const setCookie = result.headers['Set-Cookie'];
+		assert.ok(setCookie, 'confirm refreshes the stable browser-secret cookie');
+		assert.match(setCookie, new RegExp(`^${BROWSER_SECRET_COOKIE_NAME}=`), 'same stable cookie name');
+		// The refreshed cookie carries the same secret value (existing secret reused).
+		const secret = setCookie.split(';')[0].split('=').slice(1).join('=');
+		assert.equal(secret, SECRET, 'same secret refreshed, not a new one');
 	});
 
 	it('token is single-use: second confirm returns 400', async () => {
@@ -1029,7 +1040,7 @@ describe('handleAuthorizeConfirm', () => {
 		});
 
 		const result = await handleAuthorizeConfirm(
-			makeConsentRequest('a-different-nonce'),
+			makeConsentRequest('a-different-browser-secret'),
 			{ confirm_token: token },
 			{ enabled: true },
 			entries

--- a/test/lib/mcp/consentBinding.test.js
+++ b/test/lib/mcp/consentBinding.test.js
@@ -1,100 +1,141 @@
 /**
- * Tests for the CIMD consent browser-binding helpers (per-flow __Host- cookie).
+ * Tests for the stable browser-binding cookie helpers.
+ *
+ * #205: per-flow cookies collapsed to one stable __Host-oauth_browser secret.
  */
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-	buildConsentCookie,
-	consentNonceMatches,
-	generateConsentFlowId,
-	generateConsentNonce,
-	hashConsentNonce,
-	readConsentNonce,
-	readLoginNonce,
+	BROWSER_SECRET_COOKIE_NAME,
+	browserSecretMatches,
+	buildBrowserSecretCookie,
+	generateBrowserSecret,
+	hashBrowserSecret,
+	readBrowserSecret,
 } from '../../../dist/lib/mcp/consentBinding.js';
 
 describe('consentBinding', () => {
-	it('generates unique url-safe flow ids and nonces', () => {
-		assert.notEqual(generateConsentFlowId(), generateConsentFlowId());
-		assert.notEqual(generateConsentNonce(), generateConsentNonce());
-		assert.match(generateConsentFlowId(), /^[A-Za-z0-9_-]+$/);
-		assert.match(generateConsentNonce(), /^[A-Za-z0-9_-]{40,}$/);
+	it('generates unique url-safe browser secrets', () => {
+		assert.notEqual(generateBrowserSecret(), generateBrowserSecret());
+		assert.match(generateBrowserSecret(), /^[A-Za-z0-9_-]{40,}$/);
 	});
 
-	it('buildConsentCookie uses a __Host- per-flow name and required attributes', () => {
-		const cookie = buildConsentCookie('flow123', 'nonce-value');
-		assert.match(cookie, /^__Host-mcp_consent_flow123=nonce-value; /);
+	it('buildBrowserSecretCookie uses the stable __Host- name and required attributes', () => {
+		const cookie = buildBrowserSecretCookie('secret-value');
+		assert.match(cookie, new RegExp(`^${BROWSER_SECRET_COOKIE_NAME}=secret-value; `));
 		assert.match(cookie, /Secure/);
 		assert.match(cookie, /HttpOnly/);
 		assert.match(cookie, /SameSite=Lax/);
 		assert.match(cookie, /Path=\//);
 		assert.match(cookie, /Max-Age=\d+/);
-		// __Host- forbids a Domain attribute (that's what blocks sibling injection).
+		// __Host- forbids a Domain attribute (blocks sibling injection).
 		assert.doesNotMatch(cookie, /Domain=/i);
 	});
 
-	it('readConsentNonce reads the per-flow cookie among others', () => {
-		const request = { headers: { cookie: `a=1; __Host-mcp_consent_flowA=the-nonce ; b=2` } };
-		assert.equal(readConsentNonce(request, 'flowA'), 'the-nonce');
+	it('readBrowserSecret reads the stable cookie from a plain object header', () => {
+		const request = { headers: { cookie: `a=1; ${BROWSER_SECRET_COOKIE_NAME}=my-secret ; b=2` } };
+		assert.equal(readBrowserSecret(request), 'my-secret');
 	});
 
-	it('readConsentNonce is flow-scoped — a different flow id does not match', () => {
-		const request = { headers: { cookie: `__Host-mcp_consent_flowA=nonceA` } };
-		assert.equal(readConsentNonce(request, 'flowB'), undefined);
-		assert.equal(readConsentNonce(request, undefined), undefined);
+	it('readBrowserSecret returns undefined when absent', () => {
+		assert.equal(readBrowserSecret(undefined), undefined);
+		assert.equal(readBrowserSecret({ headers: {} }), undefined);
+		assert.equal(readBrowserSecret({ headers: { cookie: '' } }), undefined);
+		assert.equal(readBrowserSecret({ headers: { cookie: 'other=1' } }), undefined);
+		assert.equal(readBrowserSecret({ headers: { cookie: 'no-equals-sign' } }), undefined);
 	});
 
-	it('concurrent flows keep independent cookies', () => {
-		const request = {
-			headers: { cookie: `__Host-mcp_consent_flowA=nonceA; __Host-mcp_consent_flowB=nonceB` },
-		};
-		assert.equal(readConsentNonce(request, 'flowA'), 'nonceA');
-		assert.equal(readConsentNonce(request, 'flowB'), 'nonceB');
+	it('readBrowserSecret reads from a Harper .asObject headers wrapper', () => {
+		const request = { headers: { asObject: { cookie: `x=1; ${BROWSER_SECRET_COOKIE_NAME}=wrapped-secret` } } };
+		assert.equal(readBrowserSecret(request), 'wrapped-secret');
 	});
 
-	it('readConsentNonce returns undefined when absent or malformed', () => {
-		assert.equal(readConsentNonce(undefined, 'f'), undefined);
-		assert.equal(readConsentNonce({ headers: {} }, 'f'), undefined);
-		assert.equal(readConsentNonce({ headers: { cookie: '' } }, 'f'), undefined);
-		assert.equal(readConsentNonce({ headers: { cookie: 'other=1' } }, 'f'), undefined);
-		assert.equal(readConsentNonce({ headers: { cookie: 'no-equals-sign' } }, 'f'), undefined);
+	it('readBrowserSecret reads from a Web Headers object (.get)', () => {
+		const request = { headers: new Headers({ cookie: `${BROWSER_SECRET_COOKIE_NAME}=web-headers-secret` }) };
+		assert.equal(readBrowserSecret(request), 'web-headers-secret');
 	});
 
-	// Regression: the live Harper runtime passes headers as a wrapper exposing
-	// only `.asObject` (or a Web `Headers` with `.get()`), NOT a plain object.
-	// Reading `request.headers.cookie` directly returns undefined there, which
-	// fails every browser-binding check closed. Cover both wrapper shapes.
-	it('readConsentNonce reads the cookie from a Harper `.asObject` headers wrapper', () => {
-		const request = { headers: { asObject: { cookie: `x=1; __Host-mcp_consent_flowA=wrapped-nonce` } } };
-		assert.equal(readConsentNonce(request, 'flowA'), 'wrapped-nonce');
+	it('finds the binding cookie when the Cookie header is an array (HTTP/2 crumbling)', () => {
+		const request = { headers: { cookie: ['other=1', `${BROWSER_SECRET_COOKIE_NAME}=array-secret`, 'z=2'] } };
+		assert.equal(readBrowserSecret(request), 'array-secret');
 	});
 
-	it('readConsentNonce reads the cookie from a Web `Headers` object (.get)', () => {
-		const request = { headers: new Headers({ cookie: `__Host-mcp_consent_flowA=header-nonce` }) };
-		assert.equal(readConsentNonce(request, 'flowA'), 'header-nonce');
+	it('finds the binding cookie in an array via .asObject wrapper', () => {
+		const request = { headers: { asObject: { cookie: ['a=1', `${BROWSER_SECRET_COOKIE_NAME}=array-obj-secret`] } } };
+		assert.equal(readBrowserSecret(request), 'array-obj-secret');
 	});
 
-	// Regression: repeated Cookie header lines (HTTP/2 crumbling, or a transport
-	// that keeps them as an array) must ALL be parsed — the binding cookie may not
-	// be the first element. Joining with "; " keeps the flow working.
-	it('finds the binding cookie when the Cookie header is an array (non-first crumb)', () => {
-		const request = { headers: { cookie: ['other=1', `__Host-mcp_consent_flowA=array-nonce`, 'z=2'] } };
-		assert.equal(readConsentNonce(request, 'flowA'), 'array-nonce');
+	it('browserSecretMatches round-trips and rejects mismatches', () => {
+		const secret = generateBrowserSecret();
+		const hash = hashBrowserSecret(secret);
+		assert.equal(browserSecretMatches(secret, hash), true);
+		assert.equal(browserSecretMatches('other-secret', hash), false);
+		assert.equal(browserSecretMatches(undefined, hash), false);
+		assert.equal(browserSecretMatches(secret, undefined), false);
+		assert.equal(browserSecretMatches(secret, 'not-a-hash'), false);
 	});
 
-	it('finds the binding cookie in an array delivered via the `.asObject` wrapper', () => {
-		const request = { headers: { asObject: { cookie: ['a=1', `__Host-oauth_login_flowB=login-array-nonce`] } } };
-		assert.equal(readLoginNonce(request, 'flowB'), 'login-array-nonce');
+	// --- #205 exhaustion-regression tests ---
+
+	it('#205 (a): N repeated flow initiations leave exactly ONE stable cookie — no accumulation', () => {
+		// Simulate a browser that already has the stable cookie.
+		const firstSecret = generateBrowserSecret();
+		const requestWithCookie = { headers: { cookie: `${BROWSER_SECRET_COOKIE_NAME}=${firstSecret}` } };
+
+		// Each flow initiation should read the existing secret and produce ONE cookie.
+		const cookies = [];
+		for (let i = 0; i < 10; i++) {
+			const existingSecret = readBrowserSecret(requestWithCookie);
+			const browserSecret = existingSecret ?? generateBrowserSecret();
+			cookies.push(buildBrowserSecretCookie(browserSecret));
+		}
+
+		// All cookies should use the SAME stable name (no per-flow suffix).
+		for (const cookie of cookies) {
+			assert.match(cookie, new RegExp(`^${BROWSER_SECRET_COOKIE_NAME}=`), 'stable name only');
+			// Must not contain any per-flow variant name.
+			assert.doesNotMatch(cookie, /__Host-mcp_consent_|__Host-oauth_login_/);
+		}
+
+		// All cookies carry the same secret (the pre-existing one is reused).
+		const secrets = cookies.map((c) => c.split(';')[0].split('=').slice(1).join('='));
+		assert.ok(
+			secrets.every((s) => s === firstSecret),
+			'reuses the existing secret across all flow initiations'
+		);
+
+		// Only ONE distinct cookie name appears, regardless of how many flows ran.
+		const names = new Set(cookies.map((c) => c.split('=')[0]));
+		assert.equal(names.size, 1, 'exactly one cookie name produced across all flows');
 	});
 
-	it('consentNonceMatches round-trips and rejects mismatches', () => {
-		const nonce = generateConsentNonce();
-		const hash = hashConsentNonce(nonce);
-		assert.equal(consentNonceMatches(nonce, hash), true);
-		assert.equal(consentNonceMatches('other-nonce', hash), false);
-		assert.equal(consentNonceMatches(undefined, hash), false);
-		assert.equal(consentNonceMatches(nonce, undefined), false);
-		assert.equal(consentNonceMatches(nonce, 'not-a-hash'), false);
+	it('#205 (b): binding still rejects cross-browser completion (security property survives)', () => {
+		// Browser A initiates the flow.
+		const secretA = generateBrowserSecret();
+		const hashA = hashBrowserSecret(secretA);
+
+		// Browser B's cookie (different secret) attempts to complete the flow.
+		const secretB = generateBrowserSecret();
+
+		assert.equal(browserSecretMatches(secretB, hashA), false, 'cross-browser attempt rejected');
+		assert.equal(browserSecretMatches(secretA, hashA), true, 'initiating browser accepted');
+	});
+
+	it('#205 (c): stable secret survives an abandoned flow and still binds the next one', () => {
+		// Browser has the stable cookie.
+		const secret = generateBrowserSecret();
+		const requestWithCookie = { headers: { cookie: `${BROWSER_SECRET_COOKIE_NAME}=${secret}` } };
+
+		// Flow 1 is initiated.
+		const hash1 = hashBrowserSecret(readBrowserSecret(requestWithCookie) ?? generateBrowserSecret());
+		assert.equal(browserSecretMatches(secret, hash1), true, 'flow 1 bound');
+
+		// Flow 1 is abandoned (no completion). Browser initiates flow 2.
+		const hash2 = hashBrowserSecret(readBrowserSecret(requestWithCookie) ?? generateBrowserSecret());
+		assert.equal(browserSecretMatches(secret, hash2), true, 'flow 2 also bound by same secret');
+
+		// The hashes are identical (same secret, same hash function).
+		assert.equal(hash1, hash2, 'stable secret produces stable hash across flows');
 	});
 });

--- a/test/lib/mcp/consentBinding.test.js
+++ b/test/lib/mcp/consentBinding.test.js
@@ -60,6 +60,20 @@ describe('consentBinding', () => {
 		assert.equal(readConsentNonce({ headers: { cookie: 'no-equals-sign' } }, 'f'), undefined);
 	});
 
+	// Regression: the live Harper runtime passes headers as a wrapper exposing
+	// only `.asObject` (or a Web `Headers` with `.get()`), NOT a plain object.
+	// Reading `request.headers.cookie` directly returns undefined there, which
+	// fails every browser-binding check closed. Cover both wrapper shapes.
+	it('readConsentNonce reads the cookie from a Harper `.asObject` headers wrapper', () => {
+		const request = { headers: { asObject: { cookie: `x=1; __Host-mcp_consent_flowA=wrapped-nonce` } } };
+		assert.equal(readConsentNonce(request, 'flowA'), 'wrapped-nonce');
+	});
+
+	it('readConsentNonce reads the cookie from a Web `Headers` object (.get)', () => {
+		const request = { headers: new Headers({ cookie: `__Host-mcp_consent_flowA=header-nonce` }) };
+		assert.equal(readConsentNonce(request, 'flowA'), 'header-nonce');
+	});
+
 	it('consentNonceMatches round-trips and rejects mismatches', () => {
 		const nonce = generateConsentNonce();
 		const hash = hashConsentNonce(nonce);

--- a/test/lib/mcp/consentBinding.test.js
+++ b/test/lib/mcp/consentBinding.test.js
@@ -11,6 +11,7 @@ import {
 	generateConsentNonce,
 	hashConsentNonce,
 	readConsentNonce,
+	readLoginNonce,
 } from '../../../dist/lib/mcp/consentBinding.js';
 
 describe('consentBinding', () => {
@@ -72,6 +73,19 @@ describe('consentBinding', () => {
 	it('readConsentNonce reads the cookie from a Web `Headers` object (.get)', () => {
 		const request = { headers: new Headers({ cookie: `__Host-mcp_consent_flowA=header-nonce` }) };
 		assert.equal(readConsentNonce(request, 'flowA'), 'header-nonce');
+	});
+
+	// Regression: repeated Cookie header lines (HTTP/2 crumbling, or a transport
+	// that keeps them as an array) must ALL be parsed — the binding cookie may not
+	// be the first element. Joining with "; " keeps the flow working.
+	it('finds the binding cookie when the Cookie header is an array (non-first crumb)', () => {
+		const request = { headers: { cookie: ['other=1', `__Host-mcp_consent_flowA=array-nonce`, 'z=2'] } };
+		assert.equal(readConsentNonce(request, 'flowA'), 'array-nonce');
+	});
+
+	it('finds the binding cookie in an array delivered via the `.asObject` wrapper', () => {
+		const request = { headers: { asObject: { cookie: ['a=1', `__Host-oauth_login_flowB=login-array-nonce`] } } };
+		assert.equal(readLoginNonce(request, 'flowB'), 'login-array-nonce');
 	});
 
 	it('consentNonceMatches round-trips and rejects mismatches', () => {

--- a/test/lib/mcp/dcr.test.js
+++ b/test/lib/mcp/dcr.test.js
@@ -146,16 +146,22 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 	describe('rejection log safety (CWE-117)', () => {
 		const config = { enabled: true, dynamicClientRegistration: {} };
 
-		it('CRLF-encodes the attacker-controlled grant_type in the rejected-registration log', async () => {
-			// Open DCR is pre-auth; an invalid grant_type echoes into error_description
+		it('CRLF-encodes attacker-controlled token_endpoint_auth_method in the rejected-registration log', async () => {
+			// Open DCR is pre-auth; an unsupported auth method echoes into error_description
 			// which is logged. A CR/LF in it must not forge a new log line.
+			// (grant_types with CRLF are silently filtered by filterGrantTypes per #200
+			// and never appear in the rejection log; token_endpoint_auth_method is still
+			// echoed verbatim in the validateAuthMethod error string.)
 			const original = harperLogger.warn;
 			const lines = [];
 			harperLogger.warn = (msg) => lines.push(String(msg));
 			try {
 				const res = await handleRegister(
 					makeRequest(),
-					{ redirect_uris: ['https://app.example.com/cb'], grant_types: ['authorization_code\r\nFORGED ENTRY'] },
+					{
+						redirect_uris: ['https://app.example.com/cb'],
+						token_endpoint_auth_method: 'none\r\nFORGED ENTRY',
+					},
 					config
 				);
 				assert.equal(res.status, 400);

--- a/test/lib/mcp/dcr.test.js
+++ b/test/lib/mcp/dcr.test.js
@@ -4,6 +4,7 @@
 
 import { describe, it, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
+import { logger as harperLogger } from 'harper';
 import { handleRegister } from '../../../dist/lib/mcp/dcr.js';
 import { resetMCPClientsTableCache } from '../../../dist/lib/mcp/clientStore.js';
 
@@ -139,6 +140,32 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 			// treat it as "no token presented" — matching the production contract.
 			const response = await handleRegister(makeRequest({ Authorization: 'Bearer secret-token' }), VALID_BODY, config);
 			assert.equal(response.status, 401);
+		});
+	});
+
+	describe('rejection log safety (CWE-117)', () => {
+		const config = { enabled: true, dynamicClientRegistration: {} };
+
+		it('CRLF-encodes the attacker-controlled grant_type in the rejected-registration log', async () => {
+			// Open DCR is pre-auth; an invalid grant_type echoes into error_description
+			// which is logged. A CR/LF in it must not forge a new log line.
+			const original = harperLogger.warn;
+			const lines = [];
+			harperLogger.warn = (msg) => lines.push(String(msg));
+			try {
+				const res = await handleRegister(
+					makeRequest(),
+					{ redirect_uris: ['https://app.example.com/cb'], grant_types: ['authorization_code\r\nFORGED ENTRY'] },
+					config
+				);
+				assert.equal(res.status, 400);
+			} finally {
+				harperLogger.warn = original;
+			}
+			const rejected = lines.find((l) => l.includes('MCP DCR rejected'));
+			assert.ok(rejected, 'a rejection line was logged');
+			assert.ok(!rejected.includes('\r') && !rejected.includes('\n'), 'no raw CR/LF reaches the log line');
+			assert.ok(rejected.includes('\\r\\nFORGED'), 'the injected control chars are visibly encoded');
 		});
 	});
 

--- a/test/lib/mcp/dcr.test.js
+++ b/test/lib/mcp/dcr.test.js
@@ -116,6 +116,11 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 			assert.equal(response.status, 201);
 		});
 
+		it('accepts a matching token with a lowercase `bearer` scheme (RFC 6750 case-insensitive)', async () => {
+			const response = await handleRegister(makeRequest({ authorization: 'bearer secret-token' }), VALID_BODY, config);
+			assert.equal(response.status, 201);
+		});
+
 		it('accepts a matching Bearer token via the Harper `.asObject` headers wrapper (runtime shape)', async () => {
 			// Regression: the live runtime wraps headers behind `.asObject`, so
 			// reading request.headers.authorization directly returns undefined and

--- a/test/lib/mcp/dcr.test.js
+++ b/test/lib/mcp/dcr.test.js
@@ -116,6 +116,18 @@ describe('handleRegister (RFC 7591 DCR)', () => {
 			assert.equal(response.status, 201);
 		});
 
+		it('accepts a matching Bearer token via the Harper `.asObject` headers wrapper (runtime shape)', async () => {
+			// Regression: the live runtime wraps headers behind `.asObject`, so
+			// reading request.headers.authorization directly returns undefined and
+			// the token gate would reject every registration in production.
+			const response = await handleRegister(
+				makeRequest({ asObject: { authorization: 'Bearer secret-token' } }),
+				VALID_BODY,
+				config
+			);
+			assert.equal(response.status, 201);
+		});
+
 		it('rejects the capitalized Authorization header (Node HTTP parser lowercases)', async () => {
 			// Production: incoming headers are lowercased before reaching us.
 			// If a caller hands us a literal { Authorization: ... } object, we

--- a/test/lib/mcp/token.test.js
+++ b/test/lib/mcp/token.test.js
@@ -531,6 +531,45 @@ describe('handleToken', () => {
 		assert.equal(res.body.error, 'invalid_request');
 	});
 
+	it('authenticates client_secret_basic when headers use the Harper `.asObject` wrapper (runtime shape)', async () => {
+		// Regression: the live runtime wraps headers behind `.asObject`, so
+		// reading request.headers.authorization directly returns undefined and
+		// confidential-basic auth would fail closed in production.
+		seedCode('code-1', { client_id: 'conf-1' });
+		const res = await handleToken(
+			{ headers: { asObject: basicHeader('conf-1', CONF_SECRET) } },
+			{ grant_type: 'authorization_code', code: 'code-1', code_verifier: CODE_VERIFIER, redirect_uri: REDIRECT },
+			mcpConfig
+		);
+		assert.equal(res.status, 200);
+		assert.ok(res.body.access_token);
+	});
+
+	it('tolerates a public client presenting an empty Basic secret (client_id only)', async () => {
+		// `Authorization: Basic base64("<client_id>:")` carries only the client_id;
+		// some clients always send it. An empty secret is not "presenting a secret",
+		// so a public client must not be rejected for it.
+		seedCode('code-1'); // public-1
+		const res = await handleToken(
+			{ headers: basicHeader('public-1', '') },
+			{ grant_type: 'authorization_code', code: 'code-1', code_verifier: CODE_VERIFIER, redirect_uri: REDIRECT },
+			mcpConfig
+		);
+		assert.equal(res.status, 200, 'empty Basic secret tolerated as no-secret for a public client');
+		assert.ok(res.body.access_token);
+	});
+
+	it('still rejects a public client that presents a real (non-empty) Basic secret', async () => {
+		seedCode('code-1'); // public-1
+		const res = await handleToken(
+			{ headers: basicHeader('public-1', 'unexpected-secret') },
+			{ grant_type: 'authorization_code', code: 'code-1', code_verifier: CODE_VERIFIER, redirect_uri: REDIRECT },
+			mcpConfig
+		);
+		assert.equal(res.status, 401);
+		assert.equal(res.body.error, 'invalid_client');
+	});
+
 	it('authenticates a confidential client via client_secret_post (secret in body)', async () => {
 		clients.set('post-1', {
 			client_id: 'post-1',

--- a/test/lib/mcp/token.test.js
+++ b/test/lib/mcp/token.test.js
@@ -503,6 +503,18 @@ describe('handleToken', () => {
 		assert.ok(res.body.access_token);
 	});
 
+	it('authenticates client_secret_basic with a lowercase `basic` scheme (RFC 9110 case-insensitive)', async () => {
+		seedCode('code-1', { client_id: 'conf-1' });
+		const lower = { authorization: basicHeader('conf-1', CONF_SECRET).authorization.replace(/^Basic /, 'basic ') };
+		const res = await handleToken(
+			{ headers: lower },
+			{ grant_type: 'authorization_code', code: 'code-1', code_verifier: CODE_VERIFIER, redirect_uri: REDIRECT },
+			mcpConfig
+		);
+		assert.equal(res.status, 200);
+		assert.ok(res.body.access_token);
+	});
+
 	it('rejects a confidential client with a wrong secret', async () => {
 		seedCode('code-1', { client_id: 'conf-1' });
 		const res = await handleToken(

--- a/test/lib/mcp/token.test.js
+++ b/test/lib/mcp/token.test.js
@@ -7,7 +7,7 @@
 import { describe, it, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHash, generateKeyPairSync, randomBytes, sign } from 'node:crypto';
-import { handleToken, _resetGrantRateLimiter } from '../../../dist/lib/mcp/token.js';
+import { handleToken, parseBasicAuth, _resetGrantRateLimiter } from '../../../dist/lib/mcp/token.js';
 import { resetMCPAssertionJtisTableCache } from '../../../dist/lib/mcp/assertionJtiStore.js';
 import { resetMCPAuthCodesTableCache } from '../../../dist/lib/mcp/authCodeStore.js';
 import { _clearCimdCache, _setDnsLookup, _setFetch } from '../../../dist/lib/mcp/cimd.js';
@@ -73,6 +73,38 @@ const mcpConfig = {
 function basicHeader(clientId, secret) {
 	return { authorization: `Basic ${Buffer.from(`${clientId}:${secret}`).toString('base64')}` };
 }
+
+describe('parseBasicAuth (RFC 6749 §2.3.1 form-encoding)', () => {
+	const basic = (raw) => `Basic ${Buffer.from(raw).toString('base64')}`;
+
+	it('form-decodes a URL-shaped CIMD client_id presented with an empty secret', () => {
+		// A compliant CIMD client sends its HTTPS client_id form-urlencoded, empty
+		// secret. Must decode back to the real URL, not be looked up as `%3A%2F…`.
+		const r = parseBasicAuth(basic('https%3A%2F%2Fclient.example%2Fmetadata:'));
+		assert.deepEqual(r, { clientId: 'https://client.example/metadata', clientSecret: '' });
+	});
+
+	it('form-decodes both fields (percent + plus)', () => {
+		const r = parseBasicAuth(basic('a%2Bb:p%20q+r'));
+		assert.deepEqual(r, { clientId: 'a+b', clientSecret: 'p q r' });
+	});
+
+	it('leaves opaque ids/secrets (no %/+) unchanged', () => {
+		const r = parseBasicAuth(basic('conf-1:s3cret-value-xyz-0123456789'));
+		assert.deepEqual(r, { clientId: 'conf-1', clientSecret: 's3cret-value-xyz-0123456789' });
+	});
+
+	it('rejects malformed percent-encoding rather than looking up a corrupt id', () => {
+		assert.equal(parseBasicAuth(basic('bad%zz:secret')), null);
+		assert.equal(parseBasicAuth(basic('id:bad%')), null);
+	});
+
+	it('returns null for a non-Basic scheme or a missing separator', () => {
+		assert.equal(parseBasicAuth('Bearer x'), null);
+		assert.equal(parseBasicAuth(basic('no-colon-here')), null);
+		assert.equal(parseBasicAuth(undefined), null);
+	});
+});
 
 describe('handleToken', () => {
 	let originalDatabases;

--- a/test/lib/mcp/wellKnown.test.js
+++ b/test/lib/mcp/wellKnown.test.js
@@ -44,6 +44,17 @@ describe('MCP well-known: URI resolution', () => {
 		assert.equal(resolveIssuer(req, {}), 'https://auto.example.com');
 	});
 
+	it('resolveIssuer reads the Host header from a Harper `.asObject` wrapper when request.host is absent', () => {
+		// Runtime shape: request.host may be unset and headers is the `.asObject`
+		// wrapper, so a direct `headers.host` read would miss it.
+		const req = makeRequest({
+			protocol: 'https',
+			host: undefined,
+			headers: { asObject: { host: 'wrapped.example.com' } },
+		});
+		assert.equal(resolveIssuer(req, {}), 'https://wrapped.example.com');
+	});
+
 	it('resolveIssuer takes the first value when the Host header is an array', async () => {
 		const req = makeRequest({ protocol: 'https', host: undefined, headers: { host: ['first.example.com', 'second'] } });
 		assert.equal(resolveIssuer(req, {}), 'https://first.example.com');

--- a/test/lib/requestHeaders.test.js
+++ b/test/lib/requestHeaders.test.js
@@ -27,6 +27,15 @@ describe('getRequestHeader', () => {
 		assert.equal(getRequestHeader({ 'x-forwarded-for': ['1.1.1.1', '2.2.2.2'] }, 'x-forwarded-for'), '1.1.1.1');
 	});
 
+	it('always returns a string (or undefined) even for a malformed value', () => {
+		// Non-string first element → coerced to string, not returned raw.
+		assert.strictEqual(getRequestHeader({ cookie: [123] }, 'cookie'), '123');
+		// Empty array → undefined, not the array's missing first element.
+		assert.strictEqual(getRequestHeader({ cookie: [] }, 'cookie'), undefined);
+		// Null first element → undefined.
+		assert.strictEqual(getRequestHeader({ cookie: [null] }, 'cookie'), undefined);
+	});
+
 	it('returns undefined for missing headers or missing container', () => {
 		assert.equal(getRequestHeader(undefined, 'cookie'), undefined);
 		assert.equal(getRequestHeader(null, 'cookie'), undefined);

--- a/test/lib/requestHeaders.test.js
+++ b/test/lib/requestHeaders.test.js
@@ -1,0 +1,36 @@
+/**
+ * Tests for the wrapper-aware request header reader.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { getRequestHeader } from '../../dist/lib/requestHeaders.js';
+
+describe('getRequestHeader', () => {
+	it('reads from a plain IncomingMessage.headers object (tests)', () => {
+		assert.equal(getRequestHeader({ cookie: 'a=1' }, 'cookie'), 'a=1');
+		assert.equal(getRequestHeader({ referer: '/x' }, 'Referer'), '/x', 'name is case-insensitive');
+	});
+
+	it("reads from Harper's runtime `.asObject` headers wrapper", () => {
+		const wrapper = { asObject: { cookie: 'a=1', authorization: 'Bearer t' } };
+		assert.equal(getRequestHeader(wrapper, 'cookie'), 'a=1');
+		assert.equal(getRequestHeader(wrapper, 'authorization'), 'Bearer t');
+	});
+
+	it('reads from a Web `Headers` object via .get()', () => {
+		const headers = new Headers({ cookie: 'a=1' });
+		assert.equal(getRequestHeader(headers, 'cookie'), 'a=1');
+	});
+
+	it('returns the first value when a header is multi-valued', () => {
+		assert.equal(getRequestHeader({ 'x-forwarded-for': ['1.1.1.1', '2.2.2.2'] }, 'x-forwarded-for'), '1.1.1.1');
+	});
+
+	it('returns undefined for missing headers or missing container', () => {
+		assert.equal(getRequestHeader(undefined, 'cookie'), undefined);
+		assert.equal(getRequestHeader(null, 'cookie'), undefined);
+		assert.equal(getRequestHeader({}, 'cookie'), undefined);
+		assert.equal(getRequestHeader({ asObject: {} }, 'cookie'), undefined);
+	});
+});


### PR DESCRIPTION
Binds every browser-initiated OAuth flow — human login and all MCP authorize paths — to the browser that started it, closing a login-CSRF / authorization-code-injection class where an attacker-initiated flow could be completed in a victim's browser.

## Scope

**#203 — browser binding**

- **Human login**: `handleLogin` reads the stable `__Host-oauth_browser` secret (minting one if absent) and stores only its SHA-256 hash in the state token; the callback requires a constant-time match before any upstream exchange or session write. Conditional on hash-presence so in-flight logins survive a rolling deploy.
- **MCP authorize (DCR/stored path)**: the browser binding previously covered only CIMD clients; `performUpstreamRedirect` now reads/generates the stable secret for stored/DCR clients too, stores the hash in upstream state, and the callback fails closed on any MCP state without a matching cookie.
- **MCP authorize (CIMD confirm path)**: the CIMD interstitial embeds the stable hash in the confirm token; `handleAuthorizeConfirm` verifies it before redirecting upstream.
- **Runtime header reads**: binding readers (and the referer/host/authorization reads elsewhere) used `request.headers.<name>` directly, which is undefined against Harper's runtime `.asObject` wrapper — so the binding would have failed silently in production. Consolidated into a shared `getRequestHeader` (Web `Headers` / `.asObject` / plain object) applied across cookie, referer, bearer, host, and MCP token/DCR auth reads.
- **Public-client token check**: now rejects only a non-empty presented secret (tolerates `Basic base64("id:")`) to avoid a client-compat regression.
- **Logging**: `error`/`error_description` callback params are JSON-encoded before logging (CRLF-safe); DCR rejected-registration log uses `token_endpoint_auth_method` echo (attacker-controlled, stringified) instead of grant_type (now silently filtered by `filterGrantTypes`).
- **Auth-scheme matching**: `basic`/`bearer` matched case-insensitively per RFC 9110 / RFC 6750 on token and DCR endpoints.

**#205 — collapse per-flow binding cookies to one stable browser secret**

The original per-flow design minted a new `__Host-` cookie on every flow initiation. With multiple concurrent or abandoned flows a browser accumulates unbounded cookies until the browser's own cookie jar limit evicts earlier flows, causing spurious CSRF rejections. #205 replaces the per-flow nonces with a single stable `__Host-oauth_browser` secret per browser:

- One cookie name, fixed: `__Host-oauth_browser` (Secure, HttpOnly, SameSite=Lax, Path=/, no Domain — satisfies `__Host-` prefix requirements).
- Rolling 7-day Max-Age refreshed on every flow initiation (keeps the cookie alive without proliferating names).
- Only the SHA-256 hash of the secret enters server-side state — the secret never leaves the response cookie.
- Abandoned flows require no cleanup: there are no per-flow rows or cookies to expire; server-side CSRF state rows expire naturally by table TTL.
- `readBrowserSecret` reads across Web Headers / Harper `.asObject` / plain object / HTTP/2-crumbled array cookie headers (kept separate from `getRequestHeader` which returns the first value only — cookie binding needs all crumbs joined).

Closes #205

## Phase 2 guard order in authorize.ts

RFC 6749 §3.1.1 requires that `response_type` be validated before checking client authorization for the requested grant. The authorize handler's Phase 2 guard order is:

1. `redirect_uri` verification (§4.1) — must happen first so the error redirect target is known
2. `response_type !== 'code'` → `unsupported_response_type` (§3.1.1, §4.1.2.1) — spec requires rejecting unsupported types before checking grant authorization
3. `allowsGrant(client, 'authorization_code')` → `unauthorized_client` (§4.1.2.1) — grant-type enforcement

This order is preserved from main (absorbed via merge of origin/main into this branch).

## Verification

Unit tests: **1152 tests, 1150 pass, 0 fail, 2 skipped**. `tsc` clean. `oxlint` 0 errors. Prettier clean.

Integration tests: **15/15 pass**.

New unit coverage:
- **Binding matrix** (login and MCP callback): match / missing cookie / mismatched / unbound state / pre-upgrade hashless token tolerated on login, fail-closed on MCP
- **#205 regression trio** (fails on pre-#205 head — `BROWSER_SECRET_COOKIE_NAME` not exported): (a) N flow initiations → exactly one stable cookie name; (b) cross-browser rejection preserved; (c) stable secret survives abandoned flow and binds next
- **Header shapes**: Web Headers / `.asObject` / plain object / HTTP/2 array crumbs — across binding, referer, bearer, host
- **Auth-scheme case / CRLF**: lowercase basic/bearer; `error_description` CRLF injection logged safely
- **DCR/stored binding**: `browserNonceHash` minted in upstream state; stable cookie name in Set-Cookie header (no `consentFlowId`)
- **Plain-HTTP loopback**: DCR authorize emits `__Host-oauth_browser` Set-Cookie even with `protocol: 'http'` (loopback = web-platform secure context; no server-side TLS gate in the code). Catches future regression if a plain-HTTP conditional is introduced.
- **toHttpResponse passthrough**: `{ status:302, headers:{ Location, 'Set-Cookie' } }` passes through unchanged so Set-Cookie reaches Harper's HTTP layer.

E2e integration test root cause (diagnosed from stale-fixture investigation): the integration-test fixture's `node_modules/@harperfast/oauth` was a gitignored locally-installed copy built from pre-`40a6172` source (per-flow cookie code). After `40a6172` changed the server to emit `__Host-oauth_browser`, the fixture was never rebuilt locally, so the server inside the test still emitted `__Host-mcp_consent_*` while the test (fixed in 9520680) looked for `__Host-oauth_browser`. Server code is unconditionally correct — no plain-HTTP gate. CI is unaffected (integration-tests.yml runs `npm run install:fixtures` before `npm run test:integration`). Local fix: `npm run install:fixtures` after source changes. The two new unit tests document and guard the server's unconditional cookie emission.

Coverage honest caveats:
- No unit coverage of concurrent fresh-browser flows (two cookie-less tabs racing to set the singleton); self-healing (only first flow fails; retry succeeds with stable cookie), rare in practice.
- Rolling-deploy: in-flight MCP states minted by pre-upgrade code have no `browserNonceHash` and are rejected fail-closed; bounded by state TTL (10 min); login states are tolerated (conditional check).

Pre-push review: codex + gemini + harper-domain at 9520680 (session 019ffc79-749, domain 4b7ddba8-8ae).

## Decision ledger (open for human review)

- **stable-browser-cookie-vs-per-flow**: one 7-day stable secret vs capped per-flow cookies — trades #205's exhaustion for a long-lived per-browser identifier and a rare first-use concurrency race.
- **asymmetric-rollout-tolerance**: login callbacks tolerate hashless pre-upgrade states; MCP callbacks fail closed — a reviewer may demand symmetry; the tolerant branch is safe to delete post-deploy.
- **no-plain-http-escape-hatch**: hard `__Host-`/Secure requirement with no config opt-out. Loopback (127.0.0.1) is a web-platform secure context and browsers accept `__Host-` cookies over plain HTTP there — the integration fixture and local dev both work. The gap is non-loopback plain-HTTP deployments (e.g., `http://192.168.1.x`): browsers will not send back Secure cookies, every callback gets CSRF-rejected, and the error message says "reason=csrf" rather than "serve Harper behind TLS". No config escape-hatch means no way to recover short of adding TLS.
- **empty-basic-secret-tolerance**: `Basic base64("id:")` treated as no-secret-presented for public clients vs strict rejection.
- **cookie-parser-fork-vs-shared-helper**: `readCookieHeader` (joins all crumbs) alongside `getRequestHeader` (first value) vs one helper with an all-values mode.

## Human-Review-Need

**4** open decisions (see decision ledger above). No new production defects found by cross-model review beyond the stale fixture (fixed locally; CI was always correct). Minor known limitations noted in coverage caveats.