### PR TITLE
Roll out reliable AI review evidence in OAuth

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,7 @@ jobs:
     # Note: the `claude-review` label name is matched there too —
     # `_claude-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.CLAUDE_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@224c2adcfdb408d68c7ca48eb618623c990a96ad # main 2026-07-28 (#80 week-of-07-20 calibration: producing-side guard verification; on 82c9484)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_claude-review.yml@4b59dc0ddb15aff517884127b58204f79193b4f2 # main 2026-08-20 (#86 reliable review evidence, context, and run binding)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job
     # grants below what they need and breaks the workflow at startup;
@@ -58,7 +58,7 @@ jobs:
       # introspect their own ref (`github.workflow_ref` resolves to the
       # CALLER's ref in `workflow_call` context), and `uses: …@<ref>`
       # is parsed literally so we can't interpolate a variable.
-      ai-review-prompts-ref: 224c2adcfdb408d68c7ca48eb618623c990a96ad
+      ai-review-prompts-ref: 4b59dc0ddb15aff517884127b58204f79193b4f2
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -45,7 +45,7 @@ jobs:
     # Note: the `gemini-review` label name is matched there too —
     # `_gemini-review.yml`'s authorize `if:`, not in this caller.
     if: ${{ vars.GEMINI_ALWAYS_ON == 'true' || github.event.action == 'labeled' }}
-    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@224c2adcfdb408d68c7ca48eb618623c990a96ad # main 2026-07-28 (#80 week-of-07-20 calibration: producing-side guard verification; on 82c9484)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_gemini-review.yml@4b59dc0ddb15aff517884127b58204f79193b4f2 # main 2026-08-20 (#86 reliable review evidence, context, and run binding)
     # Caller-side permissions, scoped at the calling-job level (NOT
     # workflow-level — that placement caps the reusable's per-job
     # grants below what they need and breaks the workflow at startup;
@@ -67,7 +67,7 @@ jobs:
       # in this repo for why the duplication is unavoidable
       # (reusable workflows can't introspect their own ref in
       # workflow_call context).
-      ai-review-prompts-ref: 224c2adcfdb408d68c7ca48eb618623c990a96ad
+      ai-review-prompts-ref: 4b59dc0ddb15aff517884127b58204f79193b4f2
       review-layers: |
         universal
         harper/common

--- a/.github/workflows/validate-caller-workflows.yml
+++ b/.github/workflows/validate-caller-workflows.yml
@@ -25,9 +25,9 @@ on:
 
 jobs:
   validate:
-    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@224c2adcfdb408d68c7ca48eb618623c990a96ad # main 2026-07-28 (#80 week-of-07-20 calibration: producing-side guard verification; on 82c9484)
+    uses: HarperFast/ai-review-prompts/.github/workflows/_validate-caller-workflows.yml@4b59dc0ddb15aff517884127b58204f79193b4f2 # main 2026-08-20 (#86 reliable review evidence, context, and run binding)
     with:
       # Same SHA as the `uses:` ref above — the reusable uses this to
       # check out the validator script at the matching version. Same
       # SHA-twice pattern as the other caller workflows in this repo.
-      ai-review-prompts-ref: 224c2adcfdb408d68c7ca48eb618623c990a96ad
+      ai-review-prompts-ref: 4b59dc0ddb15aff517884127b58204f79193b4f2


### PR DESCRIPTION
Roll out the reliable review-evidence plumbing from HarperFast/ai-review-prompts#86 in OAuth by moving the Claude, Gemini, and caller-validator workflows to its verified merge commit. This keeps the review and validation paths on one immutable workflow, prompt, and script version.

## For the human reviewer

No open judgment calls. The three caller pins move together to avoid validating the new review callers against a different upstream revision. Mention, issue-to-PR, permissions, triggers, secrets, model selection, layers, and OAuth-specific checks are unchanged.

## Verification

- `git diff --check` passed.
- The caller-validator workflow passed against all three changed caller files.
- GitHub reports `4b59dc0ddb15aff517884127b58204f79193b4f2` as the signed, verified merge commit for HarperFast/ai-review-prompts#86.
- End-to-end route (c), live smoke: Harper #2256 loaded the same review pin; Gemini completed its context snapshot and exact run-marker posting with no blockers, while Claude correctly declined the caller-workflow change and #86 kept that failed attempt out of the verdict log.
- Gemini reviewed the final `d58736f…` head and reported no blockers; all ordinary CI passed.

## Review coverage

Authored by Codex, with the validator alignment follow-up authored by Claude Fable 5 from Kris Zyp's canary feedback. Independent Claude review covered the initial pin bump; Gemini reviewed the final head with no findings. Cursor and further domain adjudication were pruned by the minimal low-risk policy. Receipt @ d58736f255267ac6e52fbe6135d515139b6d34dd.

<sub>Human-Review-Need: 2 @ d58736f25526</sub>
